### PR TITLE
Various build fixes for Windows

### DIFF
--- a/tsd/apps/interactive/demos/animated_volume/CMakeLists.txt
+++ b/tsd/apps/interactive/demos/animated_volume/CMakeLists.txt
@@ -7,4 +7,4 @@ endif()
 
 project(tsdDemoAnimatedVolume)
 project_add_executable(jacobi3D.cu SolverControls.cpp tsdDemoAnimatedVolume.cpp)
-project_link_libraries(tsd_viewer_common CUDA::cudart)
+project_link_libraries(PRIVATE tsd_viewer_common)

--- a/tsd/src/render_pipeline/CMakeLists.txt
+++ b/tsd/src/render_pipeline/CMakeLists.txt
@@ -24,8 +24,9 @@ elseif(TSD_USE_TBB)
 endif()
 
 if (TSD_USE_OPENGL)
+  find_package(glfw3 REQUIRED)
   find_package(OpenGL REQUIRED)
-  project_link_libraries(PUBLIC tsd OpenGL::GL)
+  project_link_libraries(PUBLIC tsd glfw OpenGL::GL)
   project_compile_definitions(PUBLIC ENABLE_OPENGL)
 endif()
 

--- a/tsd/src/render_pipeline/RenderPass.cpp
+++ b/tsd/src/render_pipeline/RenderPass.cpp
@@ -28,7 +28,7 @@ DEVICE_FCN_INLINE uint32_t shadePixel(uint32_t c_in)
   return helium::cvt_color_to_uint32(c_out);
 };
 
-static void compositeFrame(RenderPass::Buffers &b_out,
+void compositeFrame(RenderPass::Buffers &b_out,
     const RenderPass::Buffers &b_in,
     tsd::uint2 size,
     bool firstPass)
@@ -46,7 +46,7 @@ static void compositeFrame(RenderPass::Buffers &b_out,
       });
 }
 
-static void computeOutline(
+void computeOutline(
     RenderPass::Buffers &b, uint32_t outlineId, tsd::uint2 size)
 {
   detail::parallel_for(
@@ -72,7 +72,7 @@ static void computeOutline(
       });
 }
 
-static void computeDepthImage(
+void computeDepthImage(
     RenderPass::Buffers &b, float maxDepth, tsd::uint2 size)
 {
   detail::parallel_for(

--- a/tsd/src/render_pipeline/RenderPass.h
+++ b/tsd/src/render_pipeline/RenderPass.h
@@ -11,12 +11,7 @@
 #include <anari/anari_cpp.hpp>
 
 #ifdef ENABLE_OPENGL
-// OpenGL
-#if __APPLE__
-#include <OpenGL/gl.h>
-#else
-#include <GL/gl.h>
-#endif
+#include <GLFW/glfw3.h>
 #endif
 
 namespace tsd {

--- a/tsd/src/tsd/CMakeLists.txt
+++ b/tsd/src/tsd/CMakeLists.txt
@@ -67,7 +67,9 @@ else()
 endif()
 
 if (MSVC)
-  project_compile_options(PRIVATE /bigobj)
+  set_source_files_properties(
+    authoring/procedural/generate_material_orb.cpp
+    PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
 if (TSD_USE_CUDA)


### PR DESCRIPTION
Especially check if the removal of the 'static' keywords in RenderPass.cpp make sense on Linux...