### PR TITLE
Add tonemap renderer parameter

### DIFF
--- a/devices/rtx/src/gpu/gpu_objects.h
+++ b/devices/rtx/src/gpu/gpu_objects.h
@@ -668,6 +668,7 @@ struct RendererGPUData
   float inverseVolumeSamplingRate;
   float occlusionDistance;
   bool cullTriangleBF;
+  bool tonemap; // enable internal tonemapping during sample accumulation
 };
 
 // Frame //

--- a/devices/rtx/src/gpu/gpu_util.h
+++ b/devices/rtx/src/gpu/gpu_util.h
@@ -423,9 +423,11 @@ VISRTX_DEVICE void accumResults(const FrameGPUData &frame,
 
   const auto accumColor = fb.buffers.colorAccumulation[idx];
   // Conditionally apply inverse tonemapping on output
+  const float frameDivisor = float(fb.frameID + frameIDOffset + 1);
+  const auto normalizedColor = accumColor / frameDivisor;
   const auto outputColor = frame.renderer.tonemap
-      ? detail::inverseTonemap(accumColor / float(fb.frameID + frameIDOffset + 1))
-      : (accumColor / float(fb.frameID + frameIDOffset + 1));
+      ? detail::inverseTonemap(normalizedColor)
+      : normalizedColor;
 
   detail::writeOutputColor(fb, outputColor, idx, frameIDOffset);
 

--- a/devices/rtx/src/renderer/AmbientOcclusion_ptx.cu
+++ b/devices/rtx/src/renderer/AmbientOcclusion_ptx.cu
@@ -206,7 +206,7 @@ VISRTX_GLOBAL void __raygen__()
       }
     }
 
-    accumResults(frameData.fb,
+    accumResults(frameData,
         ss.pixel,
         vec4(outputColor, outputOpacity),
         depth,

--- a/devices/rtx/src/renderer/Debug_ptx.cu
+++ b/devices/rtx/src/renderer/Debug_ptx.cu
@@ -246,7 +246,7 @@ VISRTX_GLOBAL void __raygen__()
     instID = vrd.instance->id;
   }
 
-  accumResults(frameData.fb,
+  accumResults(frameData,
       ss.pixel,
       vec4(color, 1.f),
       depth,

--- a/devices/rtx/src/renderer/DiffusePathTracer_ptx.cu
+++ b/devices/rtx/src/renderer/DiffusePathTracer_ptx.cu
@@ -201,7 +201,7 @@ VISRTX_GLOBAL void __raygen__()
       color = vec3(1) - color;
     if (debug())
       printf("========== END: FrameID %i ==========\n", frameData.fb.frameID);
-    accumResults(frameData.fb,
+    accumResults(frameData,
         ss.pixel,
         vec4(color, 1.f),
         outDepth,

--- a/devices/rtx/src/renderer/DirectLight_ptx.cu
+++ b/devices/rtx/src/renderer/DirectLight_ptx.cu
@@ -414,7 +414,7 @@ VISRTX_GLOBAL void __raygen__()
       }
     }
 
-    accumResults(frameData.fb,
+    accumResults(frameData,
         ss.pixel,
         vec4(outputColor, outputOpacity),
         depth,

--- a/devices/rtx/src/renderer/Raycast_ptx.cu
+++ b/devices/rtx/src/renderer/Raycast_ptx.cu
@@ -167,7 +167,7 @@ VISRTX_GLOBAL void __raygen__()
     }
   }
 
-  accumResults(frameData.fb,
+  accumResults(frameData,
       ss.pixel,
       vec4(outputColor, outputOpacity),
       depth,

--- a/devices/rtx/src/renderer/Renderer.cpp
+++ b/devices/rtx/src/renderer/Renderer.cpp
@@ -161,6 +161,7 @@ void Renderer::commitParameters()
   m_occlusionDistance = getParam<float>("ambientOcclusionDistance", 1e20f);
   m_checkerboard = getParam<bool>("checkerboarding", false);
   m_denoise = getParam<bool>("denoise", false);
+  m_tonemap = getParam<bool>("tonemap", true); // enable internal tonemapping during sample accumulation
   m_sampleLimit = getParam<int>("sampleLimit", 128);
   m_cullTriangleBF = getParam<bool>("cullTriangleBackfaces", false);
   m_volumeSamplingRate =
@@ -201,6 +202,7 @@ void Renderer::populateFrameData(FrameGPUData &fd) const
   fd.renderer.ambientIntensity = m_ambientIntensity;
   fd.renderer.occlusionDistance = m_occlusionDistance;
   fd.renderer.cullTriangleBF = m_cullTriangleBF;
+  fd.renderer.tonemap = m_tonemap;
   fd.renderer.inverseVolumeSamplingRate = 1.f / m_volumeSamplingRate;
   fd.renderer.numIterations = std::max(m_spp, 1);
   fd.renderer.maxRayDepth = m_maxRayDepth;
@@ -772,6 +774,11 @@ void Renderer::cleanup()
       m_backgroundImage->releaseCUDAArrayUint8();
     }
   }
+}
+
+bool Renderer::tonemap() const
+{
+  return m_tonemap;
 }
 
 } // namespace visrtx

--- a/devices/rtx/src/renderer/Renderer.h
+++ b/devices/rtx/src/renderer/Renderer.h
@@ -72,6 +72,7 @@ struct Renderer : public Object
   int spp() const;
   bool checkerboarding() const;
   bool denoise() const;
+  bool tonemap() const;
   int sampleLimit() const;
 
   static Renderer *createInstance(
@@ -86,6 +87,7 @@ struct Renderer : public Object
   float m_occlusionDistance{1e20f};
   bool m_checkerboard{false};
   bool m_denoise{false};
+  bool m_tonemap{true}; // enable internal tonemapping during sample accumulation
   int m_sampleLimit{0};
   bool m_cullTriangleBF{false};
   float m_volumeSamplingRate{1.f};

--- a/devices/rtx/src/renderer/Test_ptx.cu
+++ b/devices/rtx/src/renderer/Test_ptx.cu
@@ -57,7 +57,7 @@ VISRTX_GLOBAL void __raygen__()
     return;
   auto ray = makePrimaryRay(ss);
 
-  accumResults(frameData.fb,
+  accumResults(frameData,
       ss.pixel,
       vec4(ray.dir, 1.f),
       1.f,

--- a/devices/rtx/src/visrtx_device.json
+++ b/devices/rtx/src/visrtx_device.json
@@ -73,6 +73,13 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "tonemap",
+          "types": ["ANARI_BOOL"],
+          "tags": [],
+          "default": true,
+          "description": "enable internal tonemapping during sample accumulation"
+        },
+        {
           "name": "cullTriangleBackfaces",
           "types": ["ANARI_BOOL"],
           "tags": [],
@@ -158,6 +165,13 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "tonemap",
+          "types": ["ANARI_BOOL"],
+          "tags": [],
+          "default": true,
+          "description": "enable internal tonemapping during sample accumulation"
+        },
+        {
           "name": "cullTriangleBackfaces",
           "types": ["ANARI_BOOL"],
           "tags": [],
@@ -226,6 +240,13 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "tonemap",
+          "types": ["ANARI_BOOL"],
+          "tags": [],
+          "default": true,
+          "description": "enable internal tonemapping during sample accumulation"
+        },
+        {
           "name": "cullTriangleBackfaces",
           "types": ["ANARI_BOOL"],
           "tags": [],
@@ -259,6 +280,13 @@
           "tags": [],
           "default": false,
           "description": "enable triangle back face culling"
+        },
+        {
+          "name": "tonemap",
+          "types": ["ANARI_BOOL"],
+          "tags": [],
+          "default": true,
+          "description": "enable internal tonemapping during sample accumulation"
         },
         {
           "name": "volumeSamplingRate",


### PR DESCRIPTION
This PR adds a new renderer parameter (defaults to true), to possibly disable internal tonemapping.

Along with #160, this should fix #56 