### PR TITLE
Support anisotropy in TSD

### DIFF
--- a/tsd/src/tsd/core/scene/objects/Material.cpp
+++ b/tsd/src/tsd/core/scene/objects/Material.cpp
@@ -52,6 +52,20 @@ Material::Material(Token subtype) : Object(ANARI_MATERIAL, subtype)
         .setDescription("roughness")
         .setMin(0.f)
         .setMax(1.f);
+    addParameter("anisotropyStrength")
+        .setValue(0.f)
+        .setDescription("anisotropy strength in [0:1]")
+        .setMin(0.f)
+        .setMax(1.f);
+    addParameter("anisotropyDirection")
+        .setValue(float2(1.f, 0.f))
+        .setDescription("direction in tangent and bitangent space, in [-1:1]^2");
+    addParameter("anisotropyRotation")
+        .setValue(0.f)
+        .setDescription("anisotropy rotation (in radians)")
+        .setMin(0.f)
+        //.setMax(M_PI*2.f); /* not sure why, but this leads to crashes.... */
+        .setMax(1.f);
     addParameter("emissive")
         .setValue(float3(0.f, 0.f, 0.f))
         .setDescription("strength of emissiveness")


### PR DESCRIPTION
This PR adds support for the following parameters on the physically based material and the ASSIMP importer (based on the glTF spec for `KHR_materials_anisotropy`, https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md):

* `anisotropyStrength`, `ANARI_FLOAT32` or `ANARI_SAMPLER`, in [0:1] - the amount of anisotropy.
* `anisotropyDirection` `ANARI_FLOAT32_VEC2` or `ANARI_SAMPLER`, in [-1:1]^2, `u` is the direction in tangent and `v` the direction in bitangent space.
* `anisotropyRotation`, `ANARI_FLOAT32`, uniform angle in radians, used to rotate the direction vector.

Here's a pseudo code implementation based on the above link:

```
inline float D_GGX_Anisotropic(float NdotH, float TdotH, float BdotH, float at, float ab)
{
  float a2 = at*ab;
  float3 v(ab * TdotH, at * BdotH, a2 * NdotH);
  float v2 = dot(v,v);
  float w2 = a2 / v2;
  return a2 * w2 * w2 * INV_PI;
}

inline void eval(...)
{
  // anisotropic basis:
  const float2 rotation(cosf(anisotropyRotation), sinf(anisotropyRotation));
  float2 direction = anisotropyDirection;
  direction = mat2(rotation.x, rotation.y, -rotation.y, rotation.x) * normalize(direction);
  const mat3 TBN(T,B,Ns);
  const float3 anisotropicT = normalize(TBN * float3(direction, 0.f));
  const float3 anisotropicB = normalize(cross(Ns, anisotropicT));

  // eval anisotropic microfacet distribution
  const float NdotH = dot(Ns,H);
  const float TdotH = dot(anisotropicT,H);
  const float BdotH = dot(anisotropicB,H);
  float at = max(alpha * (1.f + anisotropyStrength), 0.001f);
  float ab = max(alpha * (1.f - anisotropyStrength), 0.001f);
  const float D = D_GGX_Anisotropic(NdotH, TdotH, BdotH, at, ab);
}
```

Other than in the glTF spec, where the direction vector's components are quantized to [0:1], I propose to specify these as being in [-1:1], which lends itself to importers remapping texture channels using sampler out transforms (see the ASSIMP importer for an example).

Here's some visual proof that this works with the `anari-visionaray` device (cf. https://github.com/szellmann/anari-visionaray/commit/f82181080c0d59e538183b861d54c4d5371de6bb):
<img width="1820" height="1115" alt="Screenshot 2025-09-01 at 11 09 47 PM" src="https://github.com/user-attachments/assets/ef58737d-a533-49f5-a0fd-b267936da737" />

<img width="1820" height="1115" alt="Screenshot 2025-09-01 at 11 08 15 PM" src="https://github.com/user-attachments/assets/4d931299-49ed-435f-a0cf-dc50278974e3" />

(Note there's an issue preventing me from setting proper min/max limits for the rotation parameter. Sensible limits would be [0:2*PI], but at the moment, when setting 2*PI as maximum the TSD viewer app crashes. This seems like an orthogonal issue though.)
