### PR TITLE
Workaround outline not being rendered on double-click-to-select

### DIFF
--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -80,11 +80,10 @@ void Viewport::buildUI()
   ImGui::EndDisabled();
 
   ui_gizmo();
-
   ui_handleInput();
+  bool didPick = ui_picking(); // Needs to happen before ui_menubar
   ui_menubar();
 
-  bool didPick = ui_picking();
 
   if (m_anariPass && !didPick)
     m_anariPass->setEnableIDs(appCore()->objectIsSelected());


### PR DESCRIPTION
Not exactly sure what's at play here. If `ui_menubar` happens before ui_picking, we end up getting a ~0 picked id instead of the expected object id in the render passes.
To be investigated further, but for now, this should be enough to get the feature back.