### PR TITLE
Added SWC importer

### DIFF
--- a/tsd/apps/interactive/common/AppCore.cpp
+++ b/tsd/apps/interactive/common/AppCore.cpp
@@ -120,8 +120,6 @@ void AppCore::parseCommandLine(int argc, const char **argv)
       importerType = ImporterType::VOLUME;
     else if (arg == "-swc")
       importerType = ImporterType::SWC;
-    else if (arg == "-swcs")
-      importerType = ImporterType::SWCS;
     else if (importerType != ImporterType::NONE)
       this->commandLine.filenames.push_back({importerType, arg});
   }
@@ -163,8 +161,6 @@ void AppCore::setupSceneFromCommandLine(bool hdriOnly)
         tsd::import_HDRI(tsd.ctx, f.second.c_str());
       else if (f.first == ImporterType::SWC)
         tsd::import_SWC(tsd.ctx, f.second.c_str());
-      else if (f.first == ImporterType::SWCS)
-        tsd::import_SWCs(tsd.ctx, f.second.c_str());
 #if 0
       else if (f.first == ImporterType::VOLUME)
         tsd::import_volume(tsd.ctx, f.second.c_str());

--- a/tsd/apps/interactive/common/AppCore.cpp
+++ b/tsd/apps/interactive/common/AppCore.cpp
@@ -118,6 +118,10 @@ void AppCore::parseCommandLine(int argc, const char **argv)
       importerType = ImporterType::PLY;
     else if (arg == "-volume")
       importerType = ImporterType::VOLUME;
+    else if (arg == "-swc")
+      importerType = ImporterType::SWC;
+    else if (arg == "-swcs")
+      importerType = ImporterType::SWCS;
     else if (importerType != ImporterType::NONE)
       this->commandLine.filenames.push_back({importerType, arg});
   }
@@ -157,6 +161,10 @@ void AppCore::setupSceneFromCommandLine(bool hdriOnly)
         tsd::import_NBODY(tsd.ctx, f.second.c_str());
       else if (f.first == ImporterType::HDRI)
         tsd::import_HDRI(tsd.ctx, f.second.c_str());
+      else if (f.first == ImporterType::SWC)
+        tsd::import_SWC(tsd.ctx, f.second.c_str());
+      else if (f.first == ImporterType::SWCS)
+        tsd::import_SWCs(tsd.ctx, f.second.c_str());
 #if 0
       else if (f.first == ImporterType::VOLUME)
         tsd::import_volume(tsd.ctx, f.second.c_str());

--- a/tsd/apps/interactive/common/AppCore.h
+++ b/tsd/apps/interactive/common/AppCore.h
@@ -25,6 +25,8 @@ enum class ImporterType
   HDRI,
   VOLUME,
   TSD,
+  SWC,
+  SWCS,
   NONE
 };
 

--- a/tsd/apps/interactive/common/AppCore.h
+++ b/tsd/apps/interactive/common/AppCore.h
@@ -26,7 +26,6 @@ enum class ImporterType
   VOLUME,
   TSD,
   SWC,
-  SWCS,
   NONE
 };
 

--- a/tsd/apps/interactive/common/modals/ImportFileDialog.cpp
+++ b/tsd/apps/interactive/common/modals/ImportFileDialog.cpp
@@ -97,8 +97,6 @@ void ImportFileDialog::buildUI()
       tsd::import_HDRI(ctx, m_filename.c_str(), importRoot);
     else if (selectedFileType == ImporterType::SWC)
       tsd::import_SWC(ctx, m_filename.c_str(), importRoot);
-    else if (selectedFileType == ImporterType::SWCS)
-      tsd::import_SWCs(ctx, m_filename.c_str(), importRoot);
 
     ctx.signalInstanceTreeChange();
 

--- a/tsd/apps/interactive/common/modals/ImportFileDialog.cpp
+++ b/tsd/apps/interactive/common/modals/ImportFileDialog.cpp
@@ -95,6 +95,10 @@ void ImportFileDialog::buildUI()
       tsd::import_NBODY(ctx, m_filename.c_str(), importRoot);
     else if (selectedFileType == ImporterType::HDRI)
       tsd::import_HDRI(ctx, m_filename.c_str(), importRoot);
+    else if (selectedFileType == ImporterType::SWC)
+      tsd::import_SWC(ctx, m_filename.c_str(), importRoot);
+    else if (selectedFileType == ImporterType::SWCS)
+      tsd::import_SWCs(ctx, m_filename.c_str(), importRoot);
 
     ctx.signalInstanceTreeChange();
 

--- a/tsd/src/tsd/CMakeLists.txt
+++ b/tsd/src/tsd/CMakeLists.txt
@@ -12,6 +12,7 @@ PRIVATE
   authoring/importers/import_DLAF.cpp
   authoring/importers/import_FLASH.cpp
   authoring/importers/import_HDRI.cpp
+  authoring/importers/import_SWC.cpp
   authoring/importers/import_NBODY.cpp
   authoring/importers/import_NVDB.cpp
   authoring/importers/import_OBJ.cpp

--- a/tsd/src/tsd/authoring/importers.hpp
+++ b/tsd/src/tsd/authoring/importers.hpp
@@ -16,7 +16,6 @@ void import_NBODY(Context &ctx, const char *filename, InstanceNode::Ref location
 void import_OBJ(Context &ctx, const char *filename, InstanceNode::Ref location = {}, bool useDefaultMaterial = false);
 void import_PLY(Context &ctx, const char *filename, InstanceNode::Ref location = {});
 void import_SWC(Context &ctx, const char *filename, InstanceNode::Ref location = {});
-void import_SWCs(Context &ctx, const char *folder, InstanceNode::Ref location = {});
 SpatialFieldRef import_RAW(Context &ctx, const char *filename);
 SpatialFieldRef import_FLASH(Context &ctx, const char *filename);
 SpatialFieldRef import_NVDB(Context &ctx, const char *filename);

--- a/tsd/src/tsd/authoring/importers.hpp
+++ b/tsd/src/tsd/authoring/importers.hpp
@@ -15,6 +15,8 @@ void import_HDRI(Context &ctx, const char *filename, InstanceNode::Ref location 
 void import_NBODY(Context &ctx, const char *filename, InstanceNode::Ref location = {}, bool useDefaultMaterial = false);
 void import_OBJ(Context &ctx, const char *filename, InstanceNode::Ref location = {}, bool useDefaultMaterial = false);
 void import_PLY(Context &ctx, const char *filename, InstanceNode::Ref location = {});
+void import_SWC(Context &ctx, const char *filename, InstanceNode::Ref location = {});
+void import_SWCs(Context &ctx, const char *folder, InstanceNode::Ref location = {});
 SpatialFieldRef import_RAW(Context &ctx, const char *filename);
 SpatialFieldRef import_FLASH(Context &ctx, const char *filename);
 SpatialFieldRef import_NVDB(Context &ctx, const char *filename);

--- a/tsd/src/tsd/authoring/importers/import_SWC.cpp
+++ b/tsd/src/tsd/authoring/importers/import_SWC.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <map>
 #include <random>
+#include <sstream>
 
 namespace {
 const float DEFAULT_ROUGHNESS = 0.5f;

--- a/tsd/src/tsd/authoring/importers/import_SWC.cpp
+++ b/tsd/src/tsd/authoring/importers/import_SWC.cpp
@@ -9,6 +9,11 @@
 #include <map>
 #include <random>
 
+namespace {
+const float DEFAULT_ROUGHNESS = 0.5f;
+const float DEFAULT_METALLIC = 0.5f;
+} // namespace
+
 namespace tsd {
 
 /**
@@ -143,8 +148,8 @@ void readSWCFile(
   std::uniform_real_distribution<> dis(0.0, 0.5);
   tsd::float3 baseColor(0.5 + dis(gen), 0.5 + dis(gen), 0.5 + dis(gen));
 
-  const float metallic = 0.5;
-  const float roughness = 0.5;
+  const float metallic = DEFAULT_METALLIC;
+  const float roughness = DEFAULT_ROUGHNESS;
 
   // Set the material properties
   m->setParameter("baseColor"_t, ANARI_FLOAT32_VEC3, &baseColor);

--- a/tsd/src/tsd/authoring/importers/import_SWC.cpp
+++ b/tsd/src/tsd/authoring/importers/import_SWC.cpp
@@ -1,0 +1,170 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/authoring/importers.hpp"
+#include "tsd/authoring/importers/detail/importer_common.hpp"
+#include "tsd/core/Logging.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace tsd {
+
+std::vector<std::string> listFiles(
+    const std::string &folderPath, const std::string &extension)
+{
+  std::vector<std::string> files;
+  for (const auto &entry : std::filesystem::directory_iterator(folderPath)) {
+    if (entry.is_regular_file()) {
+      std::string ext = entry.path().extension().string();
+      std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+      if (ext == extension) {
+        files.push_back(entry.path().filename().string());
+      }
+    }
+  }
+
+  return files;
+}
+
+struct SWCPoint
+{
+  int id;
+  int type;
+  double x, y, z;
+  double radius;
+  int parent;
+};
+
+void readSWCFile(Context &ctx,
+    const std::string &filename,
+    InstanceNode::Ref location,
+    const std::string &name = "morphology")
+{
+  std::ifstream file(filename);
+  std::string line;
+
+  if (!file.is_open()) {
+    logError("Error opening file: %s", filename);
+    return;
+  }
+
+  std::map<uint64_t, SWCPoint> points;
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#')
+      continue;
+
+    std::istringstream iss(line);
+    SWCPoint point;
+    if (iss >> point.id >> point.type >> point.x >> point.y >> point.z
+        >> point.radius >> point.parent) {
+      points[point.id] = point;
+    }
+  }
+  file.close();
+
+  if (!location)
+    location = ctx.tree.root();
+
+  // Material //
+
+  auto material = ctx.defaultMaterial();
+
+  const auto numPoints = points.size();
+
+  // Generate spheres //
+
+  auto spheres = ctx.createObject<tsd::Geometry>(tsd::tokens::geometry::sphere);
+
+  spheres->setName("spheres_geometry_t");
+
+  std::vector<float3> spherePositions;
+  spherePositions.reserve(numPoints);
+  std::vector<float> sphereRadii;
+  sphereRadii.reserve(numPoints);
+
+  for (const auto &p : points) {
+    spherePositions.push_back(tsd::float3(p.second.x, p.second.y, p.second.z));
+    sphereRadii.push_back(p.second.radius * 0.5);
+  }
+
+  auto spherePositionArray = ctx.createArray(ANARI_FLOAT32_VEC3, numPoints);
+  auto sphereRadiusArray = ctx.createArray(ANARI_FLOAT32, numPoints);
+
+  spherePositionArray->setData(spherePositions);
+  sphereRadiusArray->setData(sphereRadii);
+
+  spheres->setParameterObject("vertex.position"_t, *spherePositionArray);
+  spheres->setParameterObject("vertex.radius"_t, *sphereRadiusArray);
+
+  // Generate cones //
+
+  auto cones = ctx.createObject<Geometry>(tokens::geometry::cone);
+
+  cones->setName("cones_geometry_t");
+
+  std::vector<float3> conePositions;
+  std::vector<float> coneRadii;
+
+  uint64_t numcones = 0;
+  for (const auto &p : points) {
+    if (p.second.parent == -1)
+      continue;
+
+    conePositions.push_back(tsd::float3(p.second.x, p.second.y, p.second.z));
+    coneRadii.push_back(p.second.radius * 0.5f);
+
+    const auto &p1 = points[p.second.parent];
+    conePositions.push_back(tsd::float3(p1.x, p1.y, p1.z));
+    coneRadii.push_back(p1.radius * 0.5f);
+    ++numcones;
+  }
+
+  auto positionArray = ctx.createArray(ANARI_FLOAT32_VEC3, 2 * numcones);
+  auto radiiArray = ctx.createArray(ANARI_FLOAT32, 2 * numcones);
+
+  positionArray->setData(conePositions);
+  radiiArray->setData(coneRadii);
+
+  cones->setParameterObject("vertex.position"_t, *positionArray);
+  cones->setParameterObject("vertex.radius"_t, *radiiArray);
+
+  // Surfaces //
+
+  const std::string conesName = name + "_cones";
+  auto conseSurface = ctx.createSurface(conesName.c_str(), cones, material);
+  ctx.insertChildObjectNode(location, conseSurface);
+  const std::string spheresName = name + "_spheres";
+  auto sphereSurface =
+      ctx.createSurface(spheresName.c_str(), spheres, material);
+  ctx.insertChildObjectNode(location, sphereSurface);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+void import_SWC(Context &ctx, const char *filename, InstanceNode::Ref location)
+{
+  readSWCFile(ctx, filename, location);
+}
+
+void import_SWCs(
+    Context &ctx, const char *folderPath, InstanceNode::Ref location)
+{
+  std::vector<std::string> swcFiles = listFiles(folderPath, ".swc");
+  for (const auto &swcFile : swcFiles) {
+    const fs::path fileName = swcFile;
+    const fs::path fullPath = folderPath / fileName;
+    readSWCFile(ctx, fullPath, location, swcFile);
+  }
+}
+
+} // namespace tsd

--- a/tsd/src/tsd/authoring/importers/import_SWC.cpp
+++ b/tsd/src/tsd/authoring/importers/import_SWC.cpp
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tsd/authoring/importers.hpp"
-#include "tsd/authoring/importers/detail/importer_common.hpp"
 #include "tsd/core/Logging.hpp"
 
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <map>
-#include <sstream>
-#include <string>
-#include <vector>
+#include <random>
 
 namespace fs = std::filesystem;
 
 namespace tsd {
 
+/**
+ * Lists all files with a specified extension in a given folder.
+ *
+ * @param folderPath Path to the folder containing files.
+ * @param extension The file extension to search for (e.g. ".swc").
+ *
+ * @return A vector of file names with the specified extension.
+ */
 std::vector<std::string> listFiles(
     const std::string &folderPath, const std::string &extension)
 {
@@ -34,20 +38,39 @@ std::vector<std::string> listFiles(
   return files;
 }
 
+/**
+ * Represents a point in a SWC (Standard Warehouse Connector) file.
+ *
+ * A SWC file is a text file that describes a collection of points and their
+ * connections. Each point is represented by six values: an ID, a type, and x,
+ * y, z coordinates.
+ *
+ * @struct SWCPoint
+ */
 struct SWCPoint
 {
-  int id;
-  int type;
-  double x, y, z;
-  double radius;
-  int parent;
+  int id; ///< Unique identifier for the point.
+  int type; ///< Type of point (e.g. 0 for neurite, 1 for dendrite, 2 for axon).
+  double x, y, z; ///< 3D coordinates of the point in space.
+  double radius; ///< Radius of the point.
+  int parent; ///< ID of the parent point (or -1 if it is a root point).
 };
 
+/**
+ * Reads a SWC file and generates a 3D representation.
+ *
+ * @param ctx Context in which to create the 3D representation.
+ * @param filename Path to the SWC file to read.
+ * @param location Node in the scene graph where the 3D representation should be
+ * added.
+ * @param name A default name for the 3D representation.
+ */
 void readSWCFile(Context &ctx,
     const std::string &filename,
     InstanceNode::Ref location,
     const std::string &name = "morphology")
 {
+  // Open the SWC file and check for errors
   std::ifstream file(filename);
   std::string line;
 
@@ -56,6 +79,7 @@ void readSWCFile(Context &ctx,
     return;
   }
 
+  // Read the file and store the points in a map
   std::map<uint64_t, SWCPoint> points;
   while (std::getline(file, line)) {
     if (line.empty() || line[0] == '#')
@@ -70,21 +94,21 @@ void readSWCFile(Context &ctx,
   }
   file.close();
 
+  // Get the location node if not already provided
   if (!location)
     location = ctx.tree.root();
 
-  // Material //
-
+  // Default material for the 3D representation
   auto material = ctx.defaultMaterial();
 
+  // Count the number of points in the file
   const auto numPoints = points.size();
 
-  // Generate spheres //
-
+  // Generate spheres for each point
   auto spheres = ctx.createObject<tsd::Geometry>(tsd::tokens::geometry::sphere);
-
   spheres->setName("spheres_geometry_t");
 
+  // Initialize the positions and radii of the spheres
   std::vector<float3> spherePositions;
   spherePositions.reserve(numPoints);
   std::vector<float> sphereRadii;
@@ -95,21 +119,22 @@ void readSWCFile(Context &ctx,
     sphereRadii.push_back(p.second.radius * 0.5);
   }
 
+  // Create arrays to store the positions and radii of the spheres
   auto spherePositionArray = ctx.createArray(ANARI_FLOAT32_VEC3, numPoints);
   auto sphereRadiusArray = ctx.createArray(ANARI_FLOAT32, numPoints);
 
   spherePositionArray->setData(spherePositions);
   sphereRadiusArray->setData(sphereRadii);
 
+  // Set the positions and radii of the spheres
   spheres->setParameterObject("vertex.position"_t, *spherePositionArray);
   spheres->setParameterObject("vertex.radius"_t, *sphereRadiusArray);
 
-  // Generate cones //
-
+  // Generate cones to connect the points
   auto cones = ctx.createObject<Geometry>(tokens::geometry::cone);
-
   cones->setName("cones_geometry_t");
 
+  // Initialize the positions and radii of the cones
   std::vector<float3> conePositions;
   std::vector<float> coneRadii;
 
@@ -127,35 +152,65 @@ void readSWCFile(Context &ctx,
     ++numcones;
   }
 
+  // Create arrays to store the positions and radii of the cones
   auto positionArray = ctx.createArray(ANARI_FLOAT32_VEC3, 2 * numcones);
   auto radiiArray = ctx.createArray(ANARI_FLOAT32, 2 * numcones);
 
   positionArray->setData(conePositions);
   radiiArray->setData(coneRadii);
 
+  // Set the positions and radii of the cones
   cones->setParameterObject("vertex.position"_t, *positionArray);
   cones->setParameterObject("vertex.radius"_t, *radiiArray);
 
-  // Surfaces //
+  // Material properties
+  auto m = ctx.createObject<Material>(tokens::material::physicallyBased);
 
+  // Randomly generate base color, metallic, and roughness values
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(0.0, 0.5);
+  tsd::float3 baseColor(0.5 + dis(gen), 0.5 + dis(gen), 0.5 + dis(gen));
+
+  const float metallic = 0.5;
+  const float roughness = 0.5;
+
+  // Set the material properties
+  m->setParameter("baseColor"_t, ANARI_FLOAT32_VEC3, &baseColor);
+  m->setParameter("metallic"_t, ANARI_FLOAT32, &metallic);
+  m->setParameter("roughness"_t, ANARI_FLOAT32, &roughness);
+
+  // Create surfaces for the spheres and cones
   const std::string conesName = name + "_cones";
-  auto conseSurface = ctx.createSurface(conesName.c_str(), cones, material);
-  ctx.insertChildObjectNode(location, conseSurface);
+  auto conesSurface = ctx.createSurface(conesName.c_str(), cones, m);
+  ctx.insertChildObjectNode(location, conesSurface);
+
   const std::string spheresName = name + "_spheres";
-  auto sphereSurface =
-      ctx.createSurface(spheresName.c_str(), spheres, material);
+  auto sphereSurface = ctx.createSurface(spheresName.c_str(), spheres, m);
   ctx.insertChildObjectNode(location, sphereSurface);
 }
 
-///////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////
-
+/**
+ * Imports a single SWC file into the current context.
+ *
+ * @param ctx Context in which to import the SWC file.
+ * @param filename Path to the SWC file to import.
+ * @param location Node in the scene graph where the SWC file should be
+ * imported.
+ */
 void import_SWC(Context &ctx, const char *filename, InstanceNode::Ref location)
 {
   readSWCFile(ctx, filename, location);
 }
 
+/**
+ * Imports all SWC files in a given folder into the current context.
+ *
+ * @param ctx Context in which to import the SWC files.
+ * @param folderPath Path to the folder containing the SWC files to import.
+ * @param location Node in the scene graph where the SWC files should be
+ * imported.
+ */
 void import_SWCs(
     Context &ctx, const char *folderPath, InstanceNode::Ref location)
 {


### PR DESCRIPTION
An importer for SWC files is a software tool or library designed to read and process SWC files, which are text-based files used to represent neuron morphologies as hierarchical trees of connected points. These files are widely used in computational neuroscience for visualization, simulation, and analysis of neural structures. Use the -swc command line argument to load SWC files.