### PR TITLE
Only upload the array when actually needed

### DIFF
--- a/devices/rtx/array/Array1D.cpp
+++ b/devices/rtx/array/Array1D.cpp
@@ -41,7 +41,8 @@ Array1D::Array1D(DeviceGlobalState *state, const Array1DMemoryDescriptor &d)
 const void *Array1D::dataGPU() const
 {
   const_cast<Array1D *>(this)->markDataIsOffloaded(true);
-  uploadArrayData();
+  if (needToUploadData())
+    uploadArrayData();
   return m_deviceData.buffer.ptr();
 }
 

--- a/devices/rtx/array/Array2D.cpp
+++ b/devices/rtx/array/Array2D.cpp
@@ -41,7 +41,8 @@ Array2D::Array2D(DeviceGlobalState *state, const Array2DMemoryDescriptor &d)
 const void *Array2D::dataGPU() const
 {
   const_cast<Array2D *>(this)->markDataIsOffloaded(true);
-  uploadArrayData();
+  if (needToUploadData())
+    uploadArrayData();
   return m_deviceData.buffer.ptr();
 }
 

--- a/devices/rtx/array/Array3D.cpp
+++ b/devices/rtx/array/Array3D.cpp
@@ -40,7 +40,8 @@ Array3D::Array3D(DeviceGlobalState *state, const Array3DMemoryDescriptor &d)
 const void *Array3D::dataGPU() const
 {
   const_cast<Array3D *>(this)->markDataIsOffloaded(true);
-  uploadArrayData();
+  if (needToUploadData())
+    uploadArrayData();
   return m_deviceData.buffer.ptr();
 }
 


### PR DESCRIPTION
The same device buffer can be referenced by many arrays. In the instancing case, each instance surface data will ref the same device buffer. This change makes sure it is only uploaded once.