### PR TITLE
Fix compilation with gcc-12

### DIFF
--- a/devices/rtx/gpu/gpu_objects.h
+++ b/devices/rtx/gpu/gpu_objects.h
@@ -192,7 +192,8 @@ struct NeuralGeometryData
   __half *weights[NEURAL_NB_MAX_LAYERS]; // Array of weight matrices
   __half *biases[NEURAL_NB_MAX_LAYERS]; // Array of bias vectors
   uint32_t nb_layers;
-  box3 bounds;
+  vec3 boundMin;
+  vec3 boundMax;
   float threshold;
 };
 #endif

--- a/devices/rtx/scene/Intersectors_ptx.cu
+++ b/devices/rtx/scene/Intersectors_ptx.cu
@@ -367,7 +367,7 @@ VISRTX_DEVICE float __optix_enabled__forwardSDF(
 VISRTX_DEVICE void intersectNeural(const GeometryGPUData &geometryData)
 {
   const auto &neuralData = geometryData.neural;
-  const box3 bounds = neuralData.bounds;
+  const box3 bounds = { neuralData.boundMin, neuralData.boundMax };
   const vec3 &ro = ray::localOrigin();
   const vec3 &rd = ray::localDirection();
   float t0, t1;

--- a/devices/rtx/scene/surface/geometry/Neural.cpp
+++ b/devices/rtx/scene/surface/geometry/Neural.cpp
@@ -63,11 +63,8 @@ GeometryGPUData Neural::gpuData() const
   neural.nb_layers = m_layers.size() / 2;
 
   // Read bounds from parameters
-  vec3 aabb_min = getParam<glm::vec3>("aabb_min", glm::vec3(-1.f));
-  vec3 aabb_max = getParam<glm::vec3>("aabb_max", glm::vec3(1.f));
-  m_aabb.lower = aabb_min;
-  m_aabb.upper = aabb_max;
-  neural.bounds = m_aabb;
+  neural.boundMin = getParam<glm::vec3>("aabb_min", glm::vec3(-1.f));
+  neural.boundMax = getParam<glm::vec3>("aabb_max", glm::vec3(1.f));
 
   neural.threshold = getParam<float>("threshold", 0.1f);
 


### PR DESCRIPTION
When using GCC 12, range_t<> is not trivial and so cannot be used as part of a union.
This PR replaces the use of box3 with two vec3.

Closes #132