### PR TITLE
Add Transform manipulators/Gizmos to TSD main viewport

### DIFF
--- a/tsd/external/CMakeLists.txt
+++ b/tsd/external/CMakeLists.txt
@@ -4,7 +4,6 @@
 add_subdirectory(tsd_agx)
 add_subdirectory(tsd_catch)
 add_subdirectory(tsd_flip)
-add_subdirectory(tsd_imguizmo)
 add_subdirectory(tsd_imnodes)
 add_subdirectory(tsd_mikktspace)
 add_subdirectory(tsd_nanovdb)
@@ -12,6 +11,10 @@ add_subdirectory(tsd_tinyexr)
 add_subdirectory(tsd_tinygltf)
 add_subdirectory(tsd_tinyobjloader)
 add_subdirectory(tsd_tinyply)
+
+if(TSD_BUILD_UI_LIBRARY)
+  add_subdirectory(tsd_imguizmo)
+endif()
 
 if (NOT TARGET fmt::fmt)
   add_subdirectory(

--- a/tsd/external/CMakeLists.txt
+++ b/tsd/external/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_subdirectory(tsd_agx)
 add_subdirectory(tsd_catch)
 add_subdirectory(tsd_flip)
+add_subdirectory(tsd_imguizmo)
 add_subdirectory(tsd_imnodes)
 add_subdirectory(tsd_mikktspace)
 add_subdirectory(tsd_nanovdb)

--- a/tsd/external/tsd_imguizmo/CMakeLists.txt
+++ b/tsd/external/tsd_imguizmo/CMakeLists.txt
@@ -1,0 +1,28 @@
+## Copyright 2025 NVIDIA Corporation
+## SPDX-License-Identifier: Apache-2.0
+
+project(tsd_ext_imguizmo LANGUAGES CXX)
+
+anari_sdk_fetch_project(
+  NAME ${PROJECT_NAME}
+  URL https://github.com/CedricGuillemet/ImGuizmo/archive/71f14292205c3317122b39627ed98efce137086a.zip
+  MD5 16e691b39d4baec349d769768e77d0e9
+)
+
+project_add_library(STATIC)
+
+project_sources(
+PRIVATE
+  ${tsd_ext_imguizmo_LOCATION}/ImGuizmo.cpp
+)
+
+project_include_directories(
+PUBLIC
+  $<BUILD_INTERFACE:${tsd_ext_imguizmo_LOCATION}>
+)
+
+project_link_libraries(
+PRIVATE
+  anari::helium
+  anari::anari_viewer
+)

--- a/tsd/src/tsd/ui/imgui/CMakeLists.txt
+++ b/tsd/src/tsd/ui/imgui/CMakeLists.txt
@@ -34,6 +34,7 @@ PUBLIC
   tsd_core
   tsd_io
   tsd_rendering
+  tsd_ext_imguizmo
   tsd_ext_tinyexr
   stb_image
 PRIVATE

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -79,17 +79,12 @@ void Viewport::buildUI()
 
   ImGui::EndDisabled();
 
-  // Render transform manipulators
   ui_gizmo();
-
-  // Block arcball input and picking when ImGuizmo is being used
-  if (ImGuizmo::IsUsing())
-    return;
-
-  bool didPick = ui_picking();
 
   ui_handleInput();
   ui_menubar();
+
+  bool didPick = ui_picking();
 
   if (m_anariPass && !didPick)
     m_anariPass->setEnableIDs(appCore()->objectIsSelected());
@@ -1212,7 +1207,7 @@ void Viewport::ui_handleInput()
   // window focus so they can act globally.
   // When a new manipulator mode is selected, we default to world mode.
   // Otherwise, toggle between local and global modes.
-  if (ImGui::IsKeyPressed(ImGuiKey_Q, false)) {
+  if (ImGui::IsKeyPressed(ImGuiKey_Q, false) || ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
     m_enableGizmo = false;
   } else if (ImGui::IsKeyPressed(ImGuiKey_W, false)) {
     if (m_enableGizmo && m_gizmoOperation == ImGuizmo::TRANSLATE) {
@@ -1239,6 +1234,14 @@ void Viewport::ui_handleInput()
       m_gizmoMode = ImGuizmo::WORLD;
     }
   }
+
+  // Enforce global Gizmo state so that it actually stops tracking
+  // interactions when disabled.
+  ImGuizmo::Enable(m_enableGizmo);
+
+  // Block arcball input and picking when ImGuizmo is being used
+  if (ImGuizmo::IsUsing())
+    return;
 
   // Do not bother with events if the window is not hovered
   // or no interaction is ongoing.

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -3,6 +3,7 @@
 
 #include "Viewport.h"
 // tsd_ui_imgui
+#include "imgui.h"
 #include "tsd/ui/imgui/Application.h"
 #include "tsd/ui/imgui/tsd_ui_imgui.h"
 // tsd_core
@@ -77,16 +78,6 @@ void Viewport::buildUI()
     ui_overlay();
 
   ImGui::EndDisabled();
-
-  // Make is so that middle and right-clicks get the window focused.
-  // This enables middle/right-click-drag to work right away even if the window
-  // is not focused same as left-click-drag works without requiring a prior
-  // left-click-focus.
-  if (ImGui::IsWindowHovered()
-      && (ImGui::IsMouseDown(ImGuiMouseButton_Right)
-          || ImGui::IsMouseDown(ImGuiMouseButton_Middle))) {
-    ImGui::SetWindowFocus();
-  }
 
   // Render transform manipulators
   ui_gizmo();
@@ -1213,7 +1204,15 @@ void Viewport::ui_menubar()
 
 void Viewport::ui_handleInput()
 {
-  if (!m_deviceReadyToUse || !ImGui::IsWindowFocused())
+  // No device
+  if (!m_deviceReadyToUse)
+    return;
+
+  // Do not bother with events if the window is not hovered
+  // or no interation is ongoing.
+  // We'll use that hovering status to check for starting an
+  // event below.
+  if (!ImGui::IsWindowHovered() && !m_manipulating)
     return;
 
   // Block arcball input when a database camera is selected
@@ -1231,12 +1230,13 @@ void Viewport::ui_handleInput()
   const bool orbit = ImGui::IsMouseDown(ImGuiMouseButton_Left);
 
   const bool anyMovement = dolly || pan || orbit;
-
   if (!anyMovement) {
     m_manipulating = false;
     m_previousMouse = tsd::math::float2(-1);
-  } else if (ImGui::IsItemHovered() && !m_manipulating)
+  } else if (ImGui::IsItemHovered() && !m_manipulating) {
     m_manipulating = true;
+    ImGui::SetWindowFocus(); // ensure we keep focus while manipulating
+  }
 
   if (m_mouseRotating && !orbit)
     m_mouseRotating = false;

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -1041,8 +1041,8 @@ void Viewport::ui_menubar()
 
     // Gizmo //
 
-    if (ImGui::BeginMenu("Gizmo")) {
-      ImGui::Checkbox("Enable Gizmo", &m_enableGizmo);
+    if (ImGui::BeginMenu("Transform Manipulator")) {
+      ImGui::Checkbox("Enable Manipulator", &m_enableGizmo);
 
       ImGui::Separator();
       ImGui::Text("Operation:");

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -1208,6 +1208,39 @@ void Viewport::ui_handleInput()
   if (!m_deviceReadyToUse)
     return;
 
+  // Handle gizmo keyboard shortcuts. Handle those before checking for
+  // window focus so they can act globally.
+  // When a new manipulator mode is selected, we default to world mode.
+  // Otherwise, toggle between local and global modes.
+  if (ImGui::IsKeyPressed(ImGuiKey_Q, false)) {
+    m_enableGizmo = false;
+  } else if (ImGui::IsKeyPressed(ImGuiKey_W, false)) {
+    if (m_enableGizmo && m_gizmoOperation == ImGuizmo::TRANSLATE) {
+      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+    } else {
+      m_enableGizmo = true;
+      m_gizmoOperation = ImGuizmo::TRANSLATE;
+      m_gizmoMode = ImGuizmo::WORLD;
+    }
+  } else if (ImGui::IsKeyPressed(ImGuiKey_E, false)) {
+    if (m_enableGizmo && m_gizmoOperation == ImGuizmo::SCALE) {
+      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+    } else {
+      m_enableGizmo = true;
+      m_gizmoOperation = ImGuizmo::SCALE;
+      m_gizmoMode = ImGuizmo::WORLD;
+    }
+  } else if (ImGui::IsKeyPressed(ImGuiKey_R, false)) {
+    if (m_enableGizmo && m_gizmoOperation == ImGuizmo::ROTATE) {
+      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+    } else {
+      m_enableGizmo = true;
+      m_gizmoOperation = ImGuizmo::ROTATE;
+      m_gizmoMode = ImGuizmo::WORLD;
+    }
+  }
+
+
   // Do not bother with events if the window is not hovered
   // or no interation is ongoing.
   // We'll use that hovering status to check for starting an

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -1042,7 +1042,8 @@ void Viewport::ui_menubar()
       ImGui::Separator();
       ImGui::Text("Operation:");
       ImGui::Indent(INDENT_AMOUNT);
-      if (ImGui::RadioButton("Translate", m_gizmoOperation == ImGuizmo::TRANSLATE))
+      if (ImGui::RadioButton(
+              "Translate", m_gizmoOperation == ImGuizmo::TRANSLATE))
         m_gizmoOperation = ImGuizmo::TRANSLATE;
       if (ImGui::RadioButton("Rotate", m_gizmoOperation == ImGuizmo::ROTATE))
         m_gizmoOperation = ImGuizmo::ROTATE;
@@ -1207,11 +1208,13 @@ void Viewport::ui_handleInput()
   // window focus so they can act globally.
   // When a new manipulator mode is selected, we default to world mode.
   // Otherwise, toggle between local and global modes.
-  if (ImGui::IsKeyPressed(ImGuiKey_Q, false) || ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
+  if (ImGui::IsKeyPressed(ImGuiKey_Q, false)
+      || ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
     m_enableGizmo = false;
   } else if (ImGui::IsKeyPressed(ImGuiKey_W, false)) {
     if (m_enableGizmo && m_gizmoOperation == ImGuizmo::TRANSLATE) {
-      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+      m_gizmoMode =
+          (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
     } else {
       m_enableGizmo = true;
       m_gizmoOperation = ImGuizmo::TRANSLATE;
@@ -1219,7 +1222,8 @@ void Viewport::ui_handleInput()
     }
   } else if (ImGui::IsKeyPressed(ImGuiKey_E, false)) {
     if (m_enableGizmo && m_gizmoOperation == ImGuizmo::SCALE) {
-      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+      m_gizmoMode =
+          (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
     } else {
       m_enableGizmo = true;
       m_gizmoOperation = ImGuizmo::SCALE;
@@ -1227,7 +1231,8 @@ void Viewport::ui_handleInput()
     }
   } else if (ImGui::IsKeyPressed(ImGuiKey_R, false)) {
     if (m_enableGizmo && m_gizmoOperation == ImGuizmo::ROTATE) {
-      m_gizmoMode = (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
+      m_gizmoMode =
+          (m_gizmoMode == ImGuizmo::WORLD) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
     } else {
       m_enableGizmo = true;
       m_gizmoOperation = ImGuizmo::ROTATE;
@@ -1459,7 +1464,8 @@ void Viewport::ui_gizmo()
   if (m_currentCamera == m_orthoCamera) {
     const float height = m_arcball->distance();
     const float width = height * aspect;
-    proj = linalg::frustum_matrix(-width, width, -height, height, 0.1f, 1000.0f);
+    proj =
+        linalg::frustum_matrix(-width, width, -height, height, 0.1f, 1000.0f);
   } else {
     proj = linalg::perspective_matrix(fovRadians, aspect, 0.1f, 1000.0f);
   }
@@ -1471,7 +1477,6 @@ void Viewport::ui_gizmo()
           m_gizmoOperation,
           m_gizmoMode,
           &transform[0].x)) {
-
     selectedNode->setAsTransform(transform);
     appCore()->tsd.scene.signalLayerChange(selectedNode.container());
   }

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -1240,9 +1240,8 @@ void Viewport::ui_handleInput()
     }
   }
 
-
   // Do not bother with events if the window is not hovered
-  // or no interation is ongoing.
+  // or no interaction is ongoing.
   // We'll use that hovering status to check for starting an
   // event below.
   if (!ImGui::IsWindowHovered() && !m_manipulating)
@@ -1435,13 +1434,12 @@ void Viewport::ui_gizmo()
   ImGuizmo::SetOrthographic(m_currentCamera == m_orthoCamera);
   ImGuizmo::BeginFrame();
 
-  // Setup Imguizmo with window and relative viewport information
+  // Setup ImGuizmo with window and relative viewport information
   ImVec2 viewportPos = ImGui::GetCursorScreenPos();
   ImVec2 viewportSize = ImGui::GetContentRegionAvail();
   ImVec2 imageMin = ImGui::GetItemRectMin();
   ImVec2 imageMax = ImGui::GetItemRectMax();
   ImVec2 imageSize(imageMax.x - imageMin.x, imageMax.y - imageMin.y);
-  
   ImGuizmo::SetRect(imageMin.x, imageMin.y, imageSize.x, imageSize.y);
 
   // Build view matrix and projection matrices from manipulator

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -88,6 +88,13 @@ void Viewport::buildUI()
     ImGui::SetWindowFocus();
   }
 
+  // Render transform manipulators
+  ui_gizmo();
+
+  // Block arcball input and picking when ImGuizmo is being used
+  if (ImGuizmo::IsUsing())
+    return;
+
   bool didPick = ui_picking();
 
   ui_handleInput();
@@ -267,6 +274,12 @@ void Viewport::saveSettings(tsd::core::DataNode &root)
   root["resolutionScale"] = m_resolutionScale;
   root["showAxes"] = m_showAxes;
 
+  // Gizmo settings //
+
+  root["enableGizmo"] = m_enableGizmo;
+  root["gizmoOperation"] = static_cast<int>(m_gizmoOperation);
+  root["gizmoMode"] = static_cast<int>(m_gizmoMode);
+
   root["anariLibrary"] = m_libName;
 
   // Camera //
@@ -312,6 +325,16 @@ void Viewport::loadSettings(tsd::core::DataNode &root)
   root["fov"].getValue(ANARI_FLOAT32, &m_fov);
   root["resolutionScale"].getValue(ANARI_FLOAT32, &m_resolutionScale);
   root["showAxes"].getValue(ANARI_BOOL, &m_showAxes);
+
+  // Gizmo settings //
+
+  root["enableGizmo"].getValue(ANARI_BOOL, &m_enableGizmo);
+  int gizmoOp = static_cast<int>(m_gizmoOperation);
+  root["gizmoOperation"].getValue(ANARI_INT32, &gizmoOp);
+  m_gizmoOperation = static_cast<ImGuizmo::OPERATION>(gizmoOp);
+  int gizmoMode = static_cast<int>(m_gizmoMode);
+  root["gizmoMode"].getValue(ANARI_INT32, &gizmoMode);
+  m_gizmoMode = static_cast<ImGuizmo::MODE>(gizmoMode);
 
   // Camera //
 
@@ -1025,6 +1048,34 @@ void Viewport::ui_menubar()
       ImGui::EndMenu();
     }
 
+    // Gizmo //
+
+    if (ImGui::BeginMenu("Gizmo")) {
+      ImGui::Checkbox("Enable Gizmo", &m_enableGizmo);
+
+      ImGui::Separator();
+      ImGui::Text("Operation:");
+      ImGui::Indent(INDENT_AMOUNT);
+      if (ImGui::RadioButton("Translate", m_gizmoOperation == ImGuizmo::TRANSLATE))
+        m_gizmoOperation = ImGuizmo::TRANSLATE;
+      if (ImGui::RadioButton("Rotate", m_gizmoOperation == ImGuizmo::ROTATE))
+        m_gizmoOperation = ImGuizmo::ROTATE;
+      if (ImGui::RadioButton("Scale", m_gizmoOperation == ImGuizmo::SCALE))
+        m_gizmoOperation = ImGuizmo::SCALE;
+      ImGui::Unindent(INDENT_AMOUNT);
+
+      ImGui::Separator();
+      ImGui::Text("Mode:");
+      ImGui::Indent(INDENT_AMOUNT);
+      if (ImGui::RadioButton("Local", m_gizmoMode == ImGuizmo::LOCAL))
+        m_gizmoMode = ImGuizmo::LOCAL;
+      if (ImGui::RadioButton("World", m_gizmoMode == ImGuizmo::WORLD))
+        m_gizmoMode = ImGuizmo::WORLD;
+      ImGui::Unindent(INDENT_AMOUNT);
+
+      ImGui::EndMenu();
+    }
+
     // Viewport //
 
     if (ImGui::BeginMenu("Viewport")) {
@@ -1323,6 +1374,72 @@ void Viewport::ui_overlay()
     }
 
     ImGui::End();
+  }
+}
+
+bool Viewport::canShowGizmo() const
+{
+  if (!m_enableGizmo || !m_deviceReadyToUse)
+    return false;
+
+  // Check if we have a selected node with a transform
+  if (appCore()->tsd.selectedNode) {
+    auto &node = *appCore()->tsd.selectedNode;
+    return node->isTransform();
+  }
+
+  return false;
+}
+
+void Viewport::ui_gizmo()
+{
+  if (!canShowGizmo())
+    return;
+
+  auto &selectedNode = *appCore()->tsd.selectedNode;
+  auto transform = selectedNode->getTransform();
+
+  ImGuizmo::SetOrthographic(m_currentCamera == m_orthoCamera);
+  ImGuizmo::BeginFrame();
+
+  // Setup Imguizmo with window and relative viewport information
+  ImVec2 viewportPos = ImGui::GetCursorScreenPos();
+  ImVec2 viewportSize = ImGui::GetContentRegionAvail();
+  ImVec2 imageMin = ImGui::GetItemRectMin();
+  ImVec2 imageMax = ImGui::GetItemRectMax();
+  ImVec2 imageSize(imageMax.x - imageMin.x, imageMax.y - imageMin.y);
+  
+  ImGuizmo::SetRect(imageMin.x, imageMin.y, imageSize.x, imageSize.y);
+
+  // Build view matrix and projection matrices from manipulator
+  // Not sure if we can get those more directly...
+  const auto eye = m_arcball->eye();
+  const auto at = m_arcball->at();
+  const auto up = m_arcball->up();
+  const auto view = linalg::lookat_matrix(eye, at, up);
+
+  const float aspect = m_viewportSize.x / float(m_viewportSize.y);
+  const float fovRadians = tsd::math::radians(m_fov);
+  tsd::math::mat4 proj;
+
+  if (m_currentCamera == m_orthoCamera) {
+    const float height = m_arcball->distance();
+    const float width = height * aspect;
+    proj = linalg::frustum_matrix(-width, width, -height, height, 0.1f, 1000.0f);
+  } else {
+    proj = linalg::perspective_matrix(fovRadians, aspect, 0.1f, 1000.0f);
+  }
+
+  // Draw and manipulate the gizmo
+  ImGuizmo::SetDrawlist();
+  if (ImGuizmo::Manipulate(&view[0].x,
+          &proj[0].x,
+          m_gizmoOperation,
+          m_gizmoMode,
+          &transform[0].x)) {
+
+    selectedNode->setAsTransform(transform);
+    appCore()->tsd.scene.signalLayerChange(selectedNode.container());
   }
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -6,6 +6,7 @@
 #include "Window.h"
 
 #include "tsd/ui/imgui/tsd_ui_imgui.h"
+
 // tsd_core
 #include "tsd/core/scene/Object.hpp"
 #include "tsd/core/scene/UpdateDelegate.hpp"
@@ -16,6 +17,10 @@
 #include "tsd/rendering/pipeline/RenderPipeline.h"
 #include "tsd/rendering/view/Manipulator.hpp"
 #include "tsd/rendering/view/CameraUpdateDelegate.hpp"
+
+// ImGuizmo
+#include <ImGuizmo.h>
+
 // std
 #include <array>
 #include <functional>
@@ -73,6 +78,8 @@ struct Viewport : public Window
   void ui_handleInput();
   bool ui_picking();
   void ui_overlay();
+  void ui_gizmo();
+  bool canShowGizmo() const;
 
   int windowFlags() const override; // anari_viewer::Window
 
@@ -102,6 +109,12 @@ struct Viewport : public Window
   float m_depthVisualMaximum{1.f};
 
   float m_fov{40.f};
+
+  // Gizmo state //
+
+  bool m_enableGizmo{true};
+  ImGuizmo::OPERATION m_gizmoOperation{ImGuizmo::TRANSLATE};
+  ImGuizmo::MODE m_gizmoMode{ImGuizmo::WORLD};
 
   // Picking state //
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -112,7 +112,7 @@ struct Viewport : public Window
 
   // Gizmo state //
 
-  bool m_enableGizmo{true};
+  bool m_enableGizmo{false};
   ImGuizmo::OPERATION m_gizmoOperation{ImGuizmo::TRANSLATE};
   ImGuizmo::MODE m_gizmoMode{ImGuizmo::WORLD};
 


### PR DESCRIPTION
Based on ImGuizmo.

Shortcuts are following Kit's defaults q (disable) w (translate) e (scale) r (rotate)
Hitting the same multiple times switches between local and global transformation mode.