### PR TITLE
TSD-ASSIMP: Fix clearcoat and sheer not being assign correctly 

### DIFF
--- a/tsd/src/tsd/io/importers/import_ASSIMP.cpp
+++ b/tsd/src/tsd/io/importers/import_ASSIMP.cpp
@@ -320,12 +320,12 @@ static std::vector<MaterialRef> importASSIMPMaterials(
           auto tx = getTextureUVTransform(
               AI_MATKEY_UVTRANSFORM(aiTextureType_SHEEN, 0));
           sampler->setParameter("inTransform"_t, tx);
-          m->setParameterObject("sheenColor.texture"_t, *sampler);
+          m->setParameterObject("sheenColor"_t, *sampler);
         }
       } else if (aiColor3D sheenColor;
           assimpMat->Get(AI_MATKEY_SHEEN_COLOR_FACTOR, sheenColor)
           == AI_SUCCESS) {
-        m->setParameter("sheenColor.value"_t, ANARI_FLOAT32_VEC3, &sheenColor);
+        m->setParameter("sheenColor"_t, ANARI_FLOAT32_VEC3, &sheenColor);
       }
 
       if (aiString sheenRoughnessTexture;
@@ -336,13 +336,13 @@ static std::vector<MaterialRef> importASSIMPMaterials(
           auto tx = getTextureUVTransform(
               AI_MATKEY_UVTRANSFORM(aiTextureType_SHEEN, 1));
           sampler->setParameter("inTransform"_t, tx);
-          m->setParameterObject("sheenRoughness.texture"_t, *sampler);
+          m->setParameterObject("sheenRoughness"_t, *sampler);
         }
       } else if (ai_real sheenRoughnessFactor;
           assimpMat->Get(AI_MATKEY_SHEEN_ROUGHNESS_FACTOR, sheenRoughnessFactor)
           == AI_SUCCESS) {
         m->setParameter(
-            "sheenRoughness.value"_t, ANARI_FLOAT32, &sheenRoughnessFactor);
+            "sheenRoughness"_t, ANARI_FLOAT32, &sheenRoughnessFactor);
       }
 
       // Clearcoat handling
@@ -353,12 +353,12 @@ static std::vector<MaterialRef> importASSIMPMaterials(
           auto tx = getTextureUVTransform(
               AI_MATKEY_UVTRANSFORM(aiTextureType_CLEARCOAT, 0));
           sampler->setParameter("inTransform"_t, tx);
-          m->setParameterObject("clearcoat.texture"_t, *sampler);
+          m->setParameterObject("clearcoat"_t, *sampler);
         }
       } else if (ai_real clearcoatFactor;
           assimpMat->Get(AI_MATKEY_CLEARCOAT_FACTOR, clearcoatFactor)
           == AI_SUCCESS) {
-        m->setParameter("clearcoat.value"_t, ANARI_FLOAT32, &clearcoatFactor);
+        m->setParameter("clearcoat"_t, ANARI_FLOAT32, &clearcoatFactor);
       }
 
       if (aiString clearcoatRoughnessTexture;
@@ -370,13 +370,13 @@ static std::vector<MaterialRef> importASSIMPMaterials(
           auto tx = getTextureUVTransform(
               AI_MATKEY_UVTRANSFORM(aiTextureType_CLEARCOAT, 1));
           sampler->setParameter("inTransform"_t, tx);
-          m->setParameterObject("clearcoatRoughness.texture"_t, *sampler);
+          m->setParameterObject("clearcoatRoughness"_t, *sampler);
         }
       } else if (ai_real clearcoatRoughnessFactor;
           assimpMat->Get(
               AI_MATKEY_CLEARCOAT_ROUGHNESS_FACTOR, clearcoatRoughnessFactor)
           == AI_SUCCESS) {
-        m->setParameter("clearcoatRoughness.value"_t,
+        m->setParameter("clearcoatRoughness"_t,
             ANARI_FLOAT32,
             &clearcoatRoughnessFactor);
       }

--- a/tsd/src/tsd/io/importers/import_GLTF.cpp
+++ b/tsd/src/tsd/io/importers/import_GLTF.cpp
@@ -775,6 +775,8 @@ static std::vector<MaterialRef> importGLTFMaterials(
         sampler->setParameter("outOffset"_t,
             float4(iridescenceThicknessMinimum, 0.0f, 0.0f, 0.0f));
         material->setParameterObject("iridescenceThickness"_t, *sampler);
+      } else {
+        material->setParameter("iridescenceThickness"_t, iridescenceThicknessMaximum - iridescenceThicknessMinimum);
       }
     } else {
       // Default values


### PR DESCRIPTION
Also sneaked in a glTF importer fix where iridescence scalar value was not correctly assigned.

Fixes: #148