### PR TITLE
TSD: Add support for camera objects

### DIFF
--- a/tsd/src/tsd/core/CMakeLists.txt
+++ b/tsd/src/tsd/core/CMakeLists.txt
@@ -21,6 +21,7 @@ PRIVATE
   scene/Scene.cpp
   scene/UpdateDelegate.cpp
   scene/objects/Array.cpp
+  scene/objects/Camera.cpp
   scene/objects/Geometry.cpp
   scene/objects/Light.cpp
   scene/objects/Material.cpp

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -19,7 +19,8 @@ std::string objectDBInfo(const ObjectDatabase &db)
   ss << "    samplers: " << db.sampler.size() << '\n';
   ss << "     volumes: " << db.volume.size() << '\n';
   ss << "      fields: " << db.field.size() << '\n';
-  ss << "      lights: " << db.light.size();
+  ss << "      lights: " << db.light.size() << '\n';
+  ss << "     cameras: " << db.camera.size();
   return ss.str();
 }
 
@@ -63,6 +64,7 @@ Scene::~Scene()
   reportObjectUsages(m_db.sampler);
   reportObjectUsages(m_db.field);
   reportObjectUsages(m_db.array);
+  reportObjectUsages(m_db.camera);
 }
 
 MaterialRef Scene::defaultMaterial() const
@@ -129,6 +131,9 @@ Object *Scene::getObject(ANARIDataType type, size_t i) const
   case ANARI_LIGHT:
     obj = m_db.light.at(i).data();
     break;
+  case ANARI_CAMERA:
+    obj = m_db.camera.at(i).data();
+    break;
   case ANARI_ARRAY:
   case ANARI_ARRAY1D:
   case ANARI_ARRAY2D:
@@ -167,6 +172,9 @@ size_t Scene::numberOfObjects(anari::DataType type) const
     break;
   case ANARI_LIGHT:
     numObjects = m_db.light.capacity();
+    break;
+  case ANARI_CAMERA:
+    numObjects = m_db.camera.capacity();
     break;
   case ANARI_ARRAY:
   case ANARI_ARRAY1D:
@@ -222,6 +230,9 @@ void Scene::removeObject(const Object *_o)
   case ANARI_LIGHT:
     m_db.light.erase(index);
     break;
+  case ANARI_CAMERA:
+    m_db.camera.erase(index);
+    break;
   case ANARI_ARRAY:
   case ANARI_ARRAY1D:
   case ANARI_ARRAY2D:
@@ -248,6 +259,7 @@ void Scene::removeAllObjects()
   m_db.volume.clear();
   m_db.field.clear();
   m_db.light.clear();
+  m_db.camera.clear();
 }
 
 BaseUpdateDelegate *Scene::updateDelegate() const
@@ -274,6 +286,7 @@ void Scene::setUpdateDelegate(BaseUpdateDelegate *ud)
   setDelegateOnObjects(m_db.sampler);
   setDelegateOnObjects(m_db.volume);
   setDelegateOnObjects(m_db.field);
+  setDelegateOnObjects(m_db.camera);
 }
 
 const ObjectDatabase &Scene::objectDB() const
@@ -579,6 +592,7 @@ void Scene::defragmentObjectStorage()
   defrag |= defragmentations[ANARI_VOLUME] = m_db.volume.defragment();
   defrag |= defragmentations[ANARI_SPATIAL_FIELD] = m_db.field.defragment();
   defrag |= defragmentations[ANARI_LIGHT] = m_db.light.defragment();
+  defrag |= defragmentations[ANARI_CAMERA] = m_db.camera.defragment();
 
   if (!defrag) {
     tsd::core::logStatus("No defragmentation needed");
@@ -615,6 +629,8 @@ void Scene::defragmentObjectStorage()
       return findIdx(m_db.field, idx);
     case ANARI_LIGHT:
       return findIdx(m_db.light, idx);
+    case ANARI_CAMERA:
+      return findIdx(m_db.camera, idx);
     case ANARI_ARRAY:
     case ANARI_ARRAY1D:
     case ANARI_ARRAY2D:

--- a/tsd/src/tsd/core/scene/Scene.hpp
+++ b/tsd/src/tsd/core/scene/Scene.hpp
@@ -6,6 +6,7 @@
 #include "tsd/core/scene/Animation.hpp"
 #include "tsd/core/scene/Layer.hpp"
 #include "tsd/core/scene/objects/Array.hpp"
+#include "tsd/core/scene/objects/Camera.hpp"
 #include "tsd/core/scene/objects/Geometry.hpp"
 #include "tsd/core/scene/objects/Light.hpp"
 #include "tsd/core/scene/objects/Material.hpp"
@@ -41,6 +42,7 @@ struct ObjectDatabase
   IndexedVector<Volume> volume;
   IndexedVector<SpatialField> field;
   IndexedVector<Light> light;
+  IndexedVector<Camera> camera;
 
   // Not copyable or moveable //
   ObjectDatabase() = default;
@@ -289,6 +291,12 @@ inline LightRef Scene::createObject(Token subtype)
   return createObjectImpl(m_db.light, subtype);
 }
 
+template <>
+inline CameraRef Scene::createObject(Token subtype)
+{
+  return createObjectImpl(m_db.camera, subtype);
+}
+
 template <typename T>
 inline IndexedVectorRef<T> Scene::getObject(size_t i) const
 {
@@ -337,6 +345,12 @@ template <>
 inline LightRef Scene::getObject(size_t i) const
 {
   return m_db.light.at(i);
+}
+
+template <>
+inline CameraRef Scene::getObject(size_t i) const
+{
+  return m_db.camera.at(i);
 }
 
 template <typename OBJ_T>

--- a/tsd/src/tsd/core/scene/objects/Camera.cpp
+++ b/tsd/src/tsd/core/scene/objects/Camera.cpp
@@ -1,0 +1,140 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/core/scene/objects/Camera.hpp"
+#include "tsd/core/scene/Scene.hpp"
+// std
+#include <string>
+#include <cmath>
+
+namespace tsd::core {
+
+Camera::Camera(Token subtype) : Object(ANARI_CAMERA, subtype)
+{
+  // Common parameters for all camera types (as per ANARI spec)
+  addParameter("position")
+      .setValue(float3(0.f, 0.f, 0.f))
+      .setDescription("position of the camera in world-space");
+
+  addParameter("direction")
+      .setValue(float3(0.f, 0.f, -1.f))
+      .setDescription("main viewing direction of the camera");
+
+  addParameter("up")
+      .setValue(float3(0.f, 1.f, 0.f))
+      .setDescription("up direction of the camera");
+
+  // Image region in normalized screen-space coordinates
+  // Using float4 for FLOAT32_BOX2 ((0, 0), (1, 1))
+  addParameter("imageRegion")
+      .setValue(float4(0.f, 0.f, 1.f, 1.f))
+      .setDescription("region of the sensor in normalized screen-space coordinates");
+
+  // Depth of field parameters (KHR_CAMERA_DEPTH_OF_FIELD extension)
+  addParameter("apertureRadius")
+      .setValue(0.f)
+      .setDescription("size of the aperture, controls the depth of field")
+      .setMin(0.f);
+
+  addParameter("focusDistance")
+      .setValue(1.f)
+      .setDescription("distance at where the image is sharpest when depth of field is enabled")
+      .setMin(0.001f);
+
+  // Stereo parameters (KHR_CAMERA_STEREO extension)
+  addParameter("stereoMode")
+      .setValue("none")
+      .setDescription("stereo mode: none, left, right, sideBySide, topBottom")
+      .setStringValues({"none", "left", "right", "sideBySide", "topBottom"});
+
+  addParameter("interpupillaryDistance")
+      .setValue(0.0635f)
+      .setDescription("distance between left and right eye when stereo is enabled")
+      .setMin(0.f);
+
+  // Shutter parameters (KHR_CAMERA_SHUTTER extension)
+  // Using float2 for FLOAT32_BOX1 [0.5, 0.5]
+  addParameter("shutter")
+      .setValue(float2(0.5f, 0.5f))
+      .setDescription("start and end of shutter time, clamped to [0, 1]");
+
+  // Rolling shutter parameters (KHR_CAMERA_ROLLING_SHUTTER extension)
+  addParameter("rollingShutterDirection")
+      .setValue("none")
+      .setDescription("rolling direction of the shutter: none, left, right, down, up")
+      .setStringValues({"none", "left", "right", "down", "up"});
+
+  addParameter("rollingShutterDuration")
+      .setValue(0.f)
+      .setDescription("the 'open' time per line, clamped to [0, shutter.upper-shutter.lower]")
+      .setMin(0.f);
+
+  // Camera subtype-specific parameters
+  if (subtype == tokens::camera::perspective) {
+    // KHR_CAMERA_PERSPECTIVE extension
+    addParameter("fovy")
+        .setValue(float(M_PI) / 3.0f)
+        .setDescription("the field of view (angle in radians) of the frame's height")
+        .setMin(0.001f)
+        .setMax(float(M_PI) - 0.001f);
+
+    addParameter("aspect")
+        .setValue(1.f)
+        .setDescription("ratio of width by height of the frame (and image region)");
+
+    addParameter("near")
+        .setDescription("near clip plane distance")
+        .setMin(0.f);
+
+    addParameter("far")
+        .setDescription("far clip plane distance")
+        .setMin(0.f);
+
+  } else if (subtype == tokens::camera::orthographic) {
+    // KHR_CAMERA_ORTHOGRAPHIC extension
+    addParameter("aspect")
+        .setValue(1.f)
+        .setDescription("ratio of width by height of the frame (and image region)");
+
+    addParameter("height")
+        .setValue(1.f)
+        .setDescription("height of the image plane in world units")
+        .setMin(0.001f);
+
+    addParameter("near")
+        .setDescription("near clip plane distance")
+        .setMin(0.f);
+
+    addParameter("far")
+        .setDescription("far clip plane distance")
+        .setMin(0.f);
+
+  } else if (subtype == tokens::camera::omnidirectional) {
+    // KHR_CAMERA_OMNIDIRECTIONAL extension
+    addParameter("layout")
+        .setValue("equirectangular")
+        .setDescription("pixel layout: equirectangular")
+        .setStringValues({"equirectangular"});
+  }
+}
+
+IndexedVectorRef<Camera> Camera::self() const
+{
+  return scene() ? scene()->getObject<Camera>(index())
+                 : IndexedVectorRef<Camera>{};
+}
+
+anari::Object Camera::makeANARIObject(anari::Device d) const
+{
+  return anari::newObject<anari::Camera>(d, subtype().c_str());
+}
+
+namespace tokens::camera {
+
+const Token perspective = "perspective";
+const Token orthographic = "orthographic";
+const Token omnidirectional = "omnidirectional";
+
+} // namespace tokens::camera
+
+} // namespace tsd::core

--- a/tsd/src/tsd/core/scene/objects/Camera.hpp
+++ b/tsd/src/tsd/core/scene/objects/Camera.hpp
@@ -1,0 +1,34 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tsd/core/scene/Object.hpp"
+
+namespace tsd::core {
+
+struct Camera : public Object
+{
+  static constexpr anari::DataType ANARI_TYPE = ANARI_CAMERA;
+
+  DECLARE_OBJECT_DEFAULT_LIFETIME(Camera);
+
+  Camera(Token subtype = tokens::unknown);
+  virtual ~Camera() = default;
+
+  IndexedVectorRef<Camera> self() const;
+
+  anari::Object makeANARIObject(anari::Device d) const override;
+};
+
+using CameraRef = IndexedVectorRef<Camera>;
+
+namespace tokens::camera {
+
+extern const Token perspective;
+extern const Token orthographic;
+extern const Token omnidirectional;
+
+} // namespace tokens::camera
+
+} // namespace tsd::core

--- a/tsd/src/tsd/io/serialization/serialization_datatree.cpp
+++ b/tsd/src/tsd/io/serialization/serialization_datatree.cpp
@@ -276,6 +276,9 @@ static void nodeToNewObject(Scene &scene, core::DataNode &node)
   case ANARI_LIGHT:
     obj = scene.createObject<Light>(subtype).data();
     break;
+  case ANARI_CAMERA:
+    obj = scene.createObject<Camera>(subtype).data();
+    break;
   default:
     break;
   }
@@ -410,6 +413,7 @@ void save_Scene(Scene &scene, core::DataNode &root)
   objectArrayToNode(objectDB, scene.m_db.field, "spatialfield");
   objectArrayToNode(objectDB, scene.m_db.volume, "volume");
   objectArrayToNode(objectDB, scene.m_db.light, "light");
+  objectArrayToNode(objectDB, scene.m_db.camera, "camera");
   objectArrayToNode(objectDB, scene.m_db.array, "array");
 }
 
@@ -456,6 +460,7 @@ void load_Scene(Scene &scene, core::DataNode &root)
   nodeToObjectArray(objectDB, scene, "spatialfield");
   nodeToObjectArray(objectDB, scene, "volume");
   nodeToObjectArray(objectDB, scene, "light");
+  nodeToObjectArray(objectDB, scene, "camera");
 
   // Layers
 

--- a/tsd/src/tsd/ui/imgui/windows/DatabaseEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/DatabaseEditor.cpp
@@ -44,6 +44,7 @@ void DatabaseEditor::buildUI()
 
   const auto &db = appCore()->tsd.scene.objectDB();
 
+  buildUI_objectSection(db.camera, "Cameras");
   buildUI_objectSection(db.light, "Lights");
   buildUI_objectSection(db.sampler, "Samplers");
   buildUI_objectSection(db.material, "Materials");

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -9,6 +9,8 @@
 // tsd_core
 #include "tsd/core/scene/Object.hpp"
 #include "tsd/core/scene/UpdateDelegate.hpp"
+#include "tsd/core/scene/objects/Camera.hpp"
+
 // tsd_rendering
 #include "tsd/rendering/index/RenderIndex.hpp"
 #include "tsd/rendering/pipeline/RenderPipeline.h"
@@ -39,6 +41,10 @@ struct Viewport : public Window
   void setExternalInstances(
       const anari::Instance *instances = nullptr, size_t count = 0);
 
+  void setDatabaseCamera(tsd::core::CameraRef cam);
+  void clearDatabaseCamera();
+  void createCameraFromCurrentView();
+
  private:
   void saveSettings(tsd::core::DataNode &thisWindowRoot) override;
   void loadSettings(tsd::core::DataNode &thisWindowRoot) override;
@@ -55,6 +61,8 @@ struct Viewport : public Window
   void updateFrame();
   void updateCamera(bool force = false);
   void updateImage();
+
+  void applyCameraParameters(tsd::core::Camera *cam);
 
   void echoCameraConfig();
   void ui_menubar();
@@ -130,6 +138,9 @@ struct Viewport : public Window
   tsd::rendering::UpdateToken m_cameraToken{0};
   float m_apertureRadius{0.f};
   float m_focusDistance{1.f};
+
+  // Database camera state
+  tsd::core::CameraRef m_selectedCamera;
 
   // display
 


### PR DESCRIPTION
Includes (de)serialization and UI.

A database camera can be created from current viewport view. No other UI ways are exposed for now.
A camera can be set active on the viewport, in which case its name displays green, and the camera cannot be manipulated in the viewport. It can still be edited in the database browser.

Serialization and deserialization are supported.
Only the main viewport has been updated/tested. Not sure about the behaviour of other (multidevice...) viewports.

<img width="1455" height="1051" alt="image" src="https://github.com/user-attachments/assets/8a1c31ae-49b2-4a86-871f-1ff6428dd67a" />
