### PR TITLE
Do not use the alpha channel of the color

### DIFF
--- a/devices/rtx/gpu/getMaterialValues.h
+++ b/devices/rtx/gpu/getMaterialValues.h
@@ -359,7 +359,7 @@ RT_FUNCTION MaterialValues getMaterialValues(
   retval.baseColor = vec3(values[MV_BASE_COLOR]);
   // opacity
   retval.opacity = adjustedMaterialOpacity(
-      values[MV_OPACITY].x * values[MV_BASE_COLOR].w, md);
+      values[MV_OPACITY].x, md);
   // mettalic
   retval.metallic = values[MV_METALLIC].x;
   // roughness


### PR DESCRIPTION
According to the PhysicallyPBR specifications the opacity is supposed come from the dedicated input. If needed, getting the alpha channel from the image should be done through the opacity attribute using swizzling