### PR TITLE
Add VisRTX build to the CI

### DIFF
--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -7,7 +7,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux, windows]
-        config: [release]
+        cudaversion: ['12.4.1', '13.0.2']
+        config: [release, debug]
         include:
           - runs-on: ubuntu-22.04
             os: linux
@@ -22,7 +23,7 @@ jobs:
       - name: Setup CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.29
         with:
-          cuda: '12.4.1'
+          cuda: ${{ matrix.cudaversion }}
           method: 'network'
           sub-packages: ${{ matrix.os == 'linux' && '["nvcc", "cudart", "nvml-dev", "thrust"]' || '[]' }}
           non-cuda-sub-packages: ${{ matrix.os == 'linux' && '["libcurand", "libcurand-dev"]' || '[]' }}
@@ -51,5 +52,5 @@ jobs:
       - name: Archive build artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: visrtx-build-${{ matrix.runs-on }}
+          name: visrtx-build-${{ matrix.runs-on }}-${{ matrix.cudaversion }}-${{ matrix.config }}
           path: install

--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -48,7 +48,7 @@ jobs:
           -DVISRTX_BUILD_TSD=OFF
       - name: Install VisRTX
         run: >
-          cmake --build ${{ github.workspace }}/build-visrtx --config ${{ matrix.config }} --target install
+          cmake --build ${{ github.workspace }}/build-visrtx --config ${{ matrix.config }} --target install --parallel
       - name: Configure TSD CMake
         run: >
           cmake -LA -B ${{github.workspace}}/build-tsd
@@ -66,7 +66,7 @@ jobs:
           -DTSD_ENABLE_SERIALIZATION=OFF
           ${{ github.workspace }}/tsd
       - name: Build TSD
-        run: cmake --build ${{ github.workspace }}/build-tsd --config ${{ matrix.config }}
+        run: cmake --build ${{ github.workspace }}/build-tsd --config ${{ matrix.config }} --parallel
       - name: Archive build artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -1,18 +1,55 @@
 name: Build VisRTX
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - "pull-request/[0-9]+"
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [linux, windows]
-    runs-on: ${{ matrix.os }}-amd64-cpu4
+        config: [release]
+        include:
+          - runs-on: ubuntu-22.04
+            os: linux
+            generator: Ninja
+          - runs-on: windows-2022
+            os: windows
+            generator: Visual Studio 17 2022
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Dump runner info
-        run: |          
-          which nvcc
+        uses: actions/checkout@v5
+      - name: Setup CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.29
+        with:
+          cuda: '12.4.1'
+          method: 'network'
+          sub-packages: ${{ matrix.os == 'linux' && '["nvcc", "cudart", "nvml-dev", "thrust"]' || '[]' }}
+          non-cuda-sub-packages: ${{ matrix.os == 'linux' && '["libcurand", "libcurand-dev"]' || '[]' }}
+      - name: Configure dependencies
+        run: >
+          cmake -LA -G "${{ matrix.generator }}" -B ${{github.workspace}}/deps_build
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/deps
+          ${{github.workspace}}/devices/rtx/cmake/build_deps
+      - name: Install dependencies
+        run: >
+          cmake --build ${{ github.workspace }}/deps_build --config ${{ matrix.config }}
+      - name: Configure VisRTX
+        run: >
+          cmake -LA -G "${{ matrix.generator }}" -B ${{github.workspace}}/build
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
+          -DVISRTX_BUILD_RTX_DEVICE=ON
+          -DVISRTX_PRECOMPILE_SHADERS=OFF
+          -DVISRTX_BUILD_GL_DEVICE=OFF
+          -DVISRTX_BUILD_TSD=OFF
+      - name: Install VisRTX
+        run: >
+          cmake --build build --config ${{ matrix.config }} --target install
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: visrtx-build-${{ matrix.runs-on }}
+          path: install

--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -38,7 +38,7 @@ jobs:
           cmake --build ${{ github.workspace }}/deps_build --config ${{ matrix.config }}
       - name: Configure VisRTX
         run: >
-          cmake -LA -G "${{ matrix.generator }}" -B ${{github.workspace}}/build
+          cmake -LA -G "${{ matrix.generator }}" -B ${{github.workspace}}/build-visrtx
           -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
           -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
@@ -48,7 +48,25 @@ jobs:
           -DVISRTX_BUILD_TSD=OFF
       - name: Install VisRTX
         run: >
-          cmake --build build --config ${{ matrix.config }} --target install
+          cmake --build ${{ github.workspace }}/build-visrtx --config ${{ matrix.config }} --target install
+      - name: Configure TSD CMake
+        run: >
+          cmake -LA -B ${{github.workspace}}/build-tsd
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          -DTSD_BUILD_APPS=ON
+          -DTSD_BUILD_INTERACTIVE_APPS=OFF
+          -DTSD_BUILD_UI_LIBRARY=OFF
+          -DTSD_USE_ASSIMP=OFF
+          -DTSD_USE_CUDA=ON
+          -DTSD_USE_HDF5=OFF
+          -DTSD_USE_SDL3=OFF
+          -DTSD_USE_TBB=OFF
+          -DTSD_USE_USD=OFF
+          -DTSD_ENABLE_SERIALIZATION=OFF
+          ${{ github.workspace }}/tsd
+      - name: Build TSD
+        run: cmake --build ${{ github.workspace }}/build-tsd --config ${{ matrix.config }}
       - name: Archive build artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/devices/rtx/cmake/build_deps/CMakeLists.txt
+++ b/devices/rtx/cmake/build_deps/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.12)
+
+if(NOT CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX
+      "${CMAKE_BINARY_DIR}/install"
+      CACHE STRING "Final install location." FORCE)
+endif()
+
+project(tsd_dependencies)
+
+include(superbuild_macros.cmake)
+
+## Build projects ##
+
+build_subproject(
+  NAME anari-sdk
+  URL "https://github.com/KhronosGroup/ANARI-SDK/archive/refs/heads/next_release.zip"
+  BUILD_ARGS
+    -DBUILD_EXAMPLES=OFF
+    -DBUILD_HDANARI=OFF
+    -DBUILD_HELIDE_DEVICE=OFF
+    -DBUILD_REMOTE_DEVICE=OFF
+    -DBUILD_TESTING=OFF
+)

--- a/devices/rtx/cmake/build_deps/superbuild_macros.cmake
+++ b/devices/rtx/cmake/build_deps/superbuild_macros.cmake
@@ -1,0 +1,110 @@
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+## Included CMake modules ##
+
+include(ExternalProject)
+include(GNUInstallDirs)
+include(ProcessorCount)
+
+## Variables ##
+
+ProcessorCount(PROCESSOR_COUNT)
+set(NUM_BUILD_JOBS ${PROCESSOR_COUNT} CACHE STRING "Number of build jobs '-j <n>'")
+set(DEFAULT_BUILD_COMMAND cmake --build . --config release -j ${NUM_BUILD_JOBS})
+get_filename_component(INSTALL_DIR_ABSOLUTE
+  ${CMAKE_INSTALL_PREFIX} ABSOLUTE BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+## Functions/macros ##
+
+function(print)
+  foreach(arg ${ARGN})
+    message("${arg} = ${${arg}}")
+  endforeach()
+endfunction()
+
+macro(append_cmake_prefix_path)
+  list(APPEND CMAKE_PREFIX_PATH ${ARGN})
+  string(REPLACE ";" "|" CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+endmacro()
+
+macro(setup_subproject_path_vars _NAME)
+  set(SUBPROJECT_NAME ${_NAME})
+
+  set(SUBPROJECT_INSTALL_PATH ${INSTALL_DIR_ABSOLUTE})
+
+  set(SUBPROJECT_SOURCE_PATH ${SUBPROJECT_NAME}/source)
+  set(SUBPROJECT_STAMP_PATH ${SUBPROJECT_NAME}/stamp)
+  set(SUBPROJECT_BUILD_PATH ${SUBPROJECT_NAME}/build)
+endmacro()
+
+macro(build_subproject)
+  # See cmake_parse_arguments docs to see how args get parsed here:
+  #    https://cmake.org/cmake/help/latest/command/cmake_parse_arguments.html
+  set(oneValueArgs NAME URL)
+  set(multiValueArgs BUILD_ARGS DEPENDS_ON)
+  cmake_parse_arguments(BUILD_SUBPROJECT "" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
+
+  # Setup SUBPROJECT_* variables (containing paths) for this function
+  setup_subproject_path_vars(${BUILD_SUBPROJECT_NAME})
+
+  # Build the actual subproject
+  ExternalProject_Add(${SUBPROJECT_NAME}
+    PREFIX ${SUBPROJECT_NAME}
+    DOWNLOAD_DIR ${SUBPROJECT_NAME}
+    STAMP_DIR ${SUBPROJECT_STAMP_PATH}
+    SOURCE_DIR ${SUBPROJECT_SOURCE_PATH}
+    BINARY_DIR ${SUBPROJECT_BUILD_PATH}
+    URL ${BUILD_SUBPROJECT_URL}
+    LIST_SEPARATOR | # Use the alternate list separator
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_INSTALL_PREFIX:PATH=${SUBPROJECT_INSTALL_PATH}
+      -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+      -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+      -DCMAKE_INSTALL_DOCDIR=${CMAKE_INSTALL_DOCDIR}
+      -DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}
+      -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+      ${BUILD_SUBPROJECT_BUILD_ARGS}
+    BUILD_COMMAND ${DEFAULT_BUILD_COMMAND}
+    BUILD_ALWAYS OFF
+  )
+
+  if(BUILD_SUBPROJECT_DEPENDS_ON)
+    ExternalProject_Add_StepDependencies(${SUBPROJECT_NAME}
+      configure ${BUILD_SUBPROJECT_DEPENDS_ON}
+    )
+  endif()
+
+  # Place installed component on CMAKE_PREFIX_PATH for downstream consumption
+  append_cmake_prefix_path(${SUBPROJECT_INSTALL_PATH})
+endmacro()


### PR DESCRIPTION
No PR blocking for now.

Testing with CUDA 12.4 as it seems it is the base version to use with Visual Studio 19 provided by Github runners.
The CUDA toolkit is deployed using Jimver/cudatoolkit action.
Build results are attached to the workflow artifacts, meaning that we should be able to direct download and use the already built VisRTX device.

CURAND static linking as been reverted as curand_static does note exist on Windows.