### PR TITLE
Fix older platforms with neural disabled

### DIFF
--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -311,13 +311,15 @@ function(GenerateEmbeddedPTX DIR BASE_NAME)
     ${MDL_SDK_INCLUDE_DIRS}
   )
 
+  if(VISRTX_ENABLE_NEURAL)
+    set(CUDA_ARCHS 89-virtual)
+  else()
+    set(CUDA_ARCHS 52-virtual)
+  endif()
+
   set_target_properties(${INPUT_TARGET} PROPERTIES
     CUDA_PTX_COMPILATION ON
-    if(VISRTX_ENABLE_NEURAL)
-      CUDA_ARCHITECTURES "89-virtual" # Only architectures with full support for fp16
-    else()
-      CUDA_ARCHITECTURES "52-virtual"
-    endif()
+    CUDA_ARCHITECTURES ${CUDA_ARCHS}
   )
 
   EmbedPTX(

--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -36,8 +36,6 @@ project(anari_library_visrtx VERSION ${PROJECT_VERSION} LANGUAGES CXX CUDA)
 ## RTX device options ##
 
 option(VISRTX_ENABLE_NEURAL "Enable Neural Graphics Primitives" OFF)
-mark_as_advanced(VISRTX_ENABLE_NEURAL)
-
 option(VISRTX_ENABLE_NVTX "Enable NVTX profiling instrumentation" OFF)
 mark_as_advanced(VISRTX_ENABLE_NVTX)
 

--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -153,7 +153,7 @@ set(SOURCES
   scene/surface/geometry/Curve.cpp
   scene/surface/geometry/Cylinder.cpp
   scene/surface/geometry/Geometry.cpp
-  scene/surface/geometry/Neural.cpp
+  $<$<BOOL:${VISRTX_ENABLE_NEURAL}>:scene/surface/geometry/Neural.cpp>
   scene/surface/geometry/Quad.cpp
   scene/surface/geometry/Sphere.cu
   scene/surface/geometry/Triangle.cpp
@@ -253,7 +253,7 @@ PRIVATE
   VISRTX_VERSION_PATCH=${PROJECT_VERSION_PATCH}
   $<$<BOOL:${VISRTX_ENABLE_NVTX}>:USE_NVTX>
   $<$<BOOL:${VISRTX_ENABLE_MDL_SUPPORT}>:USE_MDL>
-  $<$<BOOL:${VISRTX_USE_NEURAL}>:VISRTX_USE_NEURAL>
+  $<$<BOOL:${VISRTX_ENABLE_NEURAL}>:VISRTX_USE_NEURAL>
 )
 
 if(NOT WIN32)
@@ -314,9 +314,9 @@ function(GenerateEmbeddedPTX DIR BASE_NAME)
   set_target_properties(${INPUT_TARGET} PROPERTIES
     CUDA_PTX_COMPILATION ON
     if(VISRTX_ENABLE_NEURAL)
-      CUDA_ARCHITECTURES "89" # Only architectures with full support for fp16
+      CUDA_ARCHITECTURES "89-virtual" # Only architectures with full support for fp16
     else()
-      CUDA_ARCHITECTURES OFF
+      CUDA_ARCHITECTURES "52-virtual"
     endif()
   )
 

--- a/devices/rtx/gpu/gpu_objects.h
+++ b/devices/rtx/gpu/gpu_objects.h
@@ -45,7 +45,9 @@
 #include <nanovdb/NanoVDB.h>
 
 // cuda half precision
+#ifdef VISRTX_USE_NEURAL
 #include <cuda_fp16.h>
+#endif
 
 #define DECLARE_FRAME_DATA(n)                                                  \
   extern "C" {                                                                 \
@@ -181,6 +183,8 @@ struct SphereGeometryData
   float radius;
 };
 
+#ifdef VISRTX_USE_NEURAL
+
 constexpr uint32_t NEURAL_NB_MAX_LAYERS = 5;
 constexpr uint32_t NEURAL_LAYER_SIZE = 128;
 struct NeuralGeometryData
@@ -191,6 +195,7 @@ struct NeuralGeometryData
   box3 bounds;
   float threshold;
 };
+#endif
 
 struct GeometryGPUData
 {
@@ -206,7 +211,9 @@ struct GeometryGPUData
     CurveGeometryData curve;
     ConeGeometryData cone;
     SphereGeometryData sphere;
+#ifdef VISRTX_USE_NEURAL
     NeuralGeometryData neural;
+#endif
   };
 };
 

--- a/devices/rtx/scene/surface/geometry/Geometry.cpp
+++ b/devices/rtx/scene/surface/geometry/Geometry.cpp
@@ -37,7 +37,10 @@
 #include "Quad.h"
 #include "Sphere.h"
 #include "Triangle.h"
+
+#ifdef VISRTX_USE_NEURAL
 #include "Neural.h"
+#endif
 #include "UnknownGeometry.h"
 // std
 #include <cstring>
@@ -94,8 +97,10 @@ Geometry *Geometry::createInstance(
     return new Cone(d);
   else if (subtype == "curve")
     return new Curve(d);
+#ifdef VISRTX_USE_NEURAL
   else if (subtype == "neural")
     return new Neural(d);
+#endif
   else
     return new UnknownGeometry(subtype, d);
 }


### PR DESCRIPTION
Currently, when running VisRTX on an older setup (tested on an A3000), the device fails to start.
That is because the shaders are compiled with some half precision code which is not supported by the target architecture (sm_89 vs sm_82).

This PR does make it so that neural code is isolated and not embedded into the output code if VISRTX_ENABLE_NEURAL is disabled.

Note:
- that extension is missing the required `visrtx_geometry_neural.json` file to describe its inputs. This is not addressed by this PR.
- the test in `visrtx_device.json`  `$<$<BOOL:$<TARGET_EXISTS:VISRTX_USE_NEURAL>>:"visrtx_geometry_neural",>` is also broken, as no such target exist. A different test needs to be used. This is not addressed by this PR.
