### PR TITLE
Applied patch from idcrook to use MDL-SDK binary release 2019.2

### DIFF
--- a/src/MDL/MDL.cpp
+++ b/src/MDL/MDL.cpp
@@ -481,6 +481,13 @@ public:
             this->logFile << "[" << module_category << "] " << message_severity_to_string(level) << ": " << message << std::endl;
     }
 
+    virtual void message( mi::base::Message_severity  	level,
+                          const char *  	module_category,
+                          const mi::base::Message_details &  	,
+                          const char *  	message)
+        {
+        }
+
 private:
     std::ofstream logFile;
 };
@@ -879,7 +886,7 @@ MDL::CompiledMaterial MDL::Compile(const MDL::Material& material, bool classComp
                 &result.pdfProg,
                 &result.opacityProg,
 				&result.thinwalledProg,
-				&result.iorProg,				
+				&result.iorProg,
 				&result.absorbProg
             };
 
@@ -1020,7 +1027,7 @@ MDL::CompiledMaterial MDL::Compile(const MDL::Material& material, bool classComp
                 &result.pdfProg,
                 &result.opacityProg,
 				&result.thinwalledProg,
-				&result.iorProg,				
+				&result.iorProg,
 				&result.absorbProg
             };
 

--- a/src/Pathtracer/Pathtracer.cu
+++ b/src/Pathtracer/Pathtracer.cu
@@ -654,7 +654,8 @@ RT_FUNCTION bool SampleMaterial(PathtracePRD & prd, optix::Ray & ray, VolumeStac
 				union // Put the BSDF data structs into a union to reduce number of memory writes
 				{
 					mi::neuraylib::Bsdf_sample_data sample;
-					mi::neuraylib::Bsdf_evaluate_data evaluate;
+					//mi::neuraylib::Bsdf_evaluate_data evaluate;
+					mi::neuraylib::Bsdf_evaluate_data<mi::neuraylib::DF_HSM_NONE> evaluate;
 					mi::neuraylib::Bsdf_pdf_data pdf;
 				} data;
 
@@ -714,7 +715,7 @@ RT_FUNCTION bool SampleMaterial(PathtracePRD & prd, optix::Ray & ray, VolumeStac
 						data.evaluate.k2 = L;
 						parameters.evaluate(&data.evaluate, &state, &res_data, NULL, argBlock);
 
-						if (0.0f < data.evaluate.pdf && isNotNull(data.evaluate.bsdf))
+						if (0.0f < data.evaluate.pdf && isNotNull(data.evaluate.bsdf_diffuse))
 						{
 #ifdef TEST_NEE_ONLY
 							const float misWeight = 1.0f;
@@ -723,7 +724,7 @@ RT_FUNCTION bool SampleMaterial(PathtracePRD & prd, optix::Ray & ray, VolumeStac
 							const float misWeight = (lightPdf <= 0.0f) ? 1.0f : powerHeuristic(lightPdf * prd.lastLightPdfFactor, data.evaluate.pdf);
 #endif
 
-							const optix::float3 radiance = prd.alpha * data.evaluate.bsdf * lightEdf_over_pdf * lightFactor * misWeight; //  data.evaluate.bsdf contains: bsdf * dot(normal, k2)
+							const optix::float3 radiance = prd.alpha * data.evaluate.bsdf_diffuse * lightEdf_over_pdf * lightFactor * misWeight; //  data.evaluate.bsdf contains: bsdf * dot(normal, k2)
 							prd.radiance += clampRadiance(prd.depth, launchParameters[0].fireflyClampingIndirect, radiance);
 						}
 					}
@@ -731,7 +732,7 @@ RT_FUNCTION bool SampleMaterial(PathtracePRD & prd, optix::Ray & ray, VolumeStac
 #endif
 
 				// Sample BSDF
-				data.sample.xi = Sample3D(prd.randState);
+				data.sample.xi = Sample4D(prd.randState);
 				parameters.sample(&data.sample, &state, &res_data, NULL, argBlock);
 
 				prd.lastPdf = data.sample.pdf;
@@ -784,7 +785,7 @@ RT_FUNCTION bool SampleMaterial(PathtracePRD & prd, optix::Ray & ray, VolumeStac
 RT_FUNCTION void Pathtrace(const float3& rayOrigin, const float3& rayDirection, RandState* randState)
 {
 #ifdef VISRTX_USE_DEBUG_EXCEPTIONS
-#ifdef PRINT_PIXEL_X	
+#ifdef PRINT_PIXEL_X
 
 	rtPrintf("\n\n--- New frame ---\n");
 
@@ -865,7 +866,7 @@ RT_FUNCTION void Pathtrace(const float3& rayOrigin, const float3& rayDirection, 
 			}
 
 			break;
-		}		
+		}
         else
         {
             ray.origin = prd.hitPoint;
@@ -1218,7 +1219,7 @@ RT_PROGRAM void AnyHitOcclusion()
 		//data.ior2 = make_float3(1.f);
 		data.k1 = optix::normalize(-ray.direction);
 
-		data.xi = Sample3D(shadowPrd.randState);
+		data.xi = Sample4D(shadowPrd.randState);
 		parameters.sample(&data, &state, &res_data, NULL, argBlock);
 
 		if (data.event_type & mi::neuraylib::BSDF_EVENT_TRANSMISSION)

--- a/src/Pathtracer/Random.h
+++ b/src/Pathtracer/Random.h
@@ -55,10 +55,14 @@ RT_FUNCTION optix::float3 Sample3D(RandState* state)
     return optix::make_float3(curand_uniform(state), curand_uniform(state), curand_uniform(state));
 }
 
+RT_FUNCTION optix::float4 Sample4D(RandState* state)
+{
+    return optix::make_float4(curand_uniform(state), curand_uniform(state), curand_uniform(state),
+                              curand_uniform(state));
+}
+
 #else
 
 typedef int RandState;
 
 #endif
-
-


### PR DESCRIPTION
This avoids having to compile MDL from scratch, which is a bit of a pain (on
Ubuntu 16.04 due to FreeImage dependency issues).