### PR TITLE
Enables focus on right click so that right-click-drag works with prior left-click

### DIFF
--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -71,6 +71,14 @@ void Viewport::buildUI()
 
   ImGui::EndDisabled();
 
+  // Make is so that right-click gets the window focused.
+  // This enables right-click-drag to work right away even if the window is not focused
+  // same as left-click-drag works without requiring a prior left-click-focus.
+  if (ImGui::IsWindowHovered() && ImGui::IsMouseDown(ImGuiMouseButton_Right))
+  {
+    ImGui::SetWindowFocus();
+  }
+
   bool didPick = ui_picking();
 
   ui_handleInput();


### PR DESCRIPTION
This enables dollying to work on first click same as orbiting with left-click.