### PR TITLE
Mdl fixes

### DIFF
--- a/devices/libmdl/ArgumentBlockDescriptor.h
+++ b/devices/libmdl/ArgumentBlockDescriptor.h
@@ -64,6 +64,7 @@ struct ArgumentBlockDescriptor
     {
       const float *data = {};
       std::uint64_t dims[3] = {};
+      const char* pixelFormat = {};
     } bsdf;
   };
 

--- a/devices/libmdl/ptx.cpp
+++ b/devices/libmdl/ptx.cpp
@@ -3,9 +3,11 @@
 
 #include "ptx.h"
 
+#include <algorithm>
 #include <array>
-#include <cstring>
-#include <fstream>
+#include <cassert>
+#include <cctype>
+#include <iterator>
 #include <set>
 #include <string>
 #include <string_view>
@@ -18,30 +20,45 @@ namespace visrtx::libmdl {
 std::vector<char> stitchPTXs(
     nonstd::span<const nonstd::span<const char>> ptxBlobs)
 {
-  std::vector<char> result;
-  for (const auto &s : ptxBlobs) {
-    result.insert(end(result), std::cbegin(s), std::cend(s));
-  }
+  std::vector<std::vector<char>> fixedBlobs;
+  fixedBlobs.reserve(size(ptxBlobs));
+  std::size_t totalSize = 0;
 
-  // As we are blending to separate compilation unit PTXs, make sure headers are
-  // not conflicting.
+  // As we are blending multiple separate compilation unit PTXs, make sure
+  // headers are not conflicting.
   std::string version;
   std::string target;
   std::string addressSize = ".address_size 64";
 
-  {
-    // Handle version, target and addressSize metadata
-    static constexpr const auto versionKw = "\n.version "sv;
-    static constexpr const auto targetKw = "\n.target "sv;
-    static constexpr const auto addressSizeKw = "\n.address_size "sv;
+  // For disambiguating symbol names
+  int uniquifyIdx = 0;
+  // For removing latter instances of weak and extern symbols
+  std::set<std::string> previouslySeenWeak;
+  std::set<std::string> previouslySeenExtern;
 
-    for (auto dotkword : {versionKw, targetKw, addressSizeKw}) {
-      for (auto it = std::search(
-               begin(result), end(result), cbegin(dotkword), cend(dotkword));
-          it != end(result);) {
-        auto eolIt = std::find(it + 1, end(result), '\n');
-        std::string sub(it + 1, eolIt);
-        it = result.erase(it, eolIt);
+  // For disambiguating info strings
+  uint32_t infoStringBaseIndex = 0;
+  // For disambiguating file ids
+  uint32_t fileBaseIndex = 0;
+
+  for (const auto &s : ptxBlobs) {
+    std::vector<char> blob(std::cbegin(s), std::cend(s));
+
+    // Handle version, target and addressSize metadata
+    {
+      static constexpr const auto versionKw = "\n.version "sv;
+      static constexpr const auto targetKw = "\n.target "sv;
+      static constexpr const auto addressSizeKw = "\n.address_size "sv;
+
+      for (auto dotkword : {versionKw, targetKw, addressSizeKw}) {
+        auto it = std::search(
+            begin(blob), end(blob), cbegin(dotkword), cend(dotkword));
+
+        auto eolIt = std::find(++it, end(blob), '\n');
+        std::string sub(it, eolIt);
+
+        blob.erase(it, eolIt);
+
         if (dotkword == versionKw) { // .version
           if (sub > version)
             version = sub;
@@ -49,135 +66,240 @@ std::vector<char> stitchPTXs(
           if (sub > target)
             target = sub;
         }
-        it = std::search(it, end(result), cbegin(dotkword), cend(dotkword));
       }
     }
-  }
 
-  {
-    // Same cleanup with forward decls possibly conflicting with actual
-    // declarations.
-    static constexpr const std::string_view externPrefixes[] = {
-        "\n.extern .func "sv,
-    };
-    static constexpr const std::string_view declsToKeep[] = {"vprintf"sv};
-    // For decls we keep, only keep the first occurrence.
-    std::set<std::string> previouslySeen;
+    {
+      // Same cleanup with forward decls possibly conflicting with actual
+      // declarations.
+      static constexpr const auto externPrefix = "\n.extern .func "sv;
+      static constexpr const std::string_view declsToKeep[] = {"vprintf"sv};
 
-    for (const auto &externPrefix : externPrefixes) {
-      for (auto it = std::search(begin(result),
-               end(result),
+      for (auto it = std::search(begin(blob),
+               end(blob),
                cbegin(externPrefix),
                cend(externPrefix));
-          it != end(result);) {
-        auto semiColonIt = std::find(it, end(result), ';');
+          it != end(blob);) {
+        auto semiColonIt = std::find(it, end(blob), ';');
 
-        if (semiColonIt != end(result)) {
+        if (semiColonIt != end(blob)) {
           for (const auto &decl : declsToKeep) {
             if (std::search(it, semiColonIt, cbegin(decl), cend(decl))
                 != semiColonIt) {
               // This is a decl that might need to be kept. Check if we
               // already did so.
               std::string decl(it, semiColonIt);
-              if (previouslySeen.find(decl) == cend(previouslySeen)) {
+
+              if (previouslySeenExtern.insert(decl).second) {
                 // First time. Skip it and move on.
                 it = semiColonIt;
               } // If not the first occurrence, then it will be erased.
               break;
             }
           }
-          if (it != semiColonIt)
-            it = result.erase(it, ++semiColonIt);
+
+          it = blob.erase(it, ++semiColonIt);
         }
         it = std::search(
-            it, end(result), cbegin(externPrefix), cend(externPrefix));
+            it, end(blob), cbegin(externPrefix), cend(externPrefix));
       }
     }
-  }
 
-  {
     // And ditto with colliding symbol names (focusing on constant strings for
     // now).
-    int uniquifyIdx = 0;
-
-    std::string prefix = "uniquify_" + std::to_string(uniquifyIdx++);
-    static const std::string strPrefix = "$str";
-    for (auto it = std::search(
-             begin(result), end(result), cbegin(strPrefix), cend(strPrefix));
-        it != end(result);) {
-      // Insertion might invalidate the iterator. Make sure to get the after
-      // insertion value.
-      it = result.insert(++it, cbegin(prefix), cend(prefix));
-      // And search for next occurrence from there. Note that current $str has
-      // been broken to $_something_str and is not a match anymore for the
-      // search, so we can resume at current position.
-      it = std::search(it, end(result), cbegin(strPrefix), cend(strPrefix));
-    }
-  }
-
-  // Remove .visible qualifier from of all functions but OptiX semantic entry
-  // points.
-  {
-    static constexpr std::string_view dotVisible = "\n.visible ";
-    static constexpr std::string_view directCallableSemantic =
-        "__direct_callable__";
-
-    for (auto it = std::search(
-             begin(result), end(result), cbegin(dotVisible), cend(dotVisible));
-        it != end(result);) {
-      it = next(it); // Skip the new line.
-      auto eolIt = std::find(it, end(result), '\n');
-      if (std::search(it,
-              eolIt,
-              cbegin(directCallableSemantic),
-              cend(directCallableSemantic))
-          == eolIt) {
-        it = result.erase(it, it + dotVisible.size() - 1);
-      }
-      // And search for next occurrence from there. Note that current $str has
-      // been broken to $_something_str and is not a match anymore for the
-      // search, so we can resume at current position.
-      it = std::search(it, end(result), cbegin(dotVisible), cend(dotVisible));
-    }
-  }
-
-  // Last pass: remove duplicates weak symbols
-  {
-    std::set<std::string> previouslySeen;
-    static constexpr const std::string_view weakGlobalPrefix[] = {
-        ".weak .global"sv,
-        ".weak .const"sv,
-    };
-    for (const auto &prefix : weakGlobalPrefix) {
+    {
+      std::string prefix = "uniquify_" + std::to_string(uniquifyIdx++);
+      static const std::string strPrefix = "$str";
       for (auto it = std::search(
-               begin(result), end(result), cbegin(prefix), cend(prefix));
-          it != end(result);) {
-        auto equalSignIt = std::find(it, end(result), '=');
-        if (equalSignIt == end(result))
+               begin(blob), end(blob), cbegin(strPrefix), cend(strPrefix));
+          it != end(blob);) {
+        // Insertion might invalidate the iterator. Make sure to get the after
+        // insertion value.
+        it = blob.insert(++it, cbegin(prefix), cend(prefix));
+        // And search for next occurrence from there. Note that current $str has
+        // been broken to $_something_str and is not a match anymore for the
+        // search, so we can resume at current position.
+        it = std::search(it, end(blob), cbegin(strPrefix), cend(strPrefix));
+      }
+    }
+
+    // Remove .visible qualifier from of all functions but OptiX semantic entry
+    // points.
+    {
+      static constexpr std::string_view dotVisible = "\n.visible ";
+      static constexpr std::string_view directCallableSemantic =
+          "__direct_callable__";
+
+      for (auto it = std::search(
+               begin(blob), end(blob), cbegin(dotVisible), cend(dotVisible));
+          it != end(blob);) {
+        it = next(it); // Skip the new line.
+        auto eolIt = std::find(it, end(blob), '\n');
+        if (std::search(it,
+                eolIt,
+                cbegin(directCallableSemantic),
+                cend(directCallableSemantic))
+            == eolIt) {
+          it = blob.erase(it, it + size(dotVisible) - 1);
+        }
+        // And search for next occurrence from there. Note that current $str has
+        // been broken to $_something_str and is not a match anymore for the
+        // search, so we can resume at current position.
+        it = std::search(it, end(blob), cbegin(dotVisible), cend(dotVisible));
+      }
+    }
+
+    // Next remove duplicates weak symbols
+    {
+      static constexpr const std::string_view weakGlobalPrefix[] = {
+          ".weak .global"sv,
+          ".weak .const"sv,
+      };
+      for (const auto &prefix : weakGlobalPrefix) {
+        for (auto it = std::search(
+                 begin(blob), end(blob), cbegin(prefix), cend(prefix));
+            it != end(blob);) {
+          auto equalSignIt = std::find(it, end(blob), '=');
+          if (equalSignIt == end(blob))
+            break;
+
+          std::string decl(it, equalSignIt);
+          if (previouslySeenWeak.insert(decl).second) {
+            it = equalSignIt;
+          } else {
+            // Remove duplicate.
+            auto eraseTillIt = std::find(it, end(blob), '\n');
+            if (eraseTillIt != end(blob))
+              ++eraseTillIt;
+            it = blob.erase(it, eraseTillIt);
+          }
+
+          it = std::search(it, end(blob), cbegin(prefix), cend(prefix));
+        }
+      }
+    }
+
+    // Only needed when we build the cuda code with -lineinfo or -G
+    // We don't know that here, so we proceed anyway.
+    // Ensure no duplicate info string for debug symbols
+    {
+      static constexpr const auto prefix = "$L__info_string"sv;
+      for (auto it = std::search(
+               begin(blob), end(blob), cbegin(prefix), cend(prefix));
+          it != end(blob);
+          it = std::search(it, end(blob), cbegin(prefix), cend(prefix))) {
+        it += size(prefix);
+        auto indexEndIt = std::find_if(
+            it, end(blob), [](char c) { return !std::isdigit(c); });
+        if (indexEndIt == end(blob))
           break;
 
-        std::string decl(it, equalSignIt);
-        if (!previouslySeen.insert(decl).second) {
-          auto eraseTillIt = std::find(it, end(result), '\n');
-          if (eraseTillIt != end(result))
-            ++eraseTillIt;
-          it = result.erase(it, eraseTillIt);
+        auto indexStr = std::string(it, indexEndIt);
+        auto index = std::stoi(indexStr);
+
+        int newIndex;
+        if (*indexEndIt == ':') {
+          newIndex = infoStringBaseIndex++;
         } else {
-          ++it;
+          newIndex = index + infoStringBaseIndex;
         }
 
-        it = std::search(it, end(result), cbegin(prefix), cend(prefix));
+        if (newIndex == index)
+          continue;
+
+        // Replace the index with the new one.
+        auto newIndexStr = std::to_string(newIndex);
+        if (size(newIndexStr) == size(indexStr)) {
+          // Same content, just copy the values
+          // Returned it points after the last copied element.
+          it = std::copy(cbegin(newIndexStr), cend(newIndexStr), it);
+        } else {
+          // Returned it points after the last removed element.
+          // Try and avoid calling erase + insert to move the data only once.
+          assert(size(newIndexStr) > size(indexStr));
+          it = std::copy_n(cbegin(newIndexStr), size(indexStr), it);
+          it = blob.insert(
+              it, cbegin(newIndexStr) + size(indexStr), cend(newIndexStr));
+        }
       }
     }
+
+    // Ensure no duplicate file ids for debug symbols
+    {
+      static constexpr const auto dotFilePrefix = ".file"sv;
+      static constexpr const auto dotLocPrefix = ".loc"sv;
+      static constexpr const auto inlinedAtPrefix = " inlined_at"sv;
+
+      // That's the slow code path of the stitching... Let's try and minimize
+      // the amount of traversal we need to do. Let's go with 3 linear
+      // traversal, one for each of the prefixes. WARNING: dotFilePrefix needs
+      // to be last, as it is the one that will compute the new file base index.
+      for (auto dotkword : {inlinedAtPrefix, dotLocPrefix, dotFilePrefix}) {
+        for (auto it = std::search(
+                 begin(blob), end(blob), cbegin(dotkword), cend(dotkword));
+            it != end(blob);
+            it = std::search(it, end(blob), cbegin(dotkword), cend(dotkword))) {
+          // Eat spaces prior to the actual index
+          it += size(dotkword);
+          if (!std::isspace(*it)) {
+            continue;
+          }
+          while (std::isspace(*it))
+            ++it;
+
+          // And go till the end of the current number
+          auto indexEndIt = it + 1;
+          while (std::isdigit(*indexEndIt))
+            ++indexEndIt;
+
+          if (indexEndIt == end(blob))
+            break;
+
+          auto indexStr = std::string(it, indexEndIt);
+          auto index = std::stoi(indexStr);
+
+          int newIndex;
+          if (dotkword == dotFilePrefix) {
+            newIndex = ++fileBaseIndex; // File indices starts at one, hence the
+                                        // pre-increment.
+          } else {
+            newIndex = index + fileBaseIndex;
+          }
+
+          if (newIndex == index) {
+            continue;
+          }
+
+          // Replace the index with the new one.
+          auto newIndexStr = std::to_string(newIndex);
+          if (size(newIndexStr) == size(indexStr)) {
+            // Same content, just copy the values
+            // Returned it points after the last copied element.
+            it = std::copy(cbegin(newIndexStr), cend(newIndexStr), it);
+          } else {
+            // Returned it points after the last removed element.
+            // Try and avoid calling erase + insert to move the data only once.
+            assert(size(newIndexStr) > size(indexStr));
+            it = std::copy_n(cbegin(newIndexStr), size(indexStr), it);
+            it = blob.insert(
+                it, cbegin(newIndexStr) + size(indexStr), cend(newIndexStr));
+          }
+        }
+      }
+    }
+
+    fixedBlobs.push_back(std::move(blob));
+    totalSize += size(s);
   }
 
-  std::string header =
+  // Finally join all the fixed blobs
+  const std::string header =
       "// Generated\n" + version + "\n" + target + "\n" + addressSize + "\n\n";
+  std::vector<char> result;
+  result.reserve(size(header) + totalSize);
   result.insert(begin(result), cbegin(header), cend(header));
-
-  {
-    std::ofstream ofs("/tmp/shader-new.ptx");
-    std::copy(cbegin(result), cend(result), std::ostream_iterator<char>(ofs));
+  for (const auto &blob : fixedBlobs) {
+    result.insert(end(result), std::cbegin(blob), std::cend(blob));
   }
 
   return result;

--- a/devices/rtx/mdl/MaterialRegistry.cpp
+++ b/devices/rtx/mdl/MaterialRegistry.cpp
@@ -16,6 +16,7 @@
 #include <mi/neuraylib/imdl_backend.h>
 #include <mi/neuraylib/imdl_configuration.h>
 #include <mi/neuraylib/itexture.h>
+#include <mi/neuraylib/version.h>
 
 #include <glm/fwd.hpp>
 
@@ -165,10 +166,16 @@ MaterialRegistry::acquireMaterial(
     if (targetCode->get_texture_shape(i)
         == mi::neuraylib::ITarget_code::Texture_shape_bsdf_data) {
       mi::Size x, y, z;
+      const char* pixelFormat = {};
+#if MI_NEURAYLIB_API_VERSION >= 56
+      textureDesc.bsdf.data = targetCode->get_texture_df_data(i, x, y, z, pixelFormat);
+#else
       textureDesc.bsdf.data = targetCode->get_texture_df_data(i, x, y, z);
+#endif
       textureDesc.bsdf.dims[0] = x;
       textureDesc.bsdf.dims[1] = y;
       textureDesc.bsdf.dims[2] = z;
+      textureDesc.bsdf.pixelFormat = pixelFormat;
       textureDesc.colorSpace = libmdl::ArgumentBlockDescriptor::
           TextureDescriptor::ColorSpace::Linear;
       textureDesc.url =


### PR DESCRIPTION
- Fixes libmdl compilation with latest MDL-SDK 2024.1.
- Also fixes a runtime issue in debug mode where PTX debug annotations were not handled.
  This breakage was due to latest changes for debug builds in a49859a03ad2c1873ed89e18690c2d0756ab55e2.
  This commit did add those annotations.