### PR TITLE
Added screenshot implementation

### DIFF
--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -72,6 +72,7 @@ struct Viewport : public Window
   bool m_frameCancelled{false};
   bool m_saveNextFrame{false};
   bool m_echoCameraConfig{false};
+  int m_screenshotIndex{0};
 
   bool m_showOverlay{true};
   bool m_showCameraInfo{false};


### PR DESCRIPTION
The existing "take screenshot" menu item now saves timestamped PNG files (screenshot_YYYYMMDD_HHMMSS_mmm.png) to the current working directory with full alpha channel preservation. Screenshots are captured directly from the ANARI frame buffer to ensure RGBA data integrity.