### PR TITLE
Save our NVDB loader from duplicating the dataset on load

### DIFF
--- a/devices/rtx/device/spatial_field/NvdbRegularField.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularField.h
@@ -31,8 +31,9 @@
 
 #pragma once
 
-#include "array/Array1D.h"
 #include "spatial_field/SpatialField.h"
+
+#include "array/Array1D.h"
 #include "utility/DeviceBuffer.h"
 
 #include <nanovdb/NanoVDB.h>


### PR DESCRIPTION
This was implied by the use of GridHandle, but we don't need that just for the sake of querying the grid metadata.