### PR TITLE
tsd: Reorder add_subdirectory by dependencies

### DIFF
--- a/tsd/CMakeLists.txt
+++ b/tsd/CMakeLists.txt
@@ -57,8 +57,7 @@ if (BUILD_TESTING)
 endif()
 
 ## Build Libraries ##
-
-add_subdirectory(apps)
 add_subdirectory(external)
 add_subdirectory(src)
+add_subdirectory(apps)
 add_subdirectory(tests)


### PR DESCRIPTION
src must be traversed first so other parts can use its targets.