### PR TITLE
TSD: Introduce CameraUpdateDelegate to track for database camera changes

### DIFF
--- a/tsd/src/tsd/core/scene/objects/Camera.hpp
+++ b/tsd/src/tsd/core/scene/objects/Camera.hpp
@@ -14,7 +14,7 @@ struct Camera : public Object
   DECLARE_OBJECT_DEFAULT_LIFETIME(Camera);
 
   Camera(Token subtype = tokens::unknown);
-  virtual ~Camera() = default;
+  virtual ~Camera() override = default;
 
   IndexedVectorRef<Camera> self() const;
 

--- a/tsd/src/tsd/rendering/CMakeLists.txt
+++ b/tsd/src/tsd/rendering/CMakeLists.txt
@@ -20,6 +20,7 @@ PRIVATE
   pipeline/passes/RenderPass.cpp
   pipeline/passes/VisualizeDepthPass.cpp
   pipeline/RenderPipeline.cpp
+  view/CameraUpdateDelegate.cpp
   view/ManipulatorToAnari.cpp
 )
 

--- a/tsd/src/tsd/rendering/view/CameraUpdateDelegate.cpp
+++ b/tsd/src/tsd/rendering/view/CameraUpdateDelegate.cpp
@@ -1,0 +1,52 @@
+// Copyright 2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CameraUpdateDelegate.hpp"
+
+// std
+#include <cassert>
+#include <utility>
+
+
+namespace tsd::core {
+
+CameraUpdateDelegate::CameraUpdateDelegate(Camera *camera)
+  : m_camera(camera) {
+  m_token = 1;
+  if (m_camera)
+    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(this);
+}
+
+CameraUpdateDelegate::~CameraUpdateDelegate() {
+  if (m_camera)
+    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(nullptr);
+}
+
+void CameraUpdateDelegate::signalParameterUpdated(const Object *o, const Parameter *p) {
+  m_token += (m_ignoreChangesScope == 0) ? 1 : 0;
+}
+
+bool CameraUpdateDelegate::hasChanged(UpdateToken &t) const {
+  if (t < m_token) {
+    t = m_token;
+    return true;
+  }
+  return false;
+}
+
+void CameraUpdateDelegate::detach() {
+  if (m_camera)
+    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(nullptr);
+  m_camera = nullptr;
+}
+
+void CameraUpdateDelegate::pushIgnoreChangeScope() {
+  m_ignoreChangesScope++;
+}
+
+void CameraUpdateDelegate::popIgnoreChangeScope() {
+  assert(m_ignoreChangesScope > 0 && "Mismatched popIgnoreChangeScope call");
+  m_ignoreChangesScope--;
+}
+
+} // namespace tsd::core

--- a/tsd/src/tsd/rendering/view/CameraUpdateDelegate.cpp
+++ b/tsd/src/tsd/rendering/view/CameraUpdateDelegate.cpp
@@ -14,12 +14,12 @@ CameraUpdateDelegate::CameraUpdateDelegate(Camera *camera)
   : m_camera(camera) {
   m_token = 1;
   if (m_camera)
-    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(this);
+    m_camera->setUpdateDelegate(this);
 }
 
 CameraUpdateDelegate::~CameraUpdateDelegate() {
   if (m_camera)
-    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(nullptr);
+    m_camera->setUpdateDelegate(nullptr);
 }
 
 void CameraUpdateDelegate::signalParameterUpdated(const Object *o, const Parameter *p) {
@@ -36,7 +36,7 @@ bool CameraUpdateDelegate::hasChanged(UpdateToken &t) const {
 
 void CameraUpdateDelegate::detach() {
   if (m_camera)
-    dynamic_cast<Object*>(m_camera)->setUpdateDelegate(nullptr);
+    m_camera->setUpdateDelegate(nullptr);
   m_camera = nullptr;
 }
 

--- a/tsd/src/tsd/rendering/view/CameraUpdateDelegate.hpp
+++ b/tsd/src/tsd/rendering/view/CameraUpdateDelegate.hpp
@@ -1,0 +1,50 @@
+// Copyright 2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tsd/core/scene/objects/Camera.hpp"
+#include <utility>
+#include <memory>
+
+namespace tsd::core {
+
+class CameraUpdateDelegate : public BaseUpdateDelegate {
+public:
+  using UpdateToken = size_t;
+  using DeletedCallback = std::function<void()>;
+
+  CameraUpdateDelegate(Camera *camera);
+  ~CameraUpdateDelegate();
+
+  void signalParameterUpdated(const Object *o, const Parameter *p) override;
+
+  // Empty overrides for all pure virtuals from BaseUpdateDelegate
+  void signalObjectAdded(const Object *o) override {}
+  void signalParameterRemoved(const Object *o, const Parameter *p) override {}
+  void signalArrayMapped(const Array *a) override {}
+  void signalArrayUnmapped(const Array *a) override {}
+  void signalObjectParameterUseCountZero(const Object *obj) override {}
+  void signalObjectLayerUseCountZero(const Object *obj) override {}
+  void signalObjectRemoved(const Object *o) override {};
+  void signalRemoveAllObjects() override {}
+  void signalLayerAdded(const Layer *l) override {}
+  void signalLayerUpdated(const Layer *l) override {}
+  void signalLayerRemoved(const Layer *l) override {}
+  void signalActiveLayersChanged() override {}
+  void signalObjectFilteringChanged() override {}
+  void signalInvalidateCachedObjects() override {}
+
+  bool hasChanged(UpdateToken &t) const;
+  void detach();
+
+  void pushIgnoreChangeScope();
+  void popIgnoreChangeScope();
+
+private:
+  Camera *m_camera = nullptr;
+  UpdateToken m_token = 1;
+  int m_ignoreChangesScope = 0;
+};
+
+} // namespace tsd::core

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -15,11 +15,15 @@
 #include "tsd/rendering/index/RenderIndex.hpp"
 #include "tsd/rendering/pipeline/RenderPipeline.h"
 #include "tsd/rendering/view/Manipulator.hpp"
+#include "tsd/rendering/view/CameraUpdateDelegate.hpp"
 // std
 #include <array>
 #include <functional>
 #include <future>
 #include <limits>
+#include <memory>
+#include <vector>
+#include <string>
 
 namespace tsd::ui::imgui {
 
@@ -139,8 +143,10 @@ struct Viewport : public Window
   float m_apertureRadius{0.f};
   float m_focusDistance{1.f};
 
+
   // Database camera state
   tsd::core::CameraRef m_selectedCamera;
+  std::unique_ptr<tsd::core::CameraUpdateDelegate> m_cameraDelegate;
 
   // display
 


### PR DESCRIPTION
Clean camera changes tracking so that:
- Rendering does not always dirty the ANARI object state (fixes the constant accumulation reset)
- Detect when the active database camera is being removed
- Correctly synchronize the axes overlay with the view
