### PR TITLE
Move generated queries to build folder

### DIFF
--- a/cmake/FindMDL_SDK.cmake
+++ b/cmake/FindMDL_SDK.cmake
@@ -31,7 +31,6 @@ if (TARGET MDL_SDK::MDL_SDK)
   return()
 endif()
 
-message(STATUS "find_path(MDL_SDK_ROOT NAMES mdl_sdk.h PATHS ${MDL_SDK_PATH} ENV MDL_SDK_PATH PATH_SUFFIXES include/mi/)")
 find_path(MDL_SDK_ROOT NAMES "include/mi/mdl_sdk.h" PATHS ${MDL_SDK_PATH} ENV MDL_SDK_PATH)
 
 include(FindPackageHandleStandardArgs)

--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -64,23 +64,31 @@ mark_as_advanced(VISRTX_ENABLE_NVTX)
 
 ## Code generation ##
 
+file(GLOB DEVICE_JSONS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "visrtx_*.json")
+foreach(file ${DEVICE_JSONS})
+  file(GENERATE OUTPUT ${file} INPUT ${file})
+endforeach()
+
 anari_generate_queries(
   NAME visrtx
   PREFIX VisRTXDevice
   CPP_NAMESPACE visrtx
-  JSON_ROOT_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}
-  JSON_DEFINITIONS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/visrtx_device.json
+  JSON_ROOT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}
+  JSON_DEFINITIONS_FILE ${CMAKE_CURRENT_BINARY_DIR}/visrtx_device.json
+  OUTPUT_LOCATION ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 ## Build library target ##
 
 project_add_library(SHARED)
 
+add_dependencies(${PROJECT_NAME} generate_visrtx)
+
 project_sources(PRIVATE
   Object.cpp
   optix_visrtx.cpp
   VisRTXDevice.cpp
-  VisRTXDeviceQueries.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/VisRTXDeviceQueries.cpp 
   VisRTXFeatureUtility.cpp
   VisRTXLibrary.cpp
 

--- a/devices/rtx/visrtx_device.json
+++ b/devices/rtx/visrtx_device.json
@@ -39,7 +39,7 @@
       "khr_volume_transfer_function1d",
       "visrtx_cuda_output_buffers",
       "visrtx_instance_attributes",
-      "visrtx_material_mdl",
+      $<$<BOOL:$<TARGET_EXISTS:MDL_SDK::MDL_SDK>>:"visrtx_material_mdl",>
       "visrtx_triangle_back_face_culling",
       "visrtx_triangle_face_varying_attributes"
     ]


### PR DESCRIPTION
Generate Json files and VisRTXDeviceQueries.cpp at build time so it can depend on the build configuration
This way the MDL extension is only declared when it is actually enabled.

@jeffamstutz This requires https://github.com/KhronosGroup/ANARI-SDK/pull/268 to hit ANARI-SDK first before this can work.