### PR TITLE
Add support for clampToBorder on ImageXD samplers

### DIFF
--- a/devices/rtx/src/renderer/Renderer.cpp
+++ b/devices/rtx/src/renderer/Renderer.cpp
@@ -174,7 +174,7 @@ void Renderer::finalize()
   cleanup();
   if (m_backgroundImage) {
     auto cuArray = m_backgroundImage->acquireCUDAArrayUint8();
-    m_backgroundTexture = makeCudaTextureObject(cuArray, true, "linear");
+    m_backgroundTexture = makeCudaTextureObject2D(cuArray, true, "linear");
   }
 }
 

--- a/devices/rtx/src/scene/light/HDRI.cpp
+++ b/devices/rtx/src/scene/light/HDRI.cpp
@@ -111,7 +111,7 @@ void HDRI::finalize()
           &m_conditionalCDF);
 
   m_radianceTex =
-      makeCudaTextureObject(cuArray, !isFp, "linear", "repeat", "clampToEdge");
+      makeCudaTextureObject2D(cuArray, !isFp, "linear", "repeat", "clampToEdge");
 
 #ifdef VISRTX_ENABLE_HDRI_SAMPLING_DEBUG
   cudaMalloc(&m_samples, m_size.x * m_size.y * sizeof(unsigned int));

--- a/devices/rtx/src/scene/surface/material/sampler/CompressedImage2D.cpp
+++ b/devices/rtx/src/scene/surface/material/sampler/CompressedImage2D.cpp
@@ -123,20 +123,18 @@ void CompressedImage2D::finalize()
   makeCudaCompressedTextureArray(
       m_cuArray, m_size, *m_image.get(), channelFormatKind);
 
-  m_texture = makeCudaCompressedTextureObject(m_cuArray,
+  m_texture = makeCudaCompressedTextureObject2D(m_cuArray,
+    channelFormatKind,
       m_filter,
       m_wrap1,
       m_wrap2,
-      "clampToEdge",
-      true,
-      channelFormatKind);
-  m_texels = makeCudaCompressedTextureObject(m_cuArray,
+      m_borderColor);
+  m_texels = makeCudaCompressedTexelObject2D(m_cuArray,
+    channelFormatKind,
       "nearest",
       m_wrap1,
       m_wrap2,
-      "clampToEdge",
-      false,
-      channelFormatKind);
+      m_borderColor);
 
   upload();
 }

--- a/devices/rtx/src/scene/surface/material/sampler/Image1D.cpp
+++ b/devices/rtx/src/scene/surface/material/sampler/Image1D.cpp
@@ -74,9 +74,9 @@ void Image1D::finalize()
   } else {
     cuArray = m_image->acquireCUDAArrayUint8();
   }
-  m_texture = makeCudaTextureObject(cuArray, !isFp, m_filter, m_wrap1);
-  m_texels = makeCudaTextureObject(
-      cuArray, !isFp, "nearest", m_wrap1, "clampToEdge", "clampToEdge", false);
+  m_texture = makeCudaTextureObject1D(cuArray, !isFp, m_filter, m_wrap1, m_borderColor);
+  m_texels = makeCudaTexelObject1D(
+      cuArray, !isFp, "nearest", m_wrap1, m_borderColor);
 
   upload();
 }

--- a/devices/rtx/src/scene/surface/material/sampler/Image2D.cpp
+++ b/devices/rtx/src/scene/surface/material/sampler/Image2D.cpp
@@ -75,9 +75,8 @@ void Image2D::finalize()
   } else {
     cuArray = m_image->acquireCUDAArrayUint8();
   }
-  m_texture = makeCudaTextureObject(cuArray, !isFp, m_filter, m_wrap1, m_wrap2);
-  m_texels = makeCudaTextureObject(
-      cuArray, !isFp, "nearest", m_wrap1, m_wrap2, "clampToEdge", false);
+  m_texture = makeCudaTextureObject2D(cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_borderColor);
+  m_texels = makeCudaTexelObject2D(cuArray, !isFp, "nearest", m_wrap1, m_wrap2, m_borderColor);
 
   upload();
 }

--- a/devices/rtx/src/scene/surface/material/sampler/Image3D.cpp
+++ b/devices/rtx/src/scene/surface/material/sampler/Image3D.cpp
@@ -80,10 +80,10 @@ void Image3D::finalize()
   } else {
     cuArray = m_image->acquireCUDAArrayUint8();
   }
-  m_texture = makeCudaTextureObject(
-      cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_wrap3);
-  m_texels = makeCudaTextureObject(
-      cuArray, !isFp, "nearest", m_wrap1, m_wrap2, m_wrap3, false);
+  m_texture = makeCudaTextureObject3D(
+      cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_wrap3, m_borderColor);
+  m_texels = makeCudaTexelObject3D(
+      cuArray, !isFp, "nearest", m_wrap1, m_wrap2, m_wrap3, m_borderColor);
 
   upload();
 }

--- a/devices/rtx/src/scene/surface/material/sampler/Sampler.cpp
+++ b/devices/rtx/src/scene/surface/material/sampler/Sampler.cpp
@@ -72,6 +72,7 @@ void Sampler::commitParameters()
   m_inOffset = getParam<vec4>("inOffset", vec4(0.f));
   m_outTransform = getParam<mat4>("outTransform", mat4(1.f));
   m_outOffset = getParam<vec4>("outOffset", vec4(0.f));
+  m_borderColor = getParam<vec4>("borderColor", vec4(0.f));
 }
 
 SamplerGPUData Sampler::gpuData() const

--- a/devices/rtx/src/scene/surface/material/sampler/Sampler.h
+++ b/devices/rtx/src/scene/surface/material/sampler/Sampler.h
@@ -54,6 +54,7 @@ struct Sampler : public RegisteredObject<SamplerGPUData>
   vec4 m_inOffset;
   mat4 m_outTransform;
   vec4 m_outOffset;
+  vec4 m_borderColor;
 };
 
 MaterialAttribute attributeFromString(const std::string &str);

--- a/devices/rtx/src/utility/CudaImageTexture.cpp
+++ b/devices/rtx/src/utility/CudaImageTexture.cpp
@@ -553,8 +553,14 @@ cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
     const std::string &wrap,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap, wrap, wrap, true, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap,
+      wrap,
+      wrap,
+      true,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
@@ -564,8 +570,14 @@ cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
     const std::string &wrap2,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap2, true, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap1,
+      wrap2,
+      wrap2,
+      true,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
@@ -576,8 +588,14 @@ cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap3,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap3, true, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap1,
+      wrap2,
+      wrap3,
+      true,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
@@ -586,8 +604,14 @@ cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
     const std::string &wrap,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap, wrap, wrap, false, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap,
+      wrap,
+      wrap,
+      false,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
@@ -597,8 +621,14 @@ cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
     const std::string &wrap2,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap2, false, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap1,
+      wrap2,
+      wrap2,
+      false,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
@@ -609,16 +639,24 @@ cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
     const std::string &wrap3,
     const vec4 &borderColor)
 {
-  return makeCudaTextureObject(
-      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap3, false, borderColor);
+  return makeCudaTextureObject(cuArray,
+      readModeNormalizedFloat,
+      filter,
+      wrap1,
+      wrap2,
+      wrap3,
+      false,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaCompressedTextureObject1D(cudaArray_t cuArray,
     cudaChannelFormatKind channelFormatKind,
     const std::string &filter,
     const std::string &wrap,
-    const vec4 &borderColor) {
-  return makeCudaCompressedTextureObject(cuArray, filter, wrap, wrap, wrap, true, channelFormatKind, borderColor);
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(
+      cuArray, filter, wrap, wrap, wrap, true, channelFormatKind, borderColor);
 }
 
 cudaTextureObject_t makeCudaCompressedTextureObject2D(cudaArray_t cuArray,
@@ -626,8 +664,16 @@ cudaTextureObject_t makeCudaCompressedTextureObject2D(cudaArray_t cuArray,
     const std::string &filter,
     const std::string &wrap1,
     const std::string &wrap2,
-    const vec4 &borderColor){
-  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap2, true, channelFormatKind, borderColor);
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(cuArray,
+      filter,
+      wrap1,
+      wrap2,
+      wrap2,
+      true,
+      channelFormatKind,
+      borderColor);
 }
 
 cudaTextureObject_t makeCudaCompressedTextureObject3D(cudaArray_t cuArray,
@@ -636,17 +682,26 @@ cudaTextureObject_t makeCudaCompressedTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap1,
     const std::string &wrap2,
     const std::string &wrap3,
-    const vec4 &borderColor) {
-return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap3, true, channelFormatKind, borderColor);
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(cuArray,
+      filter,
+      wrap1,
+      wrap2,
+      wrap3,
+      true,
+      channelFormatKind,
+      borderColor);
 }
-
 
 cudaTextureObject_t makeCudaCompressedTexelObject1D(cudaArray_t cuArray,
     cudaChannelFormatKind channelFormatKind,
     const std::string &filter,
     const std::string &wrap,
-    const vec4 &borderColor) {
-  return makeCudaCompressedTextureObject(cuArray, filter, wrap, wrap, wrap, false, channelFormatKind, borderColor);
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(
+      cuArray, filter, wrap, wrap, wrap, false, channelFormatKind, borderColor);
 }
 
 cudaTextureObject_t makeCudaCompressedTexelObject2D(cudaArray_t cuArray,
@@ -654,9 +709,17 @@ cudaTextureObject_t makeCudaCompressedTexelObject2D(cudaArray_t cuArray,
     const std::string &filter,
     const std::string &wrap1,
     const std::string &wrap2,
-    const vec4 &borderColor) {
-  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap2, false, channelFormatKind, borderColor);
-    }
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(cuArray,
+      filter,
+      wrap1,
+      wrap2,
+      wrap2,
+      false,
+      channelFormatKind,
+      borderColor);
+}
 
 cudaTextureObject_t makeCudaCompressedTexelObject3D(cudaArray_t cuArray,
     cudaChannelFormatKind channelFormatKind,
@@ -664,8 +727,16 @@ cudaTextureObject_t makeCudaCompressedTexelObject3D(cudaArray_t cuArray,
     const std::string &wrap1,
     const std::string &wrap2,
     const std::string &wrap3,
-    const vec4 &borderColor) {
-  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap3, false, channelFormatKind, borderColor);
-    }
+    const vec4 &borderColor)
+{
+  return makeCudaCompressedTextureObject(cuArray,
+      filter,
+      wrap1,
+      wrap2,
+      wrap3,
+      false,
+      channelFormatKind,
+      borderColor);
+}
 
 } // namespace visrtx

--- a/devices/rtx/src/utility/CudaImageTexture.cpp
+++ b/devices/rtx/src/utility/CudaImageTexture.cpp
@@ -132,6 +132,8 @@ cudaTextureAddressMode stringToAddressMode(const std::string &str)
     return cudaAddressModeWrap;
   else if (str == "mirrorRepeat")
     return cudaAddressModeMirror;
+  else if (str == "clampToBorder")
+    return cudaAddressModeBorder;
   else
     return cudaAddressModeClamp;
 }
@@ -321,7 +323,8 @@ cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
     const std::string &wrap1,
     const std::string &wrap2,
     const std::string &wrap3,
-    bool normalizedCoords)
+    bool normalizedCoords,
+    const vec4 &borderColor)
 {
   cudaResourceDesc resDesc;
   memset(&resDesc, 0, sizeof(resDesc));
@@ -338,6 +341,10 @@ cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
   texDesc.readMode = readModeNormalizedFloat ? cudaReadModeNormalizedFloat
                                              : cudaReadModeElementType;
   texDesc.normalizedCoords = normalizedCoords;
+  texDesc.borderColor[0] = borderColor.x;
+  texDesc.borderColor[1] = borderColor.y;
+  texDesc.borderColor[2] = borderColor.z;
+  texDesc.borderColor[3] = borderColor.w;
 
   cudaTextureObject_t retval = {};
   cudaCreateTextureObject(&retval, &resDesc, &texDesc, nullptr);
@@ -494,7 +501,8 @@ cudaTextureObject_t makeCudaCompressedTextureObject(cudaArray_t cuArray,
     const std::string &wrap2,
     const std::string &wrap3,
     bool normalizedCoords,
-    const cudaChannelFormatKind channelFormatKind)
+    const cudaChannelFormatKind channelFormatKind,
+    const vec4 &borderColor)
 {
   cudaResourceDesc resDesc{};
   resDesc.resType = cudaResourceTypeArray;
@@ -507,6 +515,11 @@ cudaTextureObject_t makeCudaCompressedTextureObject(cudaArray_t cuArray,
   texDesc.filterMode =
       filter == "nearest" ? cudaFilterModePoint : cudaFilterModeLinear;
   texDesc.normalizedCoords = normalizedCoords;
+
+  texDesc.borderColor[0] = borderColor.x;
+  texDesc.borderColor[1] = borderColor.y;
+  texDesc.borderColor[2] = borderColor.z;
+  texDesc.borderColor[3] = borderColor.w;
 
   // Only explicit float type are to be read as element type. Others need to be
   // read as normalized floats.
@@ -533,5 +546,126 @@ cudaTextureObject_t makeCudaCompressedTextureObject(cudaArray_t cuArray,
 
   return retval;
 }
+
+cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap, wrap, wrap, true, borderColor);
+}
+
+cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap2, true, borderColor);
+}
+
+cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const std::string &wrap3,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap3, true, borderColor);
+}
+
+cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap, wrap, wrap, false, borderColor);
+}
+
+cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap2, false, borderColor);
+}
+
+cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const std::string &wrap3,
+    const vec4 &borderColor)
+{
+  return makeCudaTextureObject(
+      cuArray, readModeNormalizedFloat, filter, wrap1, wrap2, wrap3, false, borderColor);
+}
+
+cudaTextureObject_t makeCudaCompressedTextureObject1D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap,
+    const vec4 &borderColor) {
+  return makeCudaCompressedTextureObject(cuArray, filter, wrap, wrap, wrap, true, channelFormatKind, borderColor);
+}
+
+cudaTextureObject_t makeCudaCompressedTextureObject2D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const vec4 &borderColor){
+  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap2, true, channelFormatKind, borderColor);
+}
+
+cudaTextureObject_t makeCudaCompressedTextureObject3D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const std::string &wrap3,
+    const vec4 &borderColor) {
+return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap3, true, channelFormatKind, borderColor);
+}
+
+
+cudaTextureObject_t makeCudaCompressedTexelObject1D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap,
+    const vec4 &borderColor) {
+  return makeCudaCompressedTextureObject(cuArray, filter, wrap, wrap, wrap, false, channelFormatKind, borderColor);
+}
+
+cudaTextureObject_t makeCudaCompressedTexelObject2D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const vec4 &borderColor) {
+  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap2, false, channelFormatKind, borderColor);
+    }
+
+cudaTextureObject_t makeCudaCompressedTexelObject3D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1,
+    const std::string &wrap2,
+    const std::string &wrap3,
+    const vec4 &borderColor) {
+  return makeCudaCompressedTextureObject(cuArray, filter, wrap1, wrap2, wrap3, false, channelFormatKind, borderColor);
+    }
 
 } // namespace visrtx

--- a/devices/rtx/src/utility/CudaImageTexture.h
+++ b/devices/rtx/src/utility/CudaImageTexture.h
@@ -69,7 +69,6 @@ void makeCudaCompressedTextureArray(cudaArray_t &cuArray,
     const Array &array,
     const cudaChannelFormatKind channelFormatKind);
 
-
 cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
     const std::string &filter,
@@ -90,7 +89,6 @@ cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap2 = "clampToEdge",
     const std::string &wrap3 = "clampToEdge",
     const vec4 &borderColor = vec4(0.f));
-
 
 cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
@@ -113,7 +111,6 @@ cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
     const std::string &wrap3 = "clampToEdge",
     const vec4 &borderColor = vec4(0.f));
 
-
 cudaTextureObject_t makeCudaCompressedTextureObject1D(cudaArray_t cuArray,
     cudaChannelFormatKind channelFormatKind,
     const std::string &filter,
@@ -135,11 +132,10 @@ cudaTextureObject_t makeCudaCompressedTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap3 = "clampToEdge",
     const vec4 &borderColor = vec4(0.f));
 
-
 cudaTextureObject_t makeCudaCompressedTexelObject1D(cudaArray_t cuArray,
     cudaChannelFormatKind channelFormatKind,
     const std::string &filter,
-    const std::string &wrap  = "clampToEdge",
+    const std::string &wrap = "clampToEdge",
     const vec4 &borderColor = vec4(0.f));
 
 cudaTextureObject_t makeCudaCompressedTexelObject2D(cudaArray_t cuArray,

--- a/devices/rtx/src/utility/CudaImageTexture.h
+++ b/devices/rtx/src/utility/CudaImageTexture.h
@@ -69,20 +69,91 @@ void makeCudaCompressedTextureArray(cudaArray_t &cuArray,
     const Array &array,
     const cudaChannelFormatKind channelFormatKind);
 
-cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
+
+cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
     const std::string &filter,
     const std::string &wrap1 = "clampToEdge",
     const std::string &wrap2 = "clampToEdge",
     const std::string &wrap3 = "clampToEdge",
-    bool normalizedCoords = true);
+    const vec4 &borderColor = vec4(0.f));
 
-cudaTextureObject_t makeCudaCompressedTextureObject(cudaArray_t cuArray,
+
+cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
     const std::string &filter,
-    const std::string &wrap1,
-    const std::string &wrap2,
-    const std::string &wrap3,
-    bool normalizedCoords,
-    cudaChannelFormatKind channelFormatKind);
+    const std::string &wrap = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
 
+cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
+    bool readModeNormalizedFloat,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const std::string &wrap3 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+
+cudaTextureObject_t makeCudaCompressedTextureObject1D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaCompressedTextureObject2D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaCompressedTextureObject3D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const std::string &wrap3 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+
+cudaTextureObject_t makeCudaCompressedTexelObject1D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap  = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaCompressedTexelObject2D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
+
+cudaTextureObject_t makeCudaCompressedTexelObject3D(cudaArray_t cuArray,
+    cudaChannelFormatKind channelFormatKind,
+    const std::string &filter,
+    const std::string &wrap1 = "clampToEdge",
+    const std::string &wrap2 = "clampToEdge",
+    const std::string &wrap3 = "clampToEdge",
+    const vec4 &borderColor = vec4(0.f));
 } // namespace visrtx

--- a/tsd/src/tsd/core/scene/objects/Sampler.cpp
+++ b/tsd/src/tsd/core/scene/objects/Sampler.cpp
@@ -18,26 +18,28 @@ Sampler::Sampler(Token subtype) : Object(ANARI_SAMPLER, subtype)
     if (subtype == tokens::sampler::image1D) {
       addParameter("wrapMode")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
     } else if (subtype == tokens::sampler::compressedImage2D
         || subtype == tokens::sampler::image2D) {
       addParameter("wrapMode1")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
       addParameter("wrapMode2")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
     } else if (subtype == tokens::sampler::image3D) {
       addParameter("wrapMode1")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
       addParameter("wrapMode2")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
       addParameter("wrapMode3")
           .setValue("clampToEdge")
-          .setStringValues({"clampToEdge", "repeat", "mirrorRepeat"});
+          .setStringValues({"clampToEdge", "clampToBorder", "repeat", "mirrorRepeat"});
     }
+
+    addParameter("borderColor").setValue(float4(0.f)).setUsage(ParameterUsageHint::COLOR);
     addParameter("inTransform").setValue(math::scaling_matrix(float3(1.f)));
     addParameter("inOffset").setValue(float4(0.f));
     addParameter("outTransform").setValue(math::scaling_matrix(float3(1.f)));


### PR DESCRIPTION
Samplers expose a new wrapping type `clampToBorder` along with a new `borderColor` parameter.
Also some quick sanitization of VisRTX CUDA texture object creation APIs.

Related ANARI-Docs [PR](https://github.com/KhronosGroup/ANARI-Docs/pull/169)