### PR TITLE
Export nvdb and tf updates

### DIFF
--- a/devices/rtx/device/gpu/gpu_math.h
+++ b/devices/rtx/device/gpu/gpu_math.h
@@ -143,11 +143,10 @@ struct SurfaceHit
 
 struct VolumeHit
 {
-  Ray localRay;
   const VolumeGPUData *volume{nullptr};
   const InstanceVolumeGPUData *instance{nullptr};
-  uint32_t lastVolID{~0u};
-  uint32_t lastInstID{~0u};
+  Ray localRay;
+
   bool foundHit;
 };
 

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -415,7 +415,7 @@ struct StructuredRegularData
 {
   cudaTextureObject_t texObj;
   vec3 origin;
-  vec3 spacing;
+  vec3 invDims;
   vec3 invSpacing;
 };
 

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -391,9 +391,6 @@ VISRTX_DEVICE void populateVolumeHit(VolumeHit &hit)
   hit.volume = &ray::volumeData(fd);
   hit.instance = &ivd;
 
-  hit.lastVolID = ray::objID();
-  hit.lastInstID = ray::instID();
-
   const auto ro = optixGetWorldRayOrigin();
   hit.localRay.org = make_vec3(optixTransformPointFromWorldToObjectSpace(ro));
   hit.localRay.dir = ray::volume_local_direction();

--- a/devices/rtx/device/gpu/sampleSpatialField.h
+++ b/devices/rtx/device/gpu/sampleSpatialField.h
@@ -31,10 +31,14 @@
 
 #pragma once
 
-#include <nanovdb/NanoVDB.h>
-#include <texture_types.h>
 #include "gpu/gpu_decl.h"
 #include "gpu/gpu_objects.h"
+
+// cuda
+#include <texture_types.h>
+
+// nanovdb
+#include <nanovdb/NanoVDB.h>
 #include "nanovdb/math/Math.h"
 #include "nanovdb/math/SampleFromVoxels.h"
 
@@ -59,21 +63,21 @@ class SpatialFieldSampler<cudaTextureObject_t>
   {
     m_texObj = sf.data.structuredRegular.texObj;
     m_origin = sf.data.structuredRegular.origin;
-    m_spacing = sf.data.structuredRegular.spacing;
+    m_invDims = sf.data.structuredRegular.invDims;
     m_invSpacing = sf.data.structuredRegular.invSpacing;
   }
 
   VISRTX_DEVICE float operator()(const vec3 &location)
   {
-    const auto srfCoords =
-        ((location - m_origin) + 0.5f * m_spacing) * m_invSpacing;
-    return tex3D<float>(m_texObj, srfCoords.x, srfCoords.y, srfCoords.z);
+    const auto texelCoords = (location - m_origin) * m_invSpacing + 0.5f;
+    const auto coords = texelCoords * m_invDims;
+    return tex3D<float>(m_texObj, coords.x, coords.y, coords.z);
   }
 
  private:
   cudaTextureObject_t m_texObj;
   vec3 m_origin;
-  vec3 m_spacing;
+  vec3 m_invDims;
   vec3 m_invSpacing;
 };
 
@@ -89,19 +93,24 @@ class SpatialFieldSampler<nanovdb::Grid<nanovdb::NanoTree<T>>>
       : m_grid(
             reinterpret_cast<const GridType *>(sf.data.nvdbRegular.gridData)),
         m_accessor(m_grid->getAccessor()),
-        m_sampler(nanovdb::math::createSampler<1>(m_accessor))
+        m_sampler(nanovdb::math::createSampler<1>(m_accessor)),
+        m_scale(
+            (nanovdb::Vec3f(m_grid->indexBBox().dim()) - nanovdb::Vec3f(1.0f))
+            / nanovdb::Vec3f(m_grid->indexBBox().dim()))
   {}
 
   VISRTX_DEVICE float operator()(const vec3 &location)
   {
-    const auto nvdbLoc = nanovdb::Vec3d(location.x, location.y, location.z);
-    return m_sampler(nanovdb::math::Vec3d(m_grid->worldToIndexF(nvdbLoc)));
+    return m_sampler(m_grid->worldToIndexF(
+                         nanovdb::Vec3f(location.x, location.y, location.z))
+        * m_scale);
   }
 
  private:
   const GridType *m_grid;
   const AccessorType m_accessor;
   SamplerType m_sampler;
+  nanovdb::Vec3f m_scale;
 };
 
 template <typename T>

--- a/devices/rtx/device/spatial_field/NvdbRegularField.cpp
+++ b/devices/rtx/device/spatial_field/NvdbRegularField.cpp
@@ -148,9 +148,6 @@ void NvdbRegularField::buildGrid()
 {
   auto gridSize = m_gridMetadata->indexBBox().dim();
   m_uniformGrid.init(ivec3(gridSize[0], gridSize[1], gridSize[2]), m_bounds);
-
-  size_t numVoxels =
-      (gridSize[0] - 1) * size_t(gridSize[1] - 1) * (gridSize[2] - 1);
   m_uniformGrid.buildGrid(gpuData());
 }
 

--- a/devices/rtx/device/spatial_field/StructuredRegularField.cpp
+++ b/devices/rtx/device/spatial_field/StructuredRegularField.cpp
@@ -184,9 +184,8 @@ SpatialFieldGPUData StructuredRegularField::gpuData() const
   sf.type = SpatialFieldType::STRUCTURED_REGULAR;
   sf.data.structuredRegular.texObj = m_textureObject;
   sf.data.structuredRegular.origin = m_origin;
-  sf.data.structuredRegular.spacing = m_spacing;
-  sf.data.structuredRegular.invSpacing =
-      vec3(1.f) / (m_spacing * vec3(dims.x, dims.y, dims.z));
+  sf.data.structuredRegular.invDims = 1.0f / vec3(dims.x, dims.y, dims.z);
+  sf.data.structuredRegular.invSpacing = 1.0f / m_spacing;
   sf.grid = m_uniformGrid.gpuData();
   return sf;
 }

--- a/devices/rtx/external/nanovdb/include/nanovdb/CNanoVDB.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/CNanoVDB.h
@@ -5,6 +5,9 @@
 // Simple C-wrapper for the nanovdb structure
 // Meant for systems where you lack a C++ compiler.
 //
+
+/// @warning This header file will soon be deprecated in favor of PNanoVDB.h
+
 #ifndef __CNANOVDB__
 #define __CNANOVDB__
 

--- a/devices/rtx/external/nanovdb/include/nanovdb/GridHandle.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/GridHandle.h
@@ -45,13 +45,14 @@ class GridHandle
 public:
     using BufferType = BufferT;
 
-    /// @brief  Move constructor from a host buffer
+    /// @brief  Move constructor from a dual host-device buffer
     /// @param buffer buffer containing one or more NanoGrids that will be moved into this GridHandle
     /// @throw Will throw and error with the buffer does not contain a valid NanoGrid!
+    /// @note The implementation of this template specialization is in nanovdb/cuda/GridHandle.cuh since it requires CUDA
     template<typename T = BufferT, typename util::enable_if<BufferTraits<T>::hasDeviceDual, int>::type = 0>
     GridHandle(T&& buffer);
 
-    /// @brief  Move constructor from a dual host-device buffer
+    /// @brief  Move constructor from a host buffer
     /// @param buffer buffer containing one or more NanoGrids that will be moved into this GridHandle
     /// @throw Will throw and error with the buffer does not contain a valid NanoGrid!
     template<typename T = BufferT, typename util::disable_if<BufferTraits<T>::hasDeviceDual, int>::type = 0>
@@ -110,19 +111,28 @@ public:
     typename util::enable_if<BufferTraits<U>::hasDeviceDual, const void*>::type
     deviceData() const { return mBuffer.deviceData(); }
     template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, const void*>::type
+    deviceData(int device) const { return mBuffer.deviceData(device); }
+    template<typename U = BufferT>
     typename util::enable_if<BufferTraits<U>::hasDeviceDual, void*>::type
     deviceData() { return mBuffer.deviceData(); }
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, void*>::type
+    deviceData(int device) { return mBuffer.deviceData(device); }
 
+    //@{
     /// @brief Returns the size in bytes of the raw memory buffer managed by this GridHandle.
-    uint64_t size() const { return mBuffer.size(); }
+    [[deprecated("Use GridHandle::bufferSize instead.")]] uint64_t size() const { return mBuffer.size(); }
+    uint64_t bufferSize() const { return mBuffer.size(); }
+    //@}
 
     //@{
     /// @brief Return true if this handle is empty, i.e. has no allocated memory
-    bool empty()   const { return this->size() == 0; }
-    bool isEmpty() const { return this->size() == 0; }
+    bool empty()   const { return mBuffer.size() == 0; }
+    bool isEmpty() const { return mBuffer.size() == 0; }
     //@}
 
-    /// @brief Return true if this handle contains any grids
+    /// @brief Return true if this handle is not empty, i.e. contains at least one grid
     operator bool() const { return !this->empty(); }
 
     /// @brief Returns a const host pointer to the @a n'th NanoVDB grid encoded in this GridHandle.
@@ -152,7 +162,7 @@ public:
 
     /// @brief Return a const pointer to the @a n'th grid encoded in this GridHandle on the device, e.g. GPU
     /// @tparam ValueT Value type of the grid point to be returned
-    /// @param n Index if of the grid pointer to be returned
+    /// @param n Index of the grid pointer to be returned
     /// @param verbose if non-zero error messages will be printed in case something failed
     /// @warning Note that the return pointer can be NULL if the GridHandle was not initialized, @a n is invalid,
     ///          or if the template parameter does not match the specified grid.
@@ -164,13 +174,25 @@ public:
     /// @note This method is only available if the buffer supports devices
     template<typename U = BufferT>
     typename util::enable_if<BufferTraits<U>::hasDeviceDual, void>::type
-    deviceUpload(void* stream = nullptr, bool sync = true) { mBuffer.deviceUpload(stream, sync); }
+    deviceUpload(void* stream, bool sync = true) { mBuffer.deviceUpload(stream, sync); }
+
+    /// @brief Upload the host buffer to a specific device buffer. It device buffer doesn't exist it's created first
+    /// @param device Device to upload host data to
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, void>::type
+    deviceUpload(int device = 0, void* stream = nullptr, bool sync = true) { mBuffer.deviceUpload(device, stream, sync); }
 
     /// @brief Download the grid to from the device, e.g. from GPU to CPU
     /// @note This method is only available if the buffer supports devices
     template<typename U = BufferT>
     typename util::enable_if<BufferTraits<U>::hasDeviceDual, void>::type
-    deviceDownload(void* stream = nullptr, bool sync = true) { mBuffer.deviceDownload(stream, sync); }
+    deviceDownload(void* stream, bool sync = true) { mBuffer.deviceDownload(stream, sync); }
+
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, void>::type
+    deviceDownload(int device = 0, void* stream = nullptr, bool sync = true) { mBuffer.deviceDownload(device, stream, sync); }
 
     /// @brief Check if the buffer is this handle has any padding, i.e. if the buffer is larger than the combined size of all its grids
     /// @return true is the combined size of all grid is smaller than the buffer size
@@ -183,6 +205,23 @@ public:
     /// @param n index of the grid (assumed to be less than gridCount())
     /// @return Return the byte size of the specified grid
     uint64_t gridSize(uint32_t n = 0) const {return mMetaData[n].size; }
+
+    /// @brief compute the total sum of memory footprints of all the grids in this buffer
+    /// @return the number of bytes occupied by all grids associated with this buffer
+    uint64_t totalGridSize() const {
+        uint64_t sum = 0;
+        for (auto &m : mMetaData) sum += m.size;
+        NANOVDB_ASSERT(sum <= mBuffer.size());
+        return sum;
+    }
+
+    /// @brief compute the size of unused storage in this buffer
+    /// @return the number of unused bytes in this buffer.
+    uint64_t freeSize() const {return mBuffer.size() - this->totalGridSize();}
+
+    /// @brief Test if this buffer has any unused storage left, i.e. memory not occupied by grids
+    /// @return true if there is no extra storage left in this buffer, i.e. empty or fully occupied with grids
+    bool isFull() const { return this->totalGridSize() == mBuffer.size(); }
 
     /// @brief Return the GridType of the @a n'th grid in this GridHandle
     /// @param n index of the grid (assumed to be less than gridCount())
@@ -250,12 +289,12 @@ public:
     /// @param is input stream containing a raw grid buffer
     /// @param gridName string name of the grid to be read
     /// @param pool optional pool from which to allocate the new grid buffer
-    /// @throw Will throw a std::logic_error if the stream does not contain a valid raw grid with the speficied name
+    /// @throw Will throw a std::logic_error if the stream does not contain a valid raw grid with the specified name
     void read(std::istream& is, const std::string &gridName, const BufferT& pool = BufferT());
 
     /// @brief Read a raw grid buffer from a file
     /// @param filename string name of the input file containing a raw grid buffer
-    /// @param pool optional pool from which to allocate the new grid buffe
+    /// @param pool optional pool from which to allocate the new grid buffer
     void read(const std::string &fileName, const BufferT& pool = BufferT()) {
         std::ifstream is(fileName, std::ios::in | std::ios::binary);
         if (!is.is_open()) throw std::ios_base::failure("Unable to open file named \"" + fileName + "\" for input");
@@ -315,6 +354,7 @@ inline __hostdev__ void cpyGridHandleMeta(const GridData *data, GridHandleMetaDa
     }
 }// void cpyGridHandleMeta(const GridData *data, GridHandleMetaData *meta)
 
+// template specialization of move constructor from a host buffer
 template<typename BufferT>
 template<typename T, typename util::disable_if<BufferTraits<T>::hasDeviceDual, int>::type>
 GridHandle<BufferT>::GridHandle(T&& buffer)
@@ -450,7 +490,7 @@ splitGrids(const GridHandle<BufferT> &handle, const BufferT* other = nullptr)
         h = HandleT(std::move(buffer));
         ptr = util::PtrAdd(ptr, src->mGridSize);
     }
-    return std::move(handles);
+    return handles;
 }// splitGrids
 
 /// @brief Combines (or merges) multiple GridHandles into a single GridHandle containing all grids

--- a/devices/rtx/external/nanovdb/include/nanovdb/HostBuffer.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/HostBuffer.h
@@ -192,6 +192,13 @@ public:
     void* data() { return mData; }
     //@}
 
+    /// @brief Returns an offset pointer of a specific type from the allocated host memory
+    /// @tparam T Type of the pointer returned
+    /// @param count Numbers of elements of @c parameter type T to skip
+    /// @warning might return NULL
+    template <typename T>
+    T* data(ptrdiff_t count = 0) const {return mData ? reinterpret_cast<T*>(mData) + count : nullptr;}
+
     //@{
     /// @brief Returns the size in bytes associated with this buffer.
     uint64_t bufferSize() const { return mSize; }
@@ -316,7 +323,6 @@ struct HostBuffer::Pool
                << mSize << " bytes of which\n\t" << (util::PtrDiff(alignedFree, mData) - mPadding)
                << " bytes are used by " << mRegister.size() << " other buffer(s). "
                << "Pool is " << (mManaged ? "internally" : "externally") << " managed.\n";
-            //std::cerr << ss.str();
             throw std::runtime_error(ss.str());
         }
         buffer->mSize = size;
@@ -389,7 +395,6 @@ struct HostBuffer::Pool
             }
 
             for (HostBuffer* buffer : mRegister) { // update registered buffers
-                //buffer->mData = paddedData + ptrdiff_t(buffer->mData - (mData + mPadding));
                 buffer->mData = util::PtrAdd(paddedData, util::PtrDiff(buffer->mData, util::PtrAdd(mData, mPadding)));
             }
             mFree = util::PtrAdd(paddedData, memUsage); // update the free pointer
@@ -414,12 +419,8 @@ private:
 
     static void* alloc(uint64_t size)
     {
-//#if (__cplusplus >= 201703L)
-//    return std::aligned_alloc(NANOVDB_DATA_ALIGNMENT, size);//C++17 or newer
-//#else
     // make sure we alloc enough space to align the result
     return std::malloc(size + NANOVDB_DATA_ALIGNMENT);
-//#endif
     }
 
     static void* realloc(void* const origData,

--- a/devices/rtx/external/nanovdb/include/nanovdb/PNanoVDB.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/PNanoVDB.h
@@ -198,47 +198,110 @@ PNANOVDB_BUF_FORCE_INLINE void pnanovdb_buf_write_uint64(pnanovdb_buf_t buf, uin
 typedef uint32_t pnanovdb_grid_type_t;
 #define PNANOVDB_GRID_TYPE_GET(grid_typeIn, nameIn) pnanovdb_grid_type_constants[grid_typeIn].nameIn
 #elif defined(PNANOVDB_BUF_HLSL)
-#if defined(PNANOVDB_ADDRESS_32)
+#if defined(PNANOVDB_BUF_HLSL_RW)
+#if defined(PNANOVDB_BUF_HLSL_64)
+#define pnanovdb_buf_t RWStructuredBuffer<uint2>
+#else
+#define pnanovdb_buf_t RWStructuredBuffer<uint>
+#endif
+#else
+#if defined(PNANOVDB_BUF_HLSL_64)
+#define pnanovdb_buf_t StructuredBuffer<uint2>
+#else
 #define pnanovdb_buf_t StructuredBuffer<uint>
+#endif
+#endif
+#if defined(PNANOVDB_ADDRESS_32)
 uint pnanovdb_buf_read_uint32(pnanovdb_buf_t buf, uint byte_offset)
 {
+#if defined(PNANOVDB_BUF_HLSL_64)
+    uint2 val = buf[(byte_offset >> 3u)];
+    return ((byte_offset & 4u) == 0u) ? val.x : val.y;
+#else
     return buf[(byte_offset >> 2u)];
+#endif
 }
 uint2 pnanovdb_buf_read_uint64(pnanovdb_buf_t buf, uint byte_offset)
 {
     uint2 ret;
+#if defined(PNANOVDB_BUF_HLSL_64)
+    ret = buf[(byte_offset >> 3u)];
+#else
     ret.x = pnanovdb_buf_read_uint32(buf, byte_offset + 0u);
     ret.y = pnanovdb_buf_read_uint32(buf, byte_offset + 4u);
+#endif
     return ret;
 }
 void pnanovdb_buf_write_uint32(pnanovdb_buf_t buf, uint byte_offset, uint value)
 {
     // NOP, by default no write in HLSL
+#if defined(PNANOVDB_BUF_HLSL_RW)
+#if defined(PNANOVDB_BUF_HLSL_64)
+    if ((byte_offset & 4u) == 0u) {buf[(byte_offset >> 3u)].x = value;}
+    else {buf[(byte_offset >> 3u)].y = value;}
+#else
+    buf[(byte_offset >> 2u)] = value;
+#endif
+#endif
 }
 void pnanovdb_buf_write_uint64(pnanovdb_buf_t buf, uint byte_offset, uint2 value)
 {
     // NOP, by default no write in HLSL
+#if defined(PNANOVDB_BUF_HLSL_RW)
+#if defined(PNANOVDB_BUF_HLSL_64)
+    buf[(byte_offset >> 3u)] = value;
+#else
+    pnanovdb_buf_write_uint32(buf, byte_offset + 0u, value.x);
+    pnanovdb_buf_write_uint32(buf, byte_offset + 4u, value.y);
+#endif
+#endif
 }
 #elif defined(PNANOVDB_ADDRESS_64)
-#define pnanovdb_buf_t StructuredBuffer<uint>
 uint pnanovdb_buf_read_uint32(pnanovdb_buf_t buf, uint64_t byte_offset)
 {
+#if defined(PNANOVDB_BUF_HLSL_64)
+    uint2 val = buf[uint(byte_offset >> 3u)];
+    return ((uint(byte_offset) & 4u) == 0u) ? val.x : val.y;
+#else
     return buf[uint(byte_offset >> 2u)];
+#endif
 }
 uint64_t pnanovdb_buf_read_uint64(pnanovdb_buf_t buf, uint64_t byte_offset)
 {
     uint64_t ret;
+#if defined(PNANOVDB_BUF_HLSL_64)
+    uint2 raw = buf[uint(byte_offset >> 3u)];
+    ret = uint64_t(raw.x) | (uint64_t(raw.y) << 32u);
+#else
     ret = pnanovdb_buf_read_uint32(buf, byte_offset + 0u);
-    ret = ret + (uint64_t(pnanovdb_buf_read_uint32(buf, byte_offset + 4u)) << 32u);
+    ret = ret | (uint64_t(pnanovdb_buf_read_uint32(buf, byte_offset + 4u)) << 32u);
+#endif
     return ret;
 }
 void pnanovdb_buf_write_uint32(pnanovdb_buf_t buf, uint64_t byte_offset, uint value)
 {
     // NOP, by default no write in HLSL
+#if defined(PNANOVDB_BUF_HLSL_RW)
+#if defined(PNANOVDB_BUF_HLSL_64)
+    if ((byte_offset & 4u) == 0u) {buf[uint(byte_offset >> 3u)].x = value;}
+    else {buf[uint(byte_offset >> 3u)].y = value;}
+#else
+    buf[uint(byte_offset >> 2u)] = value;
+#endif
+#endif
 }
 void pnanovdb_buf_write_uint64(pnanovdb_buf_t buf, uint64_t byte_offset, uint64_t value)
 {
     // NOP, by default no write in HLSL
+#if defined(PNANOVDB_BUF_HLSL_RW)
+#if defined(PNANOVDB_BUF_HLSL_64)
+    uint2 raw = uint2(uint(value), uint(value >> 32u));
+    buf[uint(byte_offset >> 3u)] = raw;
+#else
+    pnanovdb_buf_write_uint32(buf, byte_offset + 0u, uint(value));
+    pnanovdb_buf_write_uint32(buf, byte_offset + 4u, uint(value >> 32u));
+#endif
+#endif
 }
 #endif
 #define pnanovdb_grid_type_t uint
@@ -343,14 +406,26 @@ typedef struct pnanovdb_vec3_t
 {
     float x, y, z;
 }pnanovdb_vec3_t;
+typedef struct pnanovdb_uvec4_t
+{
+    pnanovdb_uint32_t x, y, z, w;
+}pnanovdb_uvec4_t;
+typedef struct pnanovdb_ivec4_t
+{
+    pnanovdb_int32_t x, y, z, w;
+}pnanovdb_ivec4_t;
+typedef struct pnanovdb_vec4_t
+{
+    float x, y, z, w;
+}pnanovdb_vec4_t;
 PNANOVDB_FORCE_INLINE pnanovdb_int32_t pnanovdb_uint32_as_int32(pnanovdb_uint32_t v) { return (pnanovdb_int32_t)v; }
 PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_uint64_as_int64(pnanovdb_uint64_t v) { return (pnanovdb_int64_t)v; }
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_int64_as_uint64(pnanovdb_int64_t v) { return (pnanovdb_uint64_t)v; }
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_int32_as_uint32(pnanovdb_int32_t v) { return (pnanovdb_uint32_t)v; }
 PNANOVDB_FORCE_INLINE float pnanovdb_uint32_as_float(pnanovdb_uint32_t v) { float vf; pnanovdb_memcpy(&vf, &v, sizeof(vf)); return vf; }
-PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_float_as_uint32(float v) { return *((pnanovdb_uint32_t*)(&v)); }
+PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_float_as_uint32(float v) { pnanovdb_uint32_t vu; pnanovdb_memcpy(&vu, &v, sizeof(vu)); return vu; }
 PNANOVDB_FORCE_INLINE double pnanovdb_uint64_as_double(pnanovdb_uint64_t v) { double vf; pnanovdb_memcpy(&vf, &v, sizeof(vf)); return vf; }
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_double_as_uint64(double v) { return *((pnanovdb_uint64_t*)(&v)); }
+PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_double_as_uint64(double v) { pnanovdb_uint64_t vu; pnanovdb_memcpy(&vu, &v, sizeof(vu)); return vu; }
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_uint64_low(pnanovdb_uint64_t v) { return (pnanovdb_uint32_t)v; }
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_uint64_high(pnanovdb_uint64_t v) { return (pnanovdb_uint32_t)(v >> 32u); }
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_uint32_as_uint64(pnanovdb_uint32_t x, pnanovdb_uint32_t y) { return ((pnanovdb_uint64_t)x) | (((pnanovdb_uint64_t)y) << 32u); }
@@ -373,6 +448,9 @@ typedef bool pnanovdb_bool_t;
 #define PNANOVDB_TRUE true
 typedef int3 pnanovdb_coord_t;
 typedef float3 pnanovdb_vec3_t;
+typedef uint4 pnanovdb_uvec4_t;
+typedef int4 pnanovdb_ivec4_t;
+typedef float4 pnanovdb_vec4_t;
 pnanovdb_int32_t pnanovdb_uint32_as_int32(pnanovdb_uint32_t v) { return int(v); }
 pnanovdb_uint32_t pnanovdb_int32_as_uint32(pnanovdb_int32_t v) { return uint(v); }
 float pnanovdb_uint32_as_float(pnanovdb_uint32_t v) { return asfloat(v); }
@@ -420,6 +498,9 @@ bool pnanovdb_int64_is_zero(pnanovdb_int64_t a) { return a == 0; }
 #define pnanovdb_int64_t ivec2
 #define pnanovdb_coord_t ivec3
 #define pnanovdb_vec3_t vec3
+#define pnanovdb_uvec4_t uvec4
+#define pnanovdb_ivec4_t ivec4
+#define pnanovdb_vec4_t vec4
 pnanovdb_int32_t pnanovdb_uint32_as_int32(pnanovdb_uint32_t v) { return int(v); }
 pnanovdb_int64_t pnanovdb_uint64_as_int64(pnanovdb_uint64_t v) { return ivec2(v); }
 pnanovdb_uint64_t pnanovdb_int64_as_uint64(pnanovdb_int64_t v) { return uvec2(v); }
@@ -525,6 +606,35 @@ PNANOVDB_FORCE_INLINE pnanovdb_coord_t pnanovdb_coord_add(pnanovdb_coord_t a, pn
     v.z = a.z + b.z;
     return v;
 }
+PNANOVDB_FORCE_INLINE pnanovdb_uvec4_t pnanovdb_uvec4_add(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b)
+{
+    pnanovdb_uvec4_t ret;
+    ret.x = a.x + b.x;
+    ret.y = a.y + b.y;
+    ret.z = a.z + b.z;
+    ret.w = a.w + b.w;
+    return ret;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_uvec4_t pnanovdb_uvec4_sub(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b)
+{
+    pnanovdb_uvec4_t ret;
+    ret.x = a.x - b.x;
+    ret.y = a.y - b.y;
+    ret.z = a.z - b.z;
+    ret.w = a.w - b.w;
+    return ret;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_vec4_t pnanovdb_vec4_add(pnanovdb_vec4_t a, pnanovdb_vec4_t b)
+{
+    pnanovdb_vec4_t ret;
+    ret.x = a.x + b.x;
+    ret.y = a.y + b.y;
+    ret.z = a.z + b.z;
+    ret.w = a.w + b.w;
+    return ret;
+}
 #elif defined(PNANOVDB_HLSL)
 pnanovdb_vec3_t pnanovdb_vec3_uniform(float a) { return float3(a, a, a); }
 pnanovdb_vec3_t pnanovdb_vec3_add(pnanovdb_vec3_t a, pnanovdb_vec3_t b) { return a + b; }
@@ -536,6 +646,9 @@ pnanovdb_vec3_t pnanovdb_vec3_max(pnanovdb_vec3_t a, pnanovdb_vec3_t b) { return
 pnanovdb_vec3_t pnanovdb_coord_to_vec3(pnanovdb_coord_t coord) { return float3(coord); }
 pnanovdb_coord_t pnanovdb_coord_uniform(pnanovdb_int32_t a) { return int3(a, a, a); }
 pnanovdb_coord_t pnanovdb_coord_add(pnanovdb_coord_t a, pnanovdb_coord_t b) { return a + b; }
+pnanovdb_uvec4_t pnanovdb_uvec4_add(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b) { return a + b; }
+pnanovdb_uvec4_t pnanovdb_uvec4_sub(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b) { return a - b; }
+pnanovdb_vec4_t pnanovdb_vec4_add(pnanovdb_vec4_t a, pnanovdb_vec4_t b) { return a + b; }
 #elif defined(PNANOVDB_GLSL)
 pnanovdb_vec3_t pnanovdb_vec3_uniform(float a) { return vec3(a, a, a); }
 pnanovdb_vec3_t pnanovdb_vec3_add(pnanovdb_vec3_t a, pnanovdb_vec3_t b) { return a + b; }
@@ -547,6 +660,9 @@ pnanovdb_vec3_t pnanovdb_vec3_max(pnanovdb_vec3_t a, pnanovdb_vec3_t b) { return
 pnanovdb_vec3_t pnanovdb_coord_to_vec3(const pnanovdb_coord_t coord) { return vec3(coord); }
 pnanovdb_coord_t pnanovdb_coord_uniform(pnanovdb_int32_t a) { return ivec3(a, a, a); }
 pnanovdb_coord_t pnanovdb_coord_add(pnanovdb_coord_t a, pnanovdb_coord_t b) { return a + b; }
+pnanovdb_uvec4_t pnanovdb_uvec4_add(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b) { return a + b; }
+pnanovdb_uvec4_t pnanovdb_uvec4_sub(pnanovdb_uvec4_t a, pnanovdb_uvec4_t b) { return a - b; }
+pnanovdb_vec4_t pnanovdb_vec4_add(pnanovdb_vec4_t a, pnanovdb_vec4_t b) { return a + b; }
 #endif
 
 // ------------------------------------------------ Uint64 Utils -----------------------------------------------------------
@@ -587,6 +703,19 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_uint64_offset(pnanovdb_uint64_t
         high += 1u;
     }
     return pnanovdb_uint32_as_uint64(low, high);
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_uint64_diff(pnanovdb_uint64_t a, pnanovdb_uint64_t b)
+{
+    pnanovdb_uint32_t low = pnanovdb_uint64_low(a);
+    pnanovdb_uint32_t high = pnanovdb_uint64_high(a);
+    low -= pnanovdb_uint64_low(b);
+    if (low > pnanovdb_uint64_low(a))
+    {
+        high -= 1u;
+    }
+    high -= pnanovdb_uint64_high(b);
+    return pnanovdb_uint64_as_int64(pnanovdb_uint32_as_uint64(low, high));
 }
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_uint64_dec(pnanovdb_uint64_t a)
@@ -634,6 +763,11 @@ PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_uint64_any_bit(pnanovdb_uint64_t 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_uint64_offset(pnanovdb_uint64_t a, pnanovdb_uint32_t b)
 {
     return a + b;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_uint64_diff(pnanovdb_uint64_t a, pnanovdb_uint64_t b)
+{
+    return pnanovdb_uint64_as_int64(a - b);
 }
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_uint64_dec(pnanovdb_uint64_t a)
@@ -702,6 +836,10 @@ PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_address_offset64_product(pnano
     ret.byte_offset += pnanovdb_uint64_low(byte_offset) * multiplier;
     return ret;
 }
+PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_address_diff(pnanovdb_address_t a, pnanovdb_address_t b)
+{
+    return pnanovdb_uint64_diff(pnanovdb_uint32_as_uint64_low(a.byte_offset),pnanovdb_uint32_as_uint64_low(b.byte_offset));
+}
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_address_mask(pnanovdb_address_t address, pnanovdb_uint32_t mask)
 {
     return address.byte_offset & mask;
@@ -724,6 +862,12 @@ PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_address_is_null(pnanovdb_address_
 PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_address_in_interval(pnanovdb_address_t address, pnanovdb_address_t min_address, pnanovdb_address_t max_address)
 {
     return address.byte_offset >= min_address.byte_offset && address.byte_offset < max_address.byte_offset;
+}
+PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_address_add(pnanovdb_address_t a, pnanovdb_address_t b)
+{
+    pnanovdb_address_t sum = a;
+    sum.byte_offset += b.byte_offset;
+    return sum;
 }
 #elif defined(PNANOVDB_ADDRESS_64)
 struct pnanovdb_address_t
@@ -762,6 +906,10 @@ PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_address_offset64_product(pnano
     ret.byte_offset += byte_offset * pnanovdb_uint32_as_uint64_low(multiplier);
     return ret;
 }
+PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_address_diff(pnanovdb_address_t a, pnanovdb_address_t b)
+{
+    return pnanovdb_uint64_diff(a.byte_offset, b.byte_offset);
+}
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_address_mask(pnanovdb_address_t address, pnanovdb_uint32_t mask)
 {
     return pnanovdb_uint64_low(address.byte_offset) & mask;
@@ -784,6 +932,12 @@ PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_address_is_null(pnanovdb_address_
 PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_address_in_interval(pnanovdb_address_t address, pnanovdb_address_t min_address, pnanovdb_address_t max_address)
 {
     return address.byte_offset >= min_address.byte_offset && address.byte_offset < max_address.byte_offset;
+}
+PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_address_add(pnanovdb_address_t a, pnanovdb_address_t b)
+{
+    pnanovdb_address_t sum = a;
+    sum.byte_offset += b.byte_offset;
+    return sum;
 }
 #endif
 
@@ -933,7 +1087,7 @@ PNANOVDB_FORCE_INLINE void pnanovdb_write_vec3(pnanovdb_buf_t buf, pnanovdb_addr
 #define PNANOVDB_MAGIC_FILE   0x324244566f6e614eUL// "NanoVDB2" in hex - little endian (uint64_t)
 
 #define PNANOVDB_MAJOR_VERSION_NUMBER 32// reflects changes to the ABI
-#define PNANOVDB_MINOR_VERSION_NUMBER  7// reflects changes to the API but not ABI
+#define PNANOVDB_MINOR_VERSION_NUMBER  9// reflects changes to the API but not ABI
 #define PNANOVDB_PATCH_VERSION_NUMBER  0// reflects bug-fixes with no ABI or API changes
 
 #define PNANOVDB_GRID_TYPE_UNKNOWN 0
@@ -957,13 +1111,15 @@ PNANOVDB_FORCE_INLINE void pnanovdb_write_vec3(pnanovdb_buf_t buf, pnanovdb_addr
 #define PNANOVDB_GRID_TYPE_VEC4D 18
 #define PNANOVDB_GRID_TYPE_INDEX 19
 #define PNANOVDB_GRID_TYPE_ONINDEX 20
-#define PNANOVDB_GRID_TYPE_INDEXMASK 21
-#define PNANOVDB_GRID_TYPE_ONINDEXMASK 22
+//#define PNANOVDB_GRID_TYPE_INDEXMASK 21   // retired - available for future use
+//#define PNANOVDB_GRID_TYPE_ONINDEXMASK 22 // retired - available for future use
 #define PNANOVDB_GRID_TYPE_POINTINDEX 23
 #define PNANOVDB_GRID_TYPE_VEC3U8 24
 #define PNANOVDB_GRID_TYPE_VEC3U16 25
 #define PNANOVDB_GRID_TYPE_UINT8 26
 #define PNANOVDB_GRID_TYPE_END 27
+
+#define PNANOVDB_GRID_TYPE_CAP 32
 
 #define PNANOVDB_GRID_CLASS_UNKNOWN 0
 #define PNANOVDB_GRID_CLASS_LEVEL_SET 1     // narrow band level set, e.g. SDF
@@ -989,22 +1145,22 @@ PNANOVDB_FORCE_INLINE void pnanovdb_write_vec3(pnanovdb_buf_t buf, pnanovdb_addr
 #define PNANOVDB_LEAF_TYPE_LITE 1
 #define PNANOVDB_LEAF_TYPE_FP 2
 #define PNANOVDB_LEAF_TYPE_INDEX 3
-#define PNANOVDB_LEAF_TYPE_INDEXMASK 4
+//#define PNANOVDB_LEAF_TYPE_INDEXMASK 4 // retired - available for future use
 #define PNANOVDB_LEAF_TYPE_POINTINDEX 5
 
 // BuildType = Unknown, float, double, int16_t, int32_t, int64_t, Vec3f, Vec3d, Mask, ...
 // bit count of values in leaf nodes, i.e. 8*sizeof(*nanovdb::LeafNode<BuildType>::mValues) or zero if no values are stored
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_value_strides_bits[PNANOVDB_GRID_TYPE_END]  = {  0, 32, 64, 16, 32, 64,  96, 192,  0, 16, 32,  1, 32,  4,  8, 16,  0, 128, 256,  0,  0,  0,  0, 16, 24, 48,  8 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_value_strides_bits[PNANOVDB_GRID_TYPE_CAP]  = {  0, 32, 64, 16, 32, 64,  96, 192,  0, 16, 32,  1, 32,  4,  8, 16,  0, 128, 256,  0,  0,  0,  0, 16, 24, 48,  8,  0 };
 // bit count of the Tile union in InternalNodes, i.e. 8*sizeof(nanovdb::InternalData::Tile)
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_table_strides_bits[PNANOVDB_GRID_TYPE_END]  = { 64, 64, 64, 64, 64, 64, 128, 192, 64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 256, 64, 64, 64, 64, 64, 64, 64, 64 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_table_strides_bits[PNANOVDB_GRID_TYPE_CAP]  = { 64, 64, 64, 64, 64, 64, 128, 192, 64, 64, 64, 64, 64, 64, 64, 64, 64, 128, 256, 64, 64, 64, 64, 64, 64, 64, 64, 64 };
 // bit count of min/max values, i.e. 8*sizeof(nanovdb::LeafData::mMinimum) or zero if no min/max exists
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_minmax_strides_bits[PNANOVDB_GRID_TYPE_END] = {  0, 32, 64, 16, 32, 64,  96, 192,  8, 16, 32,  8, 32, 32, 32, 32, 32, 128, 256, 64, 64, 64, 64, 64, 24, 48,  8 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_minmax_strides_bits[PNANOVDB_GRID_TYPE_CAP] = {  0, 32, 64, 16, 32, 64,  96, 192,  8, 16, 32,  8, 32, 32, 32, 32, 32, 128, 256, 64, 64,  0,  0, 64, 24, 48,  8,  0 };
 // bit alignment of the value type, controlled by the smallest native type, which is why it is always 0, 8, 16, 32, or 64, e.g. for Vec3f it is 32
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_minmax_aligns_bits[PNANOVDB_GRID_TYPE_END]  = {  0, 32, 64, 16, 32, 64,  32,  64,  8, 16, 32,  8, 32, 32, 32, 32, 32,  32,  64, 64, 64, 64, 64, 64,  8, 16,  8 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_minmax_aligns_bits[PNANOVDB_GRID_TYPE_CAP]  = {  0, 32, 64, 16, 32, 64,  32,  64,  8, 16, 32,  8, 32, 32, 32, 32, 32,  32,  64, 64, 64,  0,  0, 64,  8, 16,  8,  0 };
 // bit alignment of the stats (avg/std-dev) types, e.g. 8*sizeof(nanovdb::LeafData::mAverage)
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_stat_strides_bits[PNANOVDB_GRID_TYPE_END]   = {  0, 32, 64, 32, 32, 64,  32,  64,  8, 32, 32,  8, 32, 32, 32, 32, 32,  32,  64, 64, 64, 64, 64, 64, 32, 32, 32 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_stat_strides_bits[PNANOVDB_GRID_TYPE_CAP]   = {  0, 32, 64, 32, 32, 64,  32,  64,  8, 32, 32,  8, 32, 32, 32, 32, 32,  32,  64, 64, 64,  0,  0, 64, 32, 32, 32,  0 };
 // one of the 4 leaf types defined above, e.g. PNANOVDB_LEAF_TYPE_INDEX = 3
-PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_leaf_type[PNANOVDB_GRID_TYPE_END]           = {  0,  0,  0,  0,  0,  0,  0,    0,  1,  0,  0,  1,  0,  2,  2,  2,  2,   0,   0,  3,  3,  4,  4,  5,  0,  0,  0 };
+PNANOVDB_STATIC_CONST pnanovdb_uint32_t pnanovdb_grid_type_leaf_type[PNANOVDB_GRID_TYPE_CAP]           = {  0,  0,  0,  0,  0,  0,  0,    0,  1,  0,  0,  1,  0,  2,  2,  2,  2,   0,   0,  3,  3,  0,  0,  5,  0,  0,  0,  0 };
 
 struct pnanovdb_map_t
 {
@@ -1099,7 +1255,9 @@ struct pnanovdb_grid_t
     pnanovdb_uint32_t grid_type;                // 4 bytes,     636
     pnanovdb_int64_t blind_metadata_offset;     // 8 bytes,     640
     pnanovdb_uint32_t blind_metadata_count;     // 4 bytes,     648
-    pnanovdb_uint32_t pad[5];                   // 20 bytes,    652
+    pnanovdb_uint32_t data0;                    // 4 bytes,     652
+    pnanovdb_uint64_t data1;                    // 8 bytes,     656
+    pnanovdb_uint64_t data2;                    // 8 bytes,     664
 };
 PNANOVDB_STRUCT_TYPEDEF(pnanovdb_grid_t)
 struct pnanovdb_grid_handle_t { pnanovdb_address_t address; };
@@ -1122,6 +1280,9 @@ PNANOVDB_STRUCT_TYPEDEF(pnanovdb_grid_handle_t)
 #define PNANOVDB_GRID_OFF_GRID_TYPE 636
 #define PNANOVDB_GRID_OFF_BLIND_METADATA_OFFSET 640
 #define PNANOVDB_GRID_OFF_BLIND_METADATA_COUNT 648
+#define PNANOVDB_GRID_OFF_DATA0 652
+#define PNANOVDB_GRID_OFF_DATA1 656
+#define PNANOVDB_GRID_OFF_DATA2 664
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_grid_get_magic(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p) {
     return pnanovdb_read_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_MAGIC));
@@ -1170,6 +1331,15 @@ PNANOVDB_FORCE_INLINE pnanovdb_int64_t pnanovdb_grid_get_blind_metadata_offset(p
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_grid_get_blind_metadata_count(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p) {
     return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_BLIND_METADATA_COUNT));
 }
+PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_grid_get_data0(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p) {
+    return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA0));
+}
+PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_grid_get_data1(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p) {
+    return pnanovdb_read_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA1));
+}
+PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_grid_get_data2(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p) {
+    return pnanovdb_read_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA2));
+}
 
 PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_magic(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_uint64_t magic) {
     pnanovdb_write_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_MAGIC), magic);
@@ -1213,6 +1383,15 @@ PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_blind_metadata_offset(pnanovdb_buf_
 PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_blind_metadata_count(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_uint32_t metadata_count) {
     pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_BLIND_METADATA_COUNT), metadata_count);
 }
+PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_data0(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_uint32_t data0) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA0), data0);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_data1(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_uint64_t data1) {
+    pnanovdb_write_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA1), data1);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_data2(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_uint64_t data2) {
+    pnanovdb_write_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRID_OFF_DATA2), data2);
+}
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_make_version(pnanovdb_uint32_t major, pnanovdb_uint32_t minor, pnanovdb_uint32_t patch_num)
 {
@@ -1231,6 +1410,25 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_version_get_patch(pnanovdb_uint
 {
     return version & ((1u << 10u) - 1u);
 }
+
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_UNKNOWN 0
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_INDEX_ARRAY 1
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_ATTRIBUTE_ARRAY 2
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_GRID_NAME 3
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_CHANNEL_ARRAY 4
+#define PNANOVDB_GRIDBLINDMETADATA_CLASS_END 5
+
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_UNKNOWN 0
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_POSITION 1
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_COLOR 2
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_NORMAL 3
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_RADIUS 4
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_VELOCITY 5
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_POINT_ID 6
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_WORLD_COORDS 7
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_GRID_COORDS 8
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_VOXEL_COORDS 9
+#define PNANOVDB_GRIDBLINDMETADATA_SEMANTIC_END 10
 
 struct pnanovdb_gridblindmetadata_t
 {
@@ -1278,6 +1476,28 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_gridblindmetadata_get_name(pnan
     return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_NAME + 4u * index));
 }
 
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_data_offset(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_int64_t data_offset) {
+    pnanovdb_write_int64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_DATA_OFFSET), data_offset);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_value_count(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint64_t value_count) {
+    pnanovdb_write_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_VALUE_COUNT), value_count);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_value_size(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint32_t value_size) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_VALUE_SIZE), value_size);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_semantic(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint32_t semantic) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_SEMANTIC), semantic);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_data_class(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint32_t data_class) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_DATA_CLASS), data_class);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_data_type(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint32_t data_type) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_DATA_TYPE), data_type);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_gridblindmetadata_set_name(pnanovdb_buf_t buf, pnanovdb_gridblindmetadata_handle_t p, pnanovdb_uint32_t index, pnanovdb_uint32_t name) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_GRIDBLINDMETADATA_OFF_NAME + 4u * index), name);
+}
+
 struct pnanovdb_tree_t
 {
     pnanovdb_uint64_t node_offset_leaf;
@@ -1287,9 +1507,9 @@ struct pnanovdb_tree_t
     pnanovdb_uint32_t node_count_leaf;
     pnanovdb_uint32_t node_count_lower;
     pnanovdb_uint32_t node_count_upper;
-    pnanovdb_uint32_t tile_count_leaf;
     pnanovdb_uint32_t tile_count_lower;
     pnanovdb_uint32_t tile_count_upper;
+    pnanovdb_uint32_t tile_count_root;
     pnanovdb_uint64_t voxel_count;
 };
 PNANOVDB_STRUCT_TYPEDEF(pnanovdb_tree_t)
@@ -1305,9 +1525,9 @@ PNANOVDB_STRUCT_TYPEDEF(pnanovdb_tree_handle_t)
 #define PNANOVDB_TREE_OFF_NODE_COUNT_LEAF 32
 #define PNANOVDB_TREE_OFF_NODE_COUNT_LOWER 36
 #define PNANOVDB_TREE_OFF_NODE_COUNT_UPPER 40
-#define PNANOVDB_TREE_OFF_TILE_COUNT_LEAF 44
-#define PNANOVDB_TREE_OFF_TILE_COUNT_LOWER 48
-#define PNANOVDB_TREE_OFF_TILE_COUNT_UPPER 52
+#define PNANOVDB_TREE_OFF_TILE_COUNT_LOWER 44
+#define PNANOVDB_TREE_OFF_TILE_COUNT_UPPER 48
+#define PNANOVDB_TREE_OFF_TILE_COUNT_ROOT 52
 #define PNANOVDB_TREE_OFF_VOXEL_COUNT 56
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_tree_get_node_offset_leaf(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
@@ -1331,14 +1551,14 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_node_count_lower(pnano
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_node_count_upper(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
     return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_NODE_COUNT_UPPER));
 }
-PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_tile_count_leaf(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
-    return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_LEAF));
-}
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_tile_count_lower(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
     return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_LOWER));
 }
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_tile_count_upper(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
     return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_UPPER));
+}
+PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_tree_get_tile_count_root(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
+    return pnanovdb_read_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_ROOT));
 }
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_tree_get_voxel_count(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p) {
     return pnanovdb_read_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_VOXEL_COUNT));
@@ -1365,14 +1585,14 @@ PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_node_count_lower(pnanovdb_buf_t buf
 PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_node_count_upper(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint32_t node_count_upper) {
     pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_NODE_COUNT_UPPER), node_count_upper);
 }
-PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_tile_count_leaf(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint32_t tile_count_leaf) {
-    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_LEAF), tile_count_leaf);
-}
 PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_tile_count_lower(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint32_t tile_count_lower) {
     pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_LOWER), tile_count_lower);
 }
 PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_tile_count_upper(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint32_t tile_count_upper) {
     pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_UPPER), tile_count_upper);
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_tile_count_root(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint32_t tile_count_root) {
+    pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_TILE_COUNT_ROOT), tile_count_root);
 }
 PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_voxel_count(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_uint64_t voxel_count) {
     pnanovdb_write_uint64(buf, pnanovdb_address_offset(p.address, PNANOVDB_TREE_OFF_VOXEL_COUNT), voxel_count);
@@ -1501,6 +1721,13 @@ PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_bbox_min(pnanovdb_buf_t buf, pnano
 PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_bbox_max(pnanovdb_buf_t buf, pnanovdb_upper_handle_t p, PNANOVDB_IN(pnanovdb_coord_t) bbox_max) {
     pnanovdb_write_coord(buf, pnanovdb_address_offset(p.address, PNANOVDB_UPPER_OFF_BBOX_MAX), bbox_max);
 }
+PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_value_mask(pnanovdb_buf_t buf, pnanovdb_upper_handle_t p, pnanovdb_uint32_t bit_index, pnanovdb_bool_t value) {
+    pnanovdb_address_t addr = pnanovdb_address_offset(p.address, PNANOVDB_UPPER_OFF_VALUE_MASK + 4u * (bit_index >> 5u));
+    pnanovdb_uint32_t valueMask = pnanovdb_read_uint32(buf, addr);
+    if (!value) { valueMask &= ~(1u << (bit_index & 31u)); }
+    if (value) valueMask |= (1u << (bit_index & 31u));
+    pnanovdb_write_uint32(buf, addr, valueMask);
+}
 PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_child_mask(pnanovdb_buf_t buf, pnanovdb_upper_handle_t p, pnanovdb_uint32_t bit_index, pnanovdb_bool_t value) {
     pnanovdb_address_t addr = pnanovdb_address_offset(p.address, PNANOVDB_UPPER_OFF_CHILD_MASK + 4u * (bit_index >> 5u));
     pnanovdb_uint32_t valueMask = pnanovdb_read_uint32(buf, addr);
@@ -1556,6 +1783,13 @@ PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_bbox_min(pnanovdb_buf_t buf, pnano
 PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_bbox_max(pnanovdb_buf_t buf, pnanovdb_lower_handle_t p, PNANOVDB_IN(pnanovdb_coord_t) bbox_max) {
     pnanovdb_write_coord(buf, pnanovdb_address_offset(p.address, PNANOVDB_LOWER_OFF_BBOX_MAX), bbox_max);
 }
+PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_value_mask(pnanovdb_buf_t buf, pnanovdb_lower_handle_t p, pnanovdb_uint32_t bit_index, pnanovdb_bool_t value) {
+    pnanovdb_address_t addr = pnanovdb_address_offset(p.address, PNANOVDB_LOWER_OFF_VALUE_MASK + 4u * (bit_index >> 5u));
+    pnanovdb_uint32_t valueMask = pnanovdb_read_uint32(buf, addr);
+    if (!value) { valueMask &= ~(1u << (bit_index & 31u)); }
+    if (value) valueMask |= (1u << (bit_index & 31u));
+    pnanovdb_write_uint32(buf, addr, valueMask);
+}
 PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_child_mask(pnanovdb_buf_t buf, pnanovdb_lower_handle_t p, pnanovdb_uint32_t bit_index, pnanovdb_bool_t value) {
     pnanovdb_address_t addr = pnanovdb_address_offset(p.address, PNANOVDB_LOWER_OFF_CHILD_MASK + 4u * (bit_index >> 5u));
     pnanovdb_uint32_t valueMask = pnanovdb_read_uint32(buf, addr);
@@ -1604,6 +1838,13 @@ PNANOVDB_FORCE_INLINE void pnanovdb_leaf_set_bbox_min(pnanovdb_buf_t buf, pnanov
 PNANOVDB_FORCE_INLINE void pnanovdb_leaf_set_bbox_dif_and_flags(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t p, pnanovdb_uint32_t bbox_dif_and_flags) {
     pnanovdb_write_uint32(buf, pnanovdb_address_offset(p.address, PNANOVDB_LEAF_OFF_BBOX_DIF_AND_FLAGS), bbox_dif_and_flags);
 }
+PNANOVDB_FORCE_INLINE void pnanovdb_leaf_set_value_mask(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t p, pnanovdb_uint32_t bit_index, pnanovdb_bool_t value) {
+    pnanovdb_address_t addr = pnanovdb_address_offset(p.address, PNANOVDB_LEAF_OFF_VALUE_MASK + 4u * (bit_index >> 5u));
+    pnanovdb_uint32_t valueMask = pnanovdb_read_uint32(buf, addr);
+    if (!value) { valueMask &= ~(1u << (bit_index & 31u)); }
+    if (value) valueMask |= (1u << (bit_index & 31u));
+    pnanovdb_write_uint32(buf, addr, valueMask);
+}
 
 struct pnanovdb_grid_type_constants_t
 {
@@ -1639,7 +1880,7 @@ struct pnanovdb_grid_type_constants_t
 PNANOVDB_STRUCT_TYPEDEF(pnanovdb_grid_type_constants_t)
 
 // The following table with offsets will nedd to be updates as new GridTypes are added in NanoVDB.h
-PNANOVDB_STATIC_CONST pnanovdb_grid_type_constants_t pnanovdb_grid_type_constants[PNANOVDB_GRID_TYPE_END] =
+PNANOVDB_STATIC_CONST pnanovdb_grid_type_constants_t pnanovdb_grid_type_constants[PNANOVDB_GRID_TYPE_CAP] =
 {
 {28, 28, 28, 28, 28, 32,  0, 8, 20, 32,  8224, 8224, 8224, 8224, 8224, 270368,  1056, 1056, 1056, 1056, 1056, 33824,  80, 80, 80, 80, 96, 96},
 {28, 32, 36, 40, 44, 64,  32, 8, 20, 32,  8224, 8228, 8232, 8236, 8256, 270400,  1056, 1060, 1064, 1068, 1088, 33856,  80, 84, 88, 92, 96, 2144},
@@ -1662,12 +1903,13 @@ PNANOVDB_STATIC_CONST pnanovdb_grid_type_constants_t pnanovdb_grid_type_constant
 {32, 64, 96, 128, 136, 160,  256, 32, 24, 64,  8224, 8256, 8288, 8296, 8320, 1056896,  1056, 1088, 1120, 1128, 1152, 132224,  80, 112, 144, 152, 160, 16544},
 {32, 40, 48, 56, 64, 96,  0, 8, 24, 32,  8224, 8232, 8240, 8248, 8256, 270400,  1056, 1064, 1072, 1080, 1088, 33856,  80, 80, 80, 80, 80, 96},
 {32, 40, 48, 56, 64, 96,  0, 8, 24, 32,  8224, 8232, 8240, 8248, 8256, 270400,  1056, 1064, 1072, 1080, 1088, 33856,  80, 80, 80, 80, 80, 96},
-{32, 40, 48, 56, 64, 96,  0, 8, 24, 32,  8224, 8232, 8240, 8248, 8256, 270400,  1056, 1064, 1072, 1080, 1088, 33856,  80, 80, 80, 80, 80, 160},
-{32, 40, 48, 56, 64, 96,  0, 8, 24, 32,  8224, 8232, 8240, 8248, 8256, 270400,  1056, 1064, 1072, 1080, 1088, 33856,  80, 80, 80, 80, 80, 160},
+{28, 28, 28, 28, 28, 32,  0, 8, 20, 32,  8224, 8224, 8224, 8224, 8224, 270368,  1056, 1056, 1056, 1056, 1056, 33824,  80, 80, 80, 80, 96, 96},
+{28, 28, 28, 28, 28, 32,  0, 8, 20, 32,  8224, 8224, 8224, 8224, 8224, 270368,  1056, 1056, 1056, 1056, 1056, 33824,  80, 80, 80, 80, 96, 96},
 {32, 40, 48, 56, 64, 96,  16, 8, 24, 32,  8224, 8232, 8240, 8248, 8256, 270400,  1056, 1064, 1072, 1080, 1088, 33856,  80, 88, 96, 96, 96, 1120},
 {28, 31, 34, 40, 44, 64,  24, 8, 20, 32,  8224, 8227, 8232, 8236, 8256, 270400,  1056, 1059, 1064, 1068, 1088, 33856,  80, 83, 88, 92, 96, 1632},
 {28, 34, 40, 48, 52, 64,  48, 8, 20, 32,  8224, 8230, 8236, 8240, 8256, 270400,  1056, 1062, 1068, 1072, 1088, 33856,  80, 86, 92, 96, 128, 3200},
 {28, 29, 30, 32, 36, 64,  8, 8, 20, 32,  8224, 8225, 8228, 8232, 8256, 270400,  1056, 1057, 1060, 1064, 1088, 33856,  80, 81, 84, 88, 96, 608},
+{28, 28, 28, 28, 28, 32,  0, 8, 20, 32,  8224, 8224, 8224, 8224, 8224, 270368,  1056, 1056, 1056, 1056, 1056, 33824,  80, 80, 80, 80, 96, 96},
 };
 
 // ------------------------------------------------ Basic Lookup -----------------------------------------------------------
@@ -1719,11 +1961,21 @@ PNANOVDB_FORCE_INLINE pnanovdb_root_tile_handle_t pnanovdb_root_get_tile_zero(pn
     return tile;
 }
 
+PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_root_tile_get_child_mask(pnanovdb_buf_t buf, pnanovdb_root_tile_handle_t tile)
+{
+    return !pnanovdb_int64_is_zero(pnanovdb_root_tile_get_child(buf, tile));
+}
+
 PNANOVDB_FORCE_INLINE pnanovdb_upper_handle_t pnanovdb_root_get_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_root_handle_t root, pnanovdb_root_tile_handle_t tile)
 {
     pnanovdb_upper_handle_t upper = { root.address };
     upper.address = pnanovdb_address_offset64(upper.address, pnanovdb_int64_as_uint64(pnanovdb_root_tile_get_child(buf, tile)));
     return upper;
+}
+
+PNANOVDB_FORCE_INLINE void pnanovdb_root_set_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_root_handle_t root, pnanovdb_root_tile_handle_t tile, pnanovdb_upper_handle_t upper)
+{
+    pnanovdb_root_tile_set_child(buf, tile, pnanovdb_address_diff(upper.address, root.address));
 }
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_coord_to_key(PNANOVDB_IN(pnanovdb_coord_t) ijk)
@@ -1758,6 +2010,27 @@ PNANOVDB_FORCE_INLINE pnanovdb_root_tile_handle_t pnanovdb_root_find_tile(pnanov
     }
     pnanovdb_root_tile_handle_t null_handle = { pnanovdb_address_null() };
     return null_handle;
+}
+
+// ----------------------------- Grid Type Safe Set ---------------------------------------
+
+PNANOVDB_FORCE_INLINE void pnanovdb_grid_set_first_gridblindmetadata(pnanovdb_buf_t buf, pnanovdb_grid_handle_t p, pnanovdb_gridblindmetadata_handle_t gridblindmetadata) {
+    pnanovdb_grid_set_blind_metadata_offset(buf, p, pnanovdb_address_diff(gridblindmetadata.address, p.address));
+}
+
+// ----------------------------- Tree Type Safe Set ---------------------------------------
+
+PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_first_leaf(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_leaf_handle_t leaf) {
+    pnanovdb_tree_set_node_offset_leaf(buf, p, pnanovdb_address_diff(leaf.address, p.address));
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_first_lower(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_lower_handle_t lower) {
+    pnanovdb_tree_set_node_offset_lower(buf, p, pnanovdb_address_diff(lower.address, p.address));
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_first_upper(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_upper_handle_t upper) {
+    pnanovdb_tree_set_node_offset_upper(buf, p, pnanovdb_address_diff(upper.address, p.address));
+}
+PNANOVDB_FORCE_INLINE void pnanovdb_tree_set_first_root(pnanovdb_buf_t buf, pnanovdb_tree_handle_t p, pnanovdb_root_handle_t root) {
+    pnanovdb_tree_set_node_offset_root(buf, p, pnanovdb_address_diff(root.address, p.address));
 }
 
 // ----------------------------- Leaf Node ---------------------------------------
@@ -1880,57 +2153,6 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_index_get_value_index(pnan
     return pnanovdb_uint64_offset(offset, n);
 }
 
-// ----------------------------- Leaf IndexMask Specialization ---------------------------------------
-
-PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_leaf_indexmask_has_stats(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf)
-{
-    return pnanovdb_leaf_index_has_stats(buf, leaf);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_indexmask_get_min_index(pnanovdb_buf_t buf, pnanovdb_address_t min_address)
-{
-    return pnanovdb_leaf_index_get_min_index(buf, min_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_indexmask_get_max_index(pnanovdb_buf_t buf, pnanovdb_address_t max_address)
-{
-    return pnanovdb_leaf_index_get_max_index(buf, max_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_indexmask_get_ave_index(pnanovdb_buf_t buf, pnanovdb_address_t ave_address)
-{
-    return pnanovdb_leaf_index_get_ave_index(buf, ave_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_indexmask_get_dev_index(pnanovdb_buf_t buf, pnanovdb_address_t dev_address)
-{
-    return pnanovdb_leaf_index_get_dev_index(buf, dev_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_indexmask_get_value_index(pnanovdb_buf_t buf, pnanovdb_address_t value_address, PNANOVDB_IN(pnanovdb_coord_t) ijk)
-{
-    return pnanovdb_leaf_index_get_value_index(buf, value_address, ijk);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_leaf_indexmask_get_mask_bit(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf, pnanovdb_uint32_t n)
-{
-    pnanovdb_uint32_t word_idx = n >> 5;
-    pnanovdb_uint32_t bit_idx = n & 31;
-    pnanovdb_uint32_t val_mask =
-        pnanovdb_read_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx));
-    return (val_mask & (1u << bit_idx)) != 0u;
-}
-PNANOVDB_FORCE_INLINE void pnanovdb_leaf_indexmask_set_mask_bit(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf, pnanovdb_uint32_t n, pnanovdb_bool_t v)
-{
-    pnanovdb_uint32_t word_idx = n >> 5;
-    pnanovdb_uint32_t bit_idx = n & 31;
-    pnanovdb_uint32_t val_mask =
-        pnanovdb_read_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx));
-    if (v)
-    {
-        val_mask = val_mask | (1u << bit_idx);
-    }
-    else
-    {
-        val_mask = val_mask & ~(1u << bit_idx);
-    }
-    pnanovdb_write_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx), val_mask);
-}
-
 // ----------------------------- Leaf OnIndex Specialization ---------------------------------------
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_leaf_onindex_get_value_count(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf)
@@ -2020,65 +2242,6 @@ PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindex_get_value_index(pn
         value_index = pnanovdb_uint64_offset(offset, sum);
     }
     return value_index;
-}
-
-// ----------------------------- Leaf OnIndexMask Specialization ---------------------------------------
-
-PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_leaf_onindexmask_get_value_count(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf)
-{
-    return pnanovdb_leaf_onindex_get_value_count(buf, leaf);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_last_offset(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf)
-{
-    return pnanovdb_leaf_onindex_get_last_offset(buf, leaf);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_leaf_onindexmask_has_stats(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf)
-{
-    return pnanovdb_leaf_onindex_has_stats(buf, leaf);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_min_index(pnanovdb_buf_t buf, pnanovdb_address_t min_address)
-{
-    return pnanovdb_leaf_onindex_get_min_index(buf, min_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_max_index(pnanovdb_buf_t buf, pnanovdb_address_t max_address)
-{
-    return pnanovdb_leaf_onindex_get_max_index(buf, max_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_ave_index(pnanovdb_buf_t buf, pnanovdb_address_t ave_address)
-{
-    return pnanovdb_leaf_onindex_get_ave_index(buf, ave_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_dev_index(pnanovdb_buf_t buf, pnanovdb_address_t dev_address)
-{
-    return pnanovdb_leaf_onindex_get_dev_index(buf, dev_address);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_uint64_t pnanovdb_leaf_onindexmask_get_value_index(pnanovdb_buf_t buf, pnanovdb_address_t value_address, PNANOVDB_IN(pnanovdb_coord_t) ijk)
-{
-    return pnanovdb_leaf_onindex_get_value_index(buf, value_address, ijk);
-}
-PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_leaf_onindexmask_get_mask_bit(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf, pnanovdb_uint32_t n)
-{
-    pnanovdb_uint32_t word_idx = n >> 5;
-    pnanovdb_uint32_t bit_idx = n & 31;
-    pnanovdb_uint32_t val_mask =
-        pnanovdb_read_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx));
-    return (val_mask & (1u << bit_idx)) != 0u;
-}
-PNANOVDB_FORCE_INLINE void pnanovdb_leaf_onindexmask_set_mask_bit(pnanovdb_buf_t buf, pnanovdb_leaf_handle_t leaf, pnanovdb_uint32_t n, pnanovdb_bool_t v)
-{
-    pnanovdb_uint32_t word_idx = n >> 5;
-    pnanovdb_uint32_t bit_idx = n & 31;
-    pnanovdb_uint32_t val_mask =
-        pnanovdb_read_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx));
-    if (v)
-    {
-        val_mask = val_mask | (1u << bit_idx);
-    }
-    else
-    {
-        val_mask = val_mask & ~(1u << bit_idx);
-    }
-    pnanovdb_write_uint32(buf, pnanovdb_address_offset(leaf.address, 96u + 4u * word_idx), val_mask);
 }
 
 // ----------------------------- Leaf PointIndex Specialization ---------------------------------------
@@ -2210,6 +2373,17 @@ PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_lower_get_value_address(pnanov
     return pnanovdb_lower_get_value_address_and_level(grid_type, buf, lower, ijk, PNANOVDB_REF(level));
 }
 
+PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_table_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_lower_handle_t node, pnanovdb_uint32_t n, pnanovdb_int64_t child)
+{
+    pnanovdb_address_t table_address = pnanovdb_lower_get_table_address(grid_type, buf, node, n);
+    pnanovdb_write_int64(buf, table_address, child);
+}
+
+PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_lower_handle_t lower, pnanovdb_uint32_t n, pnanovdb_leaf_handle_t leaf)
+{
+    pnanovdb_lower_set_table_child(grid_type, buf, lower, n, pnanovdb_address_diff(leaf.address, lower.address));
+}
+
 // ------------------------------------------------ Upper Node -----------------------------------------------------------
 
 PNANOVDB_FORCE_INLINE pnanovdb_uint32_t pnanovdb_upper_coord_to_offset(PNANOVDB_IN(pnanovdb_coord_t) ijk)
@@ -2291,7 +2465,18 @@ PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_table_child(pnanovdb_grid_type_t g
     pnanovdb_write_int64(buf, bufAddress, child);
 }
 
+PNANOVDB_FORCE_INLINE void pnanovdb_upper_set_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_upper_handle_t upper, pnanovdb_uint32_t n, pnanovdb_lower_handle_t lower)
+{
+    pnanovdb_upper_set_table_child(grid_type, buf, upper, n, pnanovdb_address_diff(lower.address, upper.address));
+}
+
 // ------------------------------------------------ Root -----------------------------------------------------------
+
+PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_root_get_background_address(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_root_handle_t root)
+{
+    pnanovdb_uint32_t byte_offset = PNANOVDB_GRID_TYPE_GET(grid_type, root_off_background);
+    return pnanovdb_address_offset(root.address, byte_offset);
+}
 
 PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_root_get_min_address(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_root_handle_t root)
 {
@@ -2589,12 +2774,6 @@ PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_lower_get_value_address_and_ca
 {
     pnanovdb_uint32_t level;
     return pnanovdb_lower_get_value_address_and_level_and_cache(grid_type, buf, lower, ijk, acc, PNANOVDB_REF(level));
-}
-
-PNANOVDB_FORCE_INLINE void pnanovdb_lower_set_table_child(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_lower_handle_t node, pnanovdb_uint32_t n, pnanovdb_int64_t child)
-{
-    pnanovdb_address_t table_address = pnanovdb_lower_get_table_address(grid_type, buf, node, n);
-    pnanovdb_write_int64(buf, table_address, child);
 }
 
 PNANOVDB_FORCE_INLINE pnanovdb_address_t pnanovdb_upper_get_value_address_and_level_and_cache(pnanovdb_grid_type_t grid_type, pnanovdb_buf_t buf, pnanovdb_upper_handle_t upper, PNANOVDB_IN(pnanovdb_coord_t) ijk, PNANOVDB_INOUT(pnanovdb_readaccessor_t) acc, PNANOVDB_INOUT(pnanovdb_uint32_t) level)
@@ -3227,6 +3406,19 @@ PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_hdda_update(PNANOVDB_INOUT(pnanov
     {
         return PNANOVDB_FALSE;
     }
+
+    // compute valid voxel range
+    pnanovdb_coord_t voxel_max = {
+        (PNANOVDB_DEREF(hdda).voxel.x + PNANOVDB_DEREF(hdda).dim - 1) & (~(dim - 1)),
+        (PNANOVDB_DEREF(hdda).voxel.y + PNANOVDB_DEREF(hdda).dim - 1) & (~(dim - 1)),
+        (PNANOVDB_DEREF(hdda).voxel.z + PNANOVDB_DEREF(hdda).dim - 1) & (~(dim - 1))
+    };
+    pnanovdb_coord_t voxel_min = {
+        PNANOVDB_DEREF(hdda).voxel.x & (~(dim - 1)),
+        PNANOVDB_DEREF(hdda).voxel.y & (~(dim - 1)),
+        PNANOVDB_DEREF(hdda).voxel.z & (~(dim - 1))
+    };
+
     PNANOVDB_DEREF(hdda).dim = dim;
 
     pnanovdb_vec3_t pos = pnanovdb_vec3_add(
@@ -3236,6 +3428,14 @@ PNANOVDB_FORCE_INLINE pnanovdb_bool_t pnanovdb_hdda_update(PNANOVDB_INOUT(pnanov
     pnanovdb_vec3_t dir_inv = pnanovdb_vec3_div(pnanovdb_vec3_uniform(1.f), PNANOVDB_DEREF(direction));
 
     PNANOVDB_DEREF(hdda).voxel = pnanovdb_hdda_pos_to_voxel(PNANOVDB_REF(pos), dim);
+
+    // clamp voxel to valid range
+    PNANOVDB_DEREF(hdda).voxel.x = PNANOVDB_DEREF(hdda).voxel.x < voxel_max.x ? PNANOVDB_DEREF(hdda).voxel.x : voxel_max.x;
+    PNANOVDB_DEREF(hdda).voxel.y = PNANOVDB_DEREF(hdda).voxel.y < voxel_max.y ? PNANOVDB_DEREF(hdda).voxel.y : voxel_max.y;
+    PNANOVDB_DEREF(hdda).voxel.z = PNANOVDB_DEREF(hdda).voxel.z < voxel_max.z ? PNANOVDB_DEREF(hdda).voxel.z : voxel_max.z;
+    PNANOVDB_DEREF(hdda).voxel.x = PNANOVDB_DEREF(hdda).voxel.x > voxel_min.x ? PNANOVDB_DEREF(hdda).voxel.x : voxel_min.x;
+    PNANOVDB_DEREF(hdda).voxel.y = PNANOVDB_DEREF(hdda).voxel.y > voxel_min.y ? PNANOVDB_DEREF(hdda).voxel.y : voxel_min.y;
+    PNANOVDB_DEREF(hdda).voxel.z = PNANOVDB_DEREF(hdda).voxel.z > voxel_min.z ? PNANOVDB_DEREF(hdda).voxel.z : voxel_min.z;
 
     if (PNANOVDB_DEREF(hdda).step.x != 0)
     {

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceBuffer.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceBuffer.h
@@ -8,7 +8,7 @@
 
     \date January 8, 2020
 
-    \brief Implements a simple dual (host/device) CUDA buffer.
+    \brief DeviceBuffer has one pinned host buffer and multiple device CUDA buffers
 
     \note This file has no device-only kernel functions,
           which explains why it's a .h and not .cuh file.
@@ -17,6 +17,8 @@
 #ifndef NANOVDB_CUDA_DEVICEBUFFER_H_HAS_BEEN_INCLUDED
 #define NANOVDB_CUDA_DEVICEBUFFER_H_HAS_BEEN_INCLUDED
 
+#include <cuda.h>
+#include <memory>// for std::shared_ptr
 #include <nanovdb/HostBuffer.h>// for BufferTraits
 #include <nanovdb/util/cuda/Util.h>// for cudaMalloc/cudaMallocManaged/cudaFree
 
@@ -34,44 +36,80 @@ namespace cuda {// =============================================================
 class DeviceBuffer
 {
     uint64_t mSize; // total number of bytes managed by this buffer (assumed to be identical for host and device)
-    void *mCpuData, *mGpuData; // raw pointers to the host and device buffers
-    bool mManaged;
+    void *mCpuData, **mGpuData; // raw pointers to the host and device buffers
+    int   mDeviceCount, mManaged;// if mManaged is non-zero this class is responsible for allocating and freeing memory buffers. Otherwise this is assumed to be handled externally
+
+    /// @brief Initialize buffer
+    /// @param size byte size of buffer to be initialized
+    /// @param device id of the device on which to initialize the buffer
+    /// @note All existing buffers are first cleared
+    /// @warning size is expected to be non-zero. Use clear() clear buffer!
+    void init(uint64_t size, int device, cudaStream_t stream);
 
 public:
-    /// @brief Static factory method that return an instance of this buffer
-    /// @param size byte size of buffer to be initialized
-    /// @param dummy this argument is currently ignored but required to match the API of the HostBuffer
-    /// @param host If true buffer is initialized only on the host/CPU, else on the device/GPU
-    /// @param stream optional stream argument (defaults to stream NULL)
-    /// @return An instance of this class using move semantics
-    static DeviceBuffer create(uint64_t size, const DeviceBuffer* dummy = nullptr, bool host = true, void* stream = nullptr);
 
-    /// @brief Static factory method that return an instance of this buffer that wraps externally managed memory
-    /// @param size byte size of buffer specified by external memory
-    /// @param cpuData pointer to externally managed host memory
-    /// @param gpuData pointer to externally managed device memory
-    /// @return An instance of this class using move semantics
-    static DeviceBuffer create(uint64_t size, void* cpuData, void* gpuData);
+    using PtrT = std::shared_ptr<DeviceBuffer>;
+
+    /// @brief Default constructor of an empty buffer
+    DeviceBuffer() : mSize(0), mCpuData(nullptr), mGpuData(nullptr), mDeviceCount(0), mManaged(0){}
+
+    /// @brief Constructor with a specified device and size
+    /// @param size byte size of buffer to be initialized
+    /// @param device id of the device on which to initialize the buffer
+    /// @param stream cuda stream
+    DeviceBuffer(uint64_t size, int device = cudaCpuDeviceId, cudaStream_t stream = 0) : DeviceBuffer()
+    {
+        this->init(size, device, stream);
+    }
 
     /// @brief Constructor
     /// @param size byte size of buffer to be initialized
-    /// @param host If true buffer is initialized only on the host/CPU, else on the device/GPU
+    /// @param host If true buffer is initialized only on the host/CPU, else on the current device/GPU
     /// @param stream optional stream argument (defaults to stream NULL)
-    DeviceBuffer(uint64_t size = 0, bool host = true, void* stream = nullptr)
-        : mSize(0)
-        , mCpuData(nullptr)
-        , mGpuData(nullptr)
-        , mManaged(false)
+    DeviceBuffer(uint64_t size, bool host, void* stream) : DeviceBuffer()
     {
-        if (size > 0) this->init(size, host, stream);
+        int device = cudaCpuDeviceId;
+        if (!host) cudaCheck(cudaGetDevice(&device));
+        this->init(size, device, reinterpret_cast<cudaStream_t>(stream));
     }
 
+    /// @brief Constructor for externally managed host and device buffers
+    /// @param size byte size of the two external buffers
+    /// @param cpuData host buffer, assumed to NOT be NULL
+    /// @param gpuData device buffer, assumed to NOT be NULL;
+    /// @note The device buffer, @c gpuData, will be associated
+    ///       with the current device ID given by cudaGetDevice
     DeviceBuffer(uint64_t size, void* cpuData, void* gpuData)
         : mSize(size)
         , mCpuData(cpuData)
-        , mGpuData(gpuData)
-        , mManaged(false)
+        , mManaged(0)
     {
+        cudaCheck(cudaGetDeviceCount(&mDeviceCount));
+        mGpuData = new void*[mDeviceCount]();// NULL initialization
+        NANOVDB_ASSERT(cpuData);
+        NANOVDB_ASSERT(gpuData);
+        int device = 0;
+        cudaCheck(cudaGetDevice(&device));
+        mGpuData[device] = gpuData;
+    }
+
+    /// @brief Constructor for externally managed host and multiple device buffers
+    /// @param size byte size of the two external buffers
+    /// @param cpuData host buffer, assumed to NOT be NULL
+    /// @param list list of device IDs and external device buffers, all assumed to not be NULL
+    DeviceBuffer(uint64_t size, void* cpuData, std::initializer_list<std::pair<int,void*>> list)
+        : mSize(size)
+        , mCpuData(cpuData)
+        , mManaged(0)
+    {
+        NANOVDB_ASSERT(cpuData);
+        cudaCheck(cudaGetDeviceCount(&mDeviceCount));
+        mGpuData = new void*[mDeviceCount]();// NULL initialization
+        for (auto &p : list) {
+            NANOVDB_ASSERT(p.first>=0 && p.first<mDeviceCount);
+            NANOVDB_ASSERT(p.second);
+            mGpuData[p.first] = p.second;
+        }
     }
 
     /// @brief Disallow copy-construction
@@ -82,138 +120,283 @@ public:
         : mSize(other.mSize)
         , mCpuData(other.mCpuData)
         , mGpuData(other.mGpuData)
+        , mDeviceCount(other.mDeviceCount)
         , mManaged(other.mManaged)
     {
-        other.mSize = 0;
-        other.mCpuData = nullptr;
-        other.mGpuData = nullptr;
-        other.mManaged = false;
+        other.mCpuData = other.mGpuData = nullptr;
+        other.mSize = other.mDeviceCount = other.mManaged = 0;
     }
+
+    /// @brief Copy-constructor from a HostBuffer
+    /// @param buffer host buffer from which to copy data
+    /// @param device id of the device on which to initialize the buffer
+    /// @param stream cuda stream
+    DeviceBuffer(const HostBuffer& buffer, int device = cudaCpuDeviceId, cudaStream_t stream = 0)
+        : DeviceBuffer(buffer.size(), device, stream)
+    {
+        if (mCpuData) {
+            cudaCheck(cudaMemcpy(mCpuData, buffer.data(), mSize, cudaMemcpyHostToHost));
+        } else if (mGpuData[device]) {
+            cudaCheck(cudaMemcpyAsync(mGpuData[device], buffer.data(), mSize, cudaMemcpyHostToDevice, stream));
+        }
+    }
+
+     /// @brief Destructor frees memory on both the host and device
+    ~DeviceBuffer() { this->clear(); };
+
+    /// @brief Static factory method that return an instance of this buffer
+    /// @param size byte size of buffer to be initialized
+    /// @param dummy this argument is currently ignored but required to match the API of the HostBuffer
+    /// @param host If true buffer is initialized only on the host/CPU, else only on the device/GPU
+    /// @param stream optional stream argument (defaults to stream NULL)
+    /// @return An instance of this class using move semantics
+    static DeviceBuffer create(uint64_t size, const DeviceBuffer* dummy, bool host, void* stream){return DeviceBuffer(size, host, stream);}
+
+    /// @brief Static factory method that returns an instance of this buffer
+    /// @param size byte size of buffer to be initialized
+    /// @param dummy this argument is currently ignored but required to match the API of the HostBuffer
+    /// @param device id of the device on which to initialize the buffer
+    /// @param stream cuda stream
+    static DeviceBuffer create(uint64_t size, const DeviceBuffer* dummy = nullptr, int device = cudaCpuDeviceId, cudaStream_t stream = 0){return DeviceBuffer(size, device, stream);}
+
+    /// @brief Static factory method that returns an instance of this buffer that wraps externally managed memory
+    /// @param size byte size of buffer specified by external memory
+    /// @param cpuData pointer to externally managed host memory
+    /// @param gpuData pointer to externally managed device memory
+    /// @return An instance of this class using move semantics
+    static DeviceBuffer create(uint64_t size, void* cpuData, void* gpuData) {return DeviceBuffer(size, cpuData, gpuData);}
+
+    /// @brief  Static factory method that returns an instance of this buffer that wraps externally managed host and device memory
+    /// @param size byte size of buffer to be initialized
+    /// @param cpuData  pointer to externally managed host memory
+    /// @param list list of device IDs and device memory pointers
+    static DeviceBuffer create(uint64_t size, void* cpuData, std::initializer_list<std::pair<int,void*>> list) {return DeviceBuffer(size, cpuData, list);}
+
+    /// @brief Static factory method that returns an instance of this buffer constructed from a HostBuffer
+    /// @param buffer host buffer from which to copy data
+    /// @param device id of the device on which to initialize the buffer
+    /// @param stream cuda stream
+    static DeviceBuffer create(const HostBuffer& buffer, int device = cudaCpuDeviceId, cudaStream_t stream = 0) {return DeviceBuffer(buffer, device, stream);}
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @{
+    /// @brief Factory methods that create a shared pointer to an DeviceBuffer instance
+    static PtrT createPtr(uint64_t size, const DeviceBuffer* = nullptr, int device = cudaCpuDeviceId, cudaStream_t stream = 0) {return std::make_shared<DeviceBuffer>(size, device, stream);}
+    static PtrT createPtr(uint64_t size, void* cpuData, void* gpuData) {return std::make_shared<DeviceBuffer>(size, cpuData, gpuData);}
+    static PtrT createPtr(uint64_t size, void* cpuData, std::initializer_list<std::pair<int,void*>> list) {return std::make_shared<DeviceBuffer>(size, cpuData, list);}
+    static PtrT createPtr(const HostBuffer& buffer, int device = cudaCpuDeviceId, cudaStream_t stream = 0) {return std::make_shared<DeviceBuffer>(buffer, device, stream);}
+    /// @}
+
+    ///////////////////////////////////////////////////////////////////////
 
     /// @brief Disallow copy assignment operation
     DeviceBuffer& operator=(const DeviceBuffer&) = delete;
 
     /// @brief Move copy assignment operation
-    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept
-    {
-        this->clear();
-        mSize = other.mSize;
-        mCpuData = other.mCpuData;
-        mGpuData = other.mGpuData;
-        mManaged = other.mManaged;
-        other.mSize = 0;
-        other.mCpuData = nullptr;
-        other.mGpuData = nullptr;
-        other.mManaged = false;
-        return *this;
-    }
+    DeviceBuffer& operator=(DeviceBuffer&& other) noexcept;
 
-    /// @brief Destructor frees memory on both the host and device
-    ~DeviceBuffer() { this->clear(); };
+    ///////////////////////////////////////////////////////////////////////
 
-    /// @brief Initialize buffer
-    /// @param size byte size of buffer to be initialized
-    /// @param host If true buffer is initialized only on the host/CPU, else on the device/GPU
-    /// @note All existing buffers are first cleared
-    /// @warning size is expected to be non-zero. Use clear() clear buffer!
-    void init(uint64_t size, bool host = true, void* stream = nullptr);
-
-    /// @brief Retuns a raw pointer to the host/CPU buffer managed by this allocator.
+    /// @brief Retuns a raw void pointer to the host/CPU buffer managed by this allocator.
     /// @warning Note that the pointer can be NULL!
     void* data() const { return mCpuData; }
 
-    /// @brief Retuns a raw pointer to the device/GPU buffer managed by this allocator.
+    /// @brief Returns an offset pointer of a specific type from the allocated host memory
+    /// @tparam T Type of the pointer returned
+    /// @param count Numbers of elements of @c parameter type T to skip
+    /// @warning might return NULL
+    template <typename T>
+    T* data(ptrdiff_t count = 0, int device = cudaCpuDeviceId) const
+    {
+        NANOVDB_ASSERT(device >= cudaCpuDeviceId && device < mDeviceCount);
+        void *ptr = device == cudaCpuDeviceId ? mCpuData : mGpuData[device];
+        return ptr ? reinterpret_cast<T*>(ptr) + count : nullptr;
+    }
+
+    /// @brief Returns a byte offset void pointer from the allocated host memory
+    /// @param byteOffset offset of return pointer in units of bytes
+    /// @warning assumes that this instance is not empty!
+    void* data(ptrdiff_t byteOffset, int device = cudaCpuDeviceId) const
+    {
+        NANOVDB_ASSERT(device >= cudaCpuDeviceId && device < mDeviceCount);
+        void *ptr = device == cudaCpuDeviceId ? mCpuData : mGpuData[device];
+        return ptr ? reinterpret_cast<char*>(ptr) + byteOffset : nullptr;
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Retuns a raw pointer to the specified device/GPU buffer managed by this allocator.
     /// @warning Note that the pointer can be NULL!
-    void* deviceData() const { return mGpuData; }
+    void* deviceData(int device) const {
+        NANOVDB_ASSERT(device >= 0 && device < mDeviceCount);
+        return mGpuData[device];
+    }
 
-    /// @brief  Upload this buffer from the host to the device, i.e. CPU -> GPU.
-    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
-    /// @param sync if false the memory copy is asynchronous
-    /// @note If the device/GPU buffer does not exist it is first allocated
-    /// @warning Assumes that the host/CPU buffer already exists
-    void deviceUpload(void* stream = nullptr, bool sync = true) const;
+    /// @brief Retuns a raw pointer to the current device/GPU buffer managed by this allocator.
+    /// @warning Note that the pointer can be NULL!
+    void* deviceData() const {
+        int device = cudaCpuDeviceId;
+        cudaCheck(cudaGetDevice(&device));
+        return this->deviceData(device);
+    }
 
-    /// @brief Upload this buffer from the device to the host, i.e. GPU -> CPU.
-    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Uploads buffer on the host to a specific device. If it doesn't exist it's created first.
+    /// @param device Device ID that the data is copied to
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous.
+    /// @warning Assumes that the host buffer already exists!
+    /// @note determine the current device with cudaGetDevice
+    void deviceUpload(int device = 0, cudaStream_t stream = 0, bool sync = true);
+    void deviceUpload(int device, void* stream, bool sync){this->deviceUpload(device, cudaStream_t(stream), sync);}
+
+    /// @brief Upload buffer from the host to ALL the existing devices, i.e. CPU -> GPU.
+    ///        If no device buffers exist one is created for the current device (typically 0)
+    ///        and subsequently populated with the host data.
+    /// @param stream CUDA stream.
+    /// @param sync if false the memory copy is asynchronous.
+    /// @warning Assumes that the host buffer already exists!
+    void deviceUpload(cudaStream_t stream, bool sync);
+    void deviceUpload(void* stream, bool sync) {this->deviceUpload(cudaStream_t(stream), sync);}
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Download data from a specified device to the host. If the host buffer des not exist it will first be allocated
+    /// @param device device ID to download source data from
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous.
+    /// @warning Assumes that the specifed device buffer already exists!
+    void deviceDownload(int device = 0, cudaStream_t stream = 0, bool sync = true);
+    void deviceDownload(int device, void* stream , bool sync) {this->deviceDownload(device, cudaStream_t(stream), sync);}
+
+    /// @brief Download the buffer from the current device to the host, i.e. GPU -> CPU.
+    ///        If the host buffer des not exist it will first be allocated
+    /// @param stream CUDA stream
     /// @param sync if false the memory copy is asynchronous
     /// @note If the host/CPU buffer does not exist it is first allocated
     /// @warning Assumes that the device/GPU buffer already exists
-    void deviceDownload(void* stream = nullptr, bool sync = true) const;
+    void deviceDownload(void* stream, bool sync);
+
+    ///////////////////////////////////////////////////////////////////////
 
     /// @brief Returns the size in bytes of the raw memory buffer managed by this allocator.
     uint64_t size() const { return mSize; }
+    uint64_t capacity() const {return this->size();}
 
-    //@{
+    /// @brief Returns the number of buffers that are not NULL
+    int bufferCount() const {
+        int count = mCpuData ? 1 : 0;
+        for (int i=0; i<mDeviceCount; ++i) if (mGpuData[i]) ++count;
+        return count;
+    }
+
+    int deviceCount() const {return mDeviceCount;}
+
+    /// @{
     /// @brief Returns true if this allocator is empty, i.e. has no allocated memory
     bool empty() const { return mSize == 0; }
-    bool isEmpty() const { return mSize == 0; }
-    //@}
+    bool isEmpty() const { return this->empty(); }
+    /// @}
 
     /// @brief De-allocate all memory managed by this allocator and set all pointers to NULL
-    void clear(void* stream = nullptr);
+    void clear(cudaStream_t stream = 0);
+    void clear(void* stream){this->clear(cudaStream_t(stream));}
 
 }; // DeviceBuffer class
 
 // --------------------------> Implementations below <------------------------------------
 
-inline DeviceBuffer DeviceBuffer::create(uint64_t size, const DeviceBuffer*, bool host, void* stream)
+inline DeviceBuffer& DeviceBuffer::operator=(DeviceBuffer&& other) noexcept
 {
-    return DeviceBuffer(size, host, stream);
+    if (mManaged) {// first free all the managed data buffers
+        cudaCheck(cudaFreeHost(mCpuData));
+        for (int i=0; i<mDeviceCount; ++i) cudaCheck(util::cuda::freeAsync(mGpuData[i], 0));
+    }
+    delete [] mGpuData;
+    mSize    = other.mSize;
+    mCpuData = other.mCpuData;
+    mGpuData = other.mGpuData;
+    mDeviceCount = other.mDeviceCount;
+    mManaged = other.mManaged;
+    other.mCpuData = nullptr;
+    other.mGpuData = nullptr;
+    other.mSize = 0;
+    other.mDeviceCount = 0;
+    other.mManaged = 0;
+    return *this;
 }
 
-inline DeviceBuffer DeviceBuffer::create(uint64_t size, void* cpuData, void* gpuData)
+inline void DeviceBuffer::init(uint64_t size, int device, cudaStream_t stream)
 {
-    return DeviceBuffer(size, cpuData, gpuData);
-}
-
-inline void DeviceBuffer::init(uint64_t size, bool host, void* stream)
-{
-    if (mSize>0) this->clear(stream);
-    NANOVDB_ASSERT(size > 0);
-    if (host) {
+    if (size==0) return;
+    cudaCheck(cudaGetDeviceCount(&mDeviceCount));
+    mGpuData = new void*[mDeviceCount]();// NULL initialization
+    NANOVDB_ASSERT(device >= cudaCpuDeviceId && device < mDeviceCount);
+    if (device == cudaCpuDeviceId) {
         cudaCheck(cudaMallocHost((void**)&mCpuData, size)); // un-managed pinned memory on the host (can be slow to access!). Always 32B aligned
         checkPtr(mCpuData, "cuda::DeviceBuffer::init: failed to allocate host buffer");
     } else {
-        cudaCheck(util::cuda::mallocAsync((void**)&mGpuData, size, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
-        checkPtr(mGpuData, "cuda::DeviceBuffer::init: failed to allocate device buffer");
+        cudaCheck(util::cuda::mallocAsync(mGpuData+device, size, stream)); // un-managed memory on the device, always 32B aligned!
+        checkPtr(mGpuData[device], "cuda::DeviceBuffer::init: failed to allocate device buffer");
     }
     mSize = size;
-    mManaged = true;
+    mManaged = 1;// i.e. this instance is responsible for allocating and delete memory
 } // DeviceBuffer::init
 
-inline void DeviceBuffer::deviceUpload(void* stream, bool sync) const
+inline void DeviceBuffer::deviceUpload(int device, cudaStream_t stream, bool sync)
 {
-    if (!mManaged) throw std::runtime_error("DeviceBuffer::deviceUpload called on externally managed memory. Replace deviceUpload call with the appropriate external copy operation.");
-
-    checkPtr(mCpuData, "uninitialized cpu data");
-    if (mGpuData == nullptr) {
-        cudaCheck(util::cuda::mallocAsync((void**)&mGpuData, mSize, reinterpret_cast<cudaStream_t>(stream))); // un-managed memory on the device, always 32B aligned!
+    NANOVDB_ASSERT(device >= 0 && device < mDeviceCount);// should be device and not the host
+    checkPtr(mCpuData, "uninitialized cpu source data");
+    if (mGpuData[device] == nullptr) {
+        if (mManaged==0) throw std::runtime_error("DeviceBuffer::deviceUpload called on externally managed memory that wasn\'t allocated.");
+        cudaCheck(util::cuda::mallocAsync(mGpuData+device, mSize, stream)); // un-managed memory on the device, always 32B aligned!
     }
-    checkPtr(mGpuData, "uninitialized gpu data");
-    cudaCheck(cudaMemcpyAsync(mGpuData, mCpuData, mSize, cudaMemcpyHostToDevice, reinterpret_cast<cudaStream_t>(stream)));
-    if (sync) cudaCheck(cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(stream)));
-} // DeviceBuffer::gpuUpload
+    checkPtr(mGpuData[device], "uninitialized gpu destination data");
+    cudaCheck(cudaMemcpyAsync(mGpuData[device], mCpuData, mSize, cudaMemcpyHostToDevice, stream));
+    if (sync) cudaCheck(cudaStreamSynchronize(stream));
+} // DeviceBuffer::deviceUpload
 
-inline void DeviceBuffer::deviceDownload(void* stream, bool sync) const
+inline void DeviceBuffer::deviceUpload(cudaStream_t stream, bool sync)
 {
-    if (!mManaged) throw std::runtime_error("DeviceBuffer::deviceDownload called on externally managed memory. Replace deviceDownload call with the appropriate external copy operation.");
+    int device = 0;
+    cudaGetDevice(&device);
+    this->deviceUpload(device, stream, sync);
+} // DeviceBuffer::deviceUpload
 
-    checkPtr(mGpuData, "uninitialized gpu data");
+inline void DeviceBuffer::deviceDownload(int device, cudaStream_t stream, bool sync)
+{
+    NANOVDB_ASSERT(device >= 0 && device < mDeviceCount);
+    checkPtr(mGpuData[device], "uninitialized gpu source data");// no source data on the specified device
     if (mCpuData == nullptr) {
+        if (mManaged==0) throw std::runtime_error("DeviceBuffer::deviceDownload called on uninitialized cpu destination memory that is externally managed.");
         cudaCheck(cudaMallocHost((void**)&mCpuData, mSize)); // un-managed pinned memory on the host (can be slow to access!). Always 32B aligned
     }
-    checkPtr(mCpuData, "uninitialized cpu data");
-    cudaCheck(cudaMemcpyAsync(mCpuData, mGpuData, mSize, cudaMemcpyDeviceToHost, reinterpret_cast<cudaStream_t>(stream)));
-    if (sync) cudaCheck(cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(stream)));
-} // DeviceBuffer::gpuDownload
+    checkPtr(mCpuData, "uninitialized cpu destination data");
+    cudaCheck(cudaMemcpyAsync(mCpuData, mGpuData[device], mSize, cudaMemcpyDeviceToHost, stream));
+    if (sync) cudaCheck(cudaStreamSynchronize(stream));
+} // DeviceBuffer::deviceDownload
 
-inline void DeviceBuffer::clear(void *stream)
+inline void DeviceBuffer::deviceDownload(void* stream, bool sync)
 {
-    if (mManaged && mGpuData) cudaCheck(util::cuda::freeAsync(mGpuData, reinterpret_cast<cudaStream_t>(stream)));
-    if (mManaged && mCpuData) cudaCheck(cudaFreeHost(mCpuData));
-    mCpuData = mGpuData = nullptr;
+    int device = 0;
+    cudaCheck(cudaGetDevice(&device));
+    this->deviceDownload(device, cudaStream_t(stream), sync);
+} // DeviceBuffer::deviceDownload
+
+inline void DeviceBuffer::clear(cudaStream_t stream)
+{
+    if (mManaged) {// free all the managed data buffers
+        cudaCheck(cudaFreeHost(mCpuData));
+        for (int i=0; i<mDeviceCount; ++i) cudaCheck(util::cuda::freeAsync(mGpuData[i], stream));
+    }
+    delete [] mGpuData;
+    mCpuData = nullptr;
+    mGpuData = nullptr;
     mSize = 0;
-    mManaged = false;
+    mDeviceCount = 0;
+    mManaged = 0;
 } // DeviceBuffer::clear
 
 }// namespace cuda

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceMesh.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceMesh.h
@@ -1,0 +1,229 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file DeviceMesh.h
+
+    \brief nanovdb::cuda::DeviceMesh encapsulates device IDs, CUDA streams,
+           and NCCL communicators in order to facilitate multi-GPU applications.
+*/
+
+#ifndef NANOVDB_CUDA_DEVICEMESH_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_DEVICEMESH_H_HAS_BEEN_INCLUDED
+
+#include <vector>
+#include <algorithm>
+#include <thread>
+
+#include <nanovdb/util/cuda/Util.h>
+#ifdef NANOVDB_USE_NCCL
+#include <nccl.h>
+#endif
+
+namespace nanovdb {
+
+namespace cuda {
+
+namespace detail {
+
+/// @brief RAII class that caches/restores the current device at construction/destruction
+class DeviceGuard {
+    public:
+        DeviceGuard() { cudaGetDevice(&deviceId); }
+        ~DeviceGuard() { cudaSetDevice(deviceId); }
+
+        /// @{
+        /// @brief DeviceGuard is not copyable nor movable
+        DeviceGuard(const DeviceGuard&) = delete;
+        DeviceGuard& operator=(const DeviceGuard&) = delete;
+        DeviceGuard(DeviceGuard&& other) = delete;
+        DeviceGuard& operator=(DeviceGuard&& other) = delete;
+        /// @}
+    private:
+        int deviceId = -1;
+};
+
+}
+
+/// @brief POD struct representing a device id and a stream on that device
+struct DeviceNode
+{
+    int id = -1;
+    cudaStream_t stream = cudaStream_t(0);
+};
+
+/// @brief This class wraps a vector of per-device IDs and CUDA streams and holds inter-device connectivity information and NCCL comms.
+class DeviceMesh
+{
+    using DeviceVecT = std::vector<DeviceNode>;
+    using const_iterator = DeviceVecT::const_iterator;
+    using size_type = DeviceVecT::size_type;
+public:
+    /// @brief Constructs a device mesh for all devices on the host and initializes a CUDA stream (and NCCL communicator) for each device
+    DeviceMesh();
+    /// @brief Destroys the per-device CUDA stream and finalizes and destroys the per-device NCCL communicators
+    ~DeviceMesh();
+    /// @brief Disallow copy-construction
+    DeviceMesh(const DeviceMesh&) = delete;
+    /// @brief Move constructor.  Underlying CUDA streams and NCCL communicators are not reinitialized.
+    /// @param DeviceMesh instance that will be moved into this DeviceMesh.
+    DeviceMesh(DeviceMesh&&) noexcept;
+    /// @brief Disallow copy-assignment
+    DeviceMesh& operator=(const DeviceMesh&) = delete;
+    /// @brief Move assignment. Underlying CUDA streams and NCCL communicators are not reinitialized.
+    /// @param DeviceMesh instance that will be moved into this DeviceMesh.
+    DeviceMesh& operator=(DeviceMesh&&) noexcept;
+
+    /// @brief Returns the number of devices
+    size_type deviceCount() const { return mDeviceNodes.size(); };
+
+    /// @brief Returns a const reference to the DeviceNode for a particular device
+    const DeviceNode& operator [](int deviceId) const { return mDeviceNodes[deviceId]; }
+
+    /// @brief Returns an iterator to the first device node
+    const_iterator begin() const { return mDeviceNodes.begin(); };
+    /// @brief Returns an iterator past the last device node
+    const_iterator end() const { return mDeviceNodes.end(); };
+
+#ifdef NANOVDB_USE_NCCL
+    /// @brief Returns the NCCL communicator for a particular device
+    ncclComm_t comm(int deviceId) const { return mComms[deviceId]; }
+#endif
+
+    /// @brief Returns whether or not peer to peer access is supported between two devices.
+    bool canAccessPeer(int deviceId, int peerId) const { return mConnectivity[deviceId][peerId] & (1 << cudaDevP2PAttrAccessSupported); }
+
+private:
+    /// @brief Returns whether or not a device supports managed memory
+    bool hasManagedMemory(int deviceId) const {
+        int managedMemoryValue = 0;
+        cudaDeviceGetAttribute(&managedMemoryValue, cudaDevAttrManagedMemory, deviceId);
+        return static_cast<bool>(managedMemoryValue);
+    }
+
+    DeviceVecT mDeviceNodes;
+
+#ifdef NANOVDB_USE_NCCL
+    std::vector<ncclComm_t> mComms;
+#endif
+    std::vector<std::vector<uint32_t>> mConnectivity;
+};
+
+inline DeviceMesh::DeviceMesh()
+{
+    detail::DeviceGuard deviceGuard;
+
+    int deviceCount = -1;
+    cudaGetDeviceCount(&deviceCount);
+
+    for (int deviceId = 0; deviceId < deviceCount; ++deviceId) {
+        NANOVDB_ASSERT(hasManagedMemory(deviceId));
+        cudaSetDevice(deviceId);
+        cudaStream_t stream;
+        cudaStreamCreate(&stream);
+        mDeviceNodes.push_back({deviceId, stream});
+    }
+
+#ifdef NANOVDB_USE_NCCL
+    mComms.resize(deviceCount);
+    ncclCommInitAll(mComms.data(), deviceCount, nullptr);
+#endif
+
+    mConnectivity.resize(deviceCount);
+    for (const auto& deviceNode : mDeviceNodes) {
+        mConnectivity[deviceNode.id].resize(deviceCount);
+        for (const auto& peerNode : mDeviceNodes) {
+            mConnectivity[deviceNode.id][peerNode.id] = 0;
+            if (deviceNode.id != peerNode.id) {
+                int peerAccessSupportedValue = 0;
+                cudaDeviceGetP2PAttribute(&peerAccessSupportedValue, cudaDevP2PAttrAccessSupported, deviceNode.id, peerNode.id);
+                if (peerAccessSupportedValue) {
+                    mConnectivity[deviceNode.id][peerNode.id] |= (1 << cudaDevP2PAttrAccessSupported);
+                }
+            }
+        }
+    }
+}
+
+inline DeviceMesh::DeviceMesh(DeviceMesh&& other) noexcept
+    : mDeviceNodes(std::move(other.mDeviceNodes)),
+#ifdef NANOVDB_USE_NCCL
+      mComms(std::move(other.mComms)),
+#endif
+      mConnectivity(std::move(other.mConnectivity))
+{
+}
+
+inline DeviceMesh::~DeviceMesh()
+{
+    detail::DeviceGuard deviceGuard;
+
+#ifdef NANOVDB_USE_NCCL
+    std::for_each(mComms.begin(), mComms.end(), [](ncclComm_t comm) {
+        ncclCommFinalize(comm);
+        ncclCommDestroy(comm);
+    });
+#endif
+
+    std::for_each(mDeviceNodes.begin(), mDeviceNodes.end(), [](DeviceNode& deviceNode) {
+        cudaSetDevice(deviceNode.id);
+        cudaStreamDestroy(deviceNode.stream);
+    });
+}
+
+inline DeviceMesh& DeviceMesh::operator=(DeviceMesh&& other) noexcept
+{
+    mDeviceNodes = std::move(other.mDeviceNodes);
+#ifdef NANOVDB_USE_NCCL
+    mComms = std::move(other.mComms);
+#endif
+    mConnectivity = std::move(other.mConnectivity);
+    return *this;
+}
+
+namespace detail {
+
+inline void* queryAllocationGranularityEntryPoint()
+{
+    void* entryPoint = nullptr;
+#if CUDART_VERSION >= 12500 // cudaGetDriverEntryPointByVersion was added in CUDA 12.5 with cudaGetDriverEntryPoint being potentially deprecated
+    cudaDriverEntryPointQueryResult queryResult = cudaDriverEntryPointSymbolNotFound;
+    cudaCheck(cudaGetDriverEntryPointByVersion("cuMemGetAllocationGranularity", &entryPoint, 12000, cudaEnableDefault, &queryResult));
+    NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);
+#elif CUDART_VERSION >= 12000 // queryResult argument was added in CUDA 12
+    cudaDriverEntryPointQueryResult queryResult = cudaDriverEntryPointSymbolNotFound;
+    cudaCheck(cudaGetDriverEntryPoint("cuMemGetAllocationGranularity", &entryPoint, cudaEnableDefault, &queryResult));
+    NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);
+#else
+    cudaCheck(cudaGetDriverEntryPoint("cuMemGetAllocationGranularity", &entryPoint, cudaEnableDefault));
+#endif
+    return entryPoint;
+}// queryAllocationGranularityEntryPoint
+
+}
+
+/// @brief Returns the minimum page size (in bytes) across all devices on the system
+inline size_t minDevicePageSize(const DeviceMesh& mesh)
+{
+    using FuncT = CUresult(size_t*, const CUmemAllocationProp*, CUmemAllocationGranularity_flags);
+    static FuncT* functPtr = reinterpret_cast<FuncT*>(detail::queryAllocationGranularityEntryPoint());
+
+    NANOVDB_ASSERT(functPtr);
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    size_t minGranularity = 0;
+    for (const auto& node : mesh) {
+        prop.location.id = node.id;
+        size_t granularity = 0;
+        (*functPtr)(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+        if (minGranularity < granularity) minGranularity = granularity;
+    }
+    return minGranularity;
+}// minDevicePageSize
+
+} // namespace cuda
+
+} // namespace nanovdb
+
+#endif // end of NANOVDB_CUDA_DEVICEMESH_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceResource.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceResource.h
@@ -1,0 +1,35 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef NANOVDB_CUDA_DEVICERESOURCE_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_DEVICERESOURCE_H_HAS_BEEN_INCLUDED
+
+#include <cuda_runtime_api.h>
+#include <nanovdb/util/cuda/Util.h>
+
+namespace nanovdb {
+
+namespace cuda {
+
+class DeviceResource
+{
+public:
+    // cudaMalloc aligns memory to 256 bytes by default
+    static constexpr size_t DEFAULT_ALIGNMENT = 256;
+
+    static void* allocateAsync(size_t bytes, size_t, cudaStream_t stream) {
+        void* p = nullptr;
+        cudaCheck(util::cuda::mallocAsync(&p, bytes, stream));
+        return p;
+    }
+
+    static void deallocateAsync(void *p, size_t, size_t, cudaStream_t stream) {
+        cudaCheck(util::cuda::freeAsync(p, stream));
+    }
+};
+
+}
+
+} // namespace nanovdb::cuda
+
+#endif // end of NANOVDB_CUDA_DEVICERESOURCE_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceStreamMap.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/DeviceStreamMap.h
@@ -1,0 +1,124 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file DeviceStreamMap.h
+
+    \author Ken Museth
+
+    \date October 15, 2024
+
+    \brief nanovdb::cuda::DeviceStreamMap maps device IDs to CUDA streams,
+           which is useful for multi-GPU applications.
+*/
+
+#ifndef NANOVDB_CUDA_DEVICESTREAMMAP_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_DEVICESTREAMMAP_H_HAS_BEEN_INCLUDED
+
+#include <cuda.h>
+#include <map>
+#include <vector>
+#include <nanovdb/util/cuda/Util.h>// for cudaCheck, deviceCount etc
+
+namespace nanovdb {// ================================================================
+
+namespace cuda {// ===================================================================
+
+/// @brief map from a device ID to an associated cuda stream. Useful for multi-GPU applications.
+class DeviceStreamMap : public std::map<int, cudaStream_t>
+{
+     using FuncT = CUresult(size_t*, const CUmemAllocationProp*, CUmemAllocationGranularity_flags);
+     FuncT *mFunctPtr;
+
+public:
+
+    enum DeviceType { Any = 0, PeerToPeer = 1, Unified = 3 };
+
+    /// @brief Initiates a map between CUDA device IDs and corresponding streams that satisfy certain constraints.
+    ///        All devices should be able to access memory on all the other devices!
+    /// @param t Type of device to include in map. Any means all available devices, PeerToPeer means only devices that
+    ///          access all another devices are included, and Unified means all devices support unified memory, concurrent access,
+    ///          and can be access by all other devices.
+    /// @param exclude optional list of device IDs to exclude from the map
+    /// @param verbose  0 means quiet, 1 means print if a device is ignores and 2 means print is a device is included
+    DeviceStreamMap(DeviceType t = DeviceType::Unified, std::vector<int> exclude = {}, int verbose = 0);
+
+    /// @brief Destructor
+    ~DeviceStreamMap();
+
+    /// @brief returns the minimum page size of all the devices in this map
+    size_t getMinPageSize() const;
+
+    /// @brief Print information about all the devices included in this map
+    void printDevInfo(std::FILE* file = stdout) const {for (auto &p : *this) util::cuda::printDevInfo(p.first, nullptr, file);}
+
+    /// @brief Returns the number of device associated with this map
+    int deviceCount() const {return this->size();}
+
+};// DeviceStreamMap
+
+DeviceStreamMap::DeviceStreamMap(DeviceType t, std::vector<int> exclude, int verbose)
+{
+    std::initializer_list<cudaDeviceAttr> filter = {cudaDevAttrUnifiedAddressing, cudaDevAttrConcurrentManagedAccess};
+    const int devCount = util::cuda::deviceCount(), current = util::cuda::currentDevice();
+    for (int dev = 0; dev < devCount; ++dev) {
+        int check = 1;
+        for (auto it=exclude.begin();         check && it!=exclude.end(); ++it) if (dev == *it) check = 0;
+        for (auto it=filter.begin(); (t&2) && check && it!=filter.end(); ++it) cudaCheck(cudaDeviceGetAttribute( &check, *it, dev));
+        for (auto it= this->begin(); (t&1) && check && it!= this->end(); ++it) cudaCheck(cudaDeviceCanAccessPeer(&check, dev, it->first));
+        if (check) {
+            cudaCheck(cudaSetDevice(dev));
+            cudaStream_t stream;
+            cudaCheck(cudaStreamCreate(&stream));
+            if (verbose>1) util::cuda::printDevInfo(dev, "Using");
+            (*this)[dev] = stream;
+        } else if (verbose) util::cuda::printDevInfo(dev, "Ignoring");
+    }
+    cudaCheck(cudaSetDevice(current));// reset to the previous device
+
+    void* entryPoint = nullptr;
+#if CUDART_VERSION >= 13000
+    cudaDriverEntryPointQueryResult queryResult;
+    cudaCheck(cudaGetDriverEntryPointByVersion("cuMemGetAllocationGranularity", &entryPoint, 13000, cudaEnableDefault, &queryResult));
+    NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);
+#elif CUDART_VERSION >= 12000// queryResult argument was added in CUDA 12
+    cudaDriverEntryPointQueryResult queryResult;
+    cudaCheck(cudaGetDriverEntryPoint("cuMemGetAllocationGranularity", &entryPoint, cudaEnableDefault, &queryResult));
+    NANOVDB_ASSERT(queryResult == cudaDriverEntryPointSuccess);
+#else
+    cudaCheck(cudaGetDriverEntryPoint("cuMemGetAllocationGranularity", &entryPoint, cudaEnableDefault));
+#endif
+    mFunctPtr = reinterpret_cast<FuncT*>(entryPoint);
+}// DeviceStreamMap::DeviceStreamMap
+
+DeviceStreamMap::~DeviceStreamMap()
+{
+    const int current = util::cuda::currentDevice();
+    for (auto& [device, stream] : *this) {
+        cudaCheck(cudaSetDevice(device));
+        cudaCheck(cudaStreamDestroy(stream));
+    }
+    cudaCheck(cudaSetDevice(current));// reset to the previous device
+}
+
+inline size_t DeviceStreamMap::getMinPageSize() const
+{
+    NANOVDB_ASSERT(mFunctPtr);
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    size_t minGranularity = 0;
+    for (auto it = this->begin(); it!=this->end(); ++it) {
+        prop.location.id = it->first;
+        size_t granularity = 0;
+        (*mFunctPtr)(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+        if (minGranularity < granularity) minGranularity = granularity;
+    }
+    return minGranularity;
+}// DeviceStreamMap::getMinPageSize
+
+}// namespace cuda
+
+}// namespace nanovdb
+
+#endif // end of NANOVDB_CUDA_DEVICESTREAMMAP_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/GridHandle.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/GridHandle.cuh
@@ -25,22 +25,25 @@ namespace nanovdb {
 
 namespace cuda {
 
-namespace {// anonymous namespace
-__global__ void cpyGridHandleMeta(const GridData *d_data, GridHandleMetaData *d_meta)
+namespace detail {
+
+static __global__ void cpyGridHandleMeta(const GridData *d_data, GridHandleMetaData *d_meta)
 {
     nanovdb::cpyGridHandleMeta(d_data, d_meta);
 }
 
-__global__ void updateGridCount(GridData *d_data, uint32_t gridIndex, uint32_t gridCount, bool *d_dirty)
+static __global__ void updateGridCount(GridData *d_data, uint32_t gridIndex, uint32_t gridCount, bool *d_dirty)
 {
     NANOVDB_ASSERT(gridIndex < gridCount);
-    if (*d_dirty = d_data->mGridIndex != gridIndex || d_data->mGridCount != gridCount) {
+    *d_dirty = (d_data->mGridIndex != gridIndex) || (d_data->mGridCount != gridCount);
+    if (*d_dirty) {
         d_data->mGridIndex = gridIndex;
         d_data->mGridCount = gridCount;
         if (d_data->mChecksum.isEmpty()) *d_dirty = false;// no need to update checksum if it didn't already exist
     }
 }
-}// anonymous namespace
+
+}// namespace detail
 
 template<typename BufferT, template <class, class...> class VectorT = std::vector>
 inline typename util::enable_if<BufferTraits<BufferT>::hasDeviceDual, VectorT<GridHandle<BufferT>>>::type
@@ -51,20 +54,22 @@ splitGridHandles(const GridHandle<BufferT> &handle, const BufferT* other = nullp
     VectorT<GridHandle<BufferT>> handles(handle.gridCount());
     bool dirty, *d_dirty;// use this to check if the checksum needs to be recomputed
     cudaCheck(util::cuda::mallocAsync((void**)&d_dirty, sizeof(bool), stream));
+    int device = util::cuda::currentDevice();
     for (uint32_t n=0; n<handle.gridCount(); ++n) {
-        auto buffer = BufferT::create(handle.gridSize(n), other, false, stream);
+        auto buffer = BufferT::create(handle.gridSize(n), other, device, stream);
         GridData *dst = reinterpret_cast<GridData*>(buffer.deviceData());
         const GridData *src = reinterpret_cast<const GridData*>(ptr);
         cudaCheck(cudaMemcpyAsync(dst, src, handle.gridSize(n), cudaMemcpyDeviceToDevice, stream));
-        updateGridCount<<<1, 1, 0, stream>>>(dst, 0u, 1u, d_dirty);
+        detail::updateGridCount<<<1, 1, 0, stream>>>(dst, 0u, 1u, d_dirty);
         cudaCheckError();
         cudaCheck(cudaMemcpyAsync(&dirty, d_dirty, sizeof(bool), cudaMemcpyDeviceToHost, stream));
+        cudaCheck(cudaStreamSynchronize(stream));
         if (dirty) tools::cuda::updateChecksum(dst, CheckMode::Partial, stream);
         handles[n] = nanovdb::GridHandle<BufferT>(std::move(buffer));
         ptr = util::PtrAdd(ptr, handle.gridSize(n));
     }
     cudaCheck(util::cuda::freeAsync(d_dirty, stream));
-    return std::move(handles);
+    return handles;
 }// cuda::splitGridHandles
 
 template<typename BufferT, template <class, class...> class VectorT>
@@ -77,7 +82,8 @@ mergeGridHandles(const VectorT<GridHandle<BufferT>> &handles, const BufferT* oth
         gridCount += h.gridCount();
         for (uint32_t n=0; n<h.gridCount(); ++n) size += h.gridSize(n);
     }
-    auto buffer = BufferT::create(size, other, false, stream);
+    int device = util::cuda::currentDevice();
+    auto buffer = BufferT::create(size, other, device, stream);
     void *dst = buffer.deviceData();
     bool dirty, *d_dirty;// use this to check if the checksum needs to be recomputed
     cudaCheck(util::cuda::mallocAsync((void**)&d_dirty, sizeof(bool), stream));
@@ -86,9 +92,10 @@ mergeGridHandles(const VectorT<GridHandle<BufferT>> &handles, const BufferT* oth
         for (uint32_t n=0; n<h.gridCount(); ++n) {
             cudaCheck(cudaMemcpyAsync(dst, src, h.gridSize(n), cudaMemcpyDeviceToDevice, stream));
             GridData *data = reinterpret_cast<GridData*>(dst);
-            updateGridCount<<<1, 1, 0, stream>>>(data, counter++, gridCount, d_dirty);
+            detail::updateGridCount<<<1, 1, 0, stream>>>(data, counter++, gridCount, d_dirty);
             cudaCheckError();
             cudaCheck(cudaMemcpyAsync(&dirty, d_dirty, sizeof(bool), cudaMemcpyDeviceToHost, stream));
+            cudaCheck(cudaStreamSynchronize(stream));
             if (dirty) tools::cuda::updateChecksum(data, CheckMode::Partial, stream);
             dst = util::PtrAdd(dst, h.gridSize(n));
             src = util::PtrAdd(src, h.gridSize(n));
@@ -129,7 +136,7 @@ GridHandle<BufferT>::GridHandle(T&& buffer)
             if (!tmp.isValid()) throw std::runtime_error("GridHandle was constructed with an invalid device buffer");
             GridHandleMetaData *d_metaData;
             cudaMalloc((void**)&d_metaData, tmp.mGridCount*sizeof(GridHandleMetaData));
-            cuda::cpyGridHandleMeta<<<1,1>>>(d_data, d_metaData);
+            cuda::detail::cpyGridHandleMeta<<<1,1>>>(d_data, d_metaData);
             mMetaData.resize(tmp.mGridCount);
             cudaCheck(cudaMemcpy(mMetaData.data(), d_metaData,tmp.mGridCount*sizeof(GridHandleMetaData), cudaMemcpyDeviceToHost));
             cudaCheck(cudaFree(d_metaData));

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/TempPool.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/TempPool.h
@@ -1,0 +1,66 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+//
+/// @brief Defines a simple memory pool used to call cub functions that use dynamic temporary storage
+///
+/// @details See nanovdb/tools/cuda/PointToGrid.cuh and nanovdb/tools/cuda/DistributedPointToGrid.cuh
+///          for examples. Also note that this explains the somewhat unusual API with direct access to
+///          protected member data.
+//
+#ifndef NANOVDB_CUDA_TEMPPOOL_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_TEMPPOOL_H_HAS_BEEN_INCLUDED
+
+#include <nanovdb/cuda/DeviceResource.h>
+
+namespace nanovdb {
+
+namespace cuda {
+
+template <class Resource>
+class TempPool {
+public:
+
+    /// @brief Default c-tor of an empty memory pool.
+    TempPool() : mData(nullptr), mSize(0), mRequestedSize(0) {}
+
+    /// @brief Destructor
+    ~TempPool() {
+        mRequestedSize = 0;
+        Resource::deallocateAsync(mData, mSize, Resource::DEFAULT_ALIGNMENT, nullptr);
+        mData = nullptr;
+        mSize = 0;
+    }
+
+    /// @brief Returns a non-const void pointer to the data managed by this instance.
+    void* data() {return mData;}
+
+    /// @brief Returns a non-const reference to the actual size of the data managed by this instance.
+    size_t& size() {return mSize;}
+
+    /// @brief Returns a non-const reference to the requested size of the data managed by this instance.
+    /// @note This requested size should always be less than or smaller than the actual size().
+    size_t& requestedSize() {return mRequestedSize;}
+
+    /// @brief Re-allocation of the data managed by this instance. Only has affect if the pool in empty or
+    ///        the requested memory is larger than the existing size.
+    /// @param stream cuda stream used for asynchronous de-allocation and allocation.
+    void reallocate(cudaStream_t stream) {
+        if (!mData || mRequestedSize > mSize) {
+            Resource::deallocateAsync(mData, mSize, Resource::DEFAULT_ALIGNMENT, stream);
+            mData = Resource::allocateAsync(mRequestedSize, Resource::DEFAULT_ALIGNMENT, stream);
+            mSize = mRequestedSize;
+        }
+    }
+private:
+    void  *mData;
+    size_t mSize;
+    size_t mRequestedSize;
+};// TempPool<Resource> class
+
+using TempDevicePool = TempPool<DeviceResource>;
+
+} // namespace cuda
+
+} // namespace nanovdb
+
+#endif // end of NANOVDB_CUDA_TEMPPOOL_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/cuda/UnifiedBuffer.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/cuda/UnifiedBuffer.h
@@ -1,0 +1,326 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file UnifiedBuffer.h
+
+    \author Ken Museth
+
+    \date October 15, 2024
+
+    \brief nanovdb::cuda::UnifiedBuffer that uses unified memory management
+
+    \note This file has no device-only kernel functions,
+          which explains why it's a .h and not .cuh file.
+*/
+
+#ifndef NANOVDB_CUDA_UNIFIEDBUFFER_H_HAS_BEEN_INCLUDED
+#define NANOVDB_CUDA_UNIFIEDBUFFER_H_HAS_BEEN_INCLUDED
+
+#include <cuda.h>
+#include <memory>// for std::shared_ptr
+#include <nanovdb/HostBuffer.h>// for BufferTraits
+#include <nanovdb/util/cuda/Util.h>// for cudaCheck
+
+namespace nanovdb {// ================================================================
+
+namespace cuda {// ===================================================================
+
+/// @brief  buffer, used for instance by the GridHandle, to allocate unified memory that
+///         can be resized and shared between multiple devices and the host.
+class UnifiedBuffer
+{
+    void *mPtr;
+    size_t mSize, mCapacity;
+public:
+
+    using PtrT = std::shared_ptr<UnifiedBuffer>;
+
+    /// @brief Default constructor of an empty buffer
+    UnifiedBuffer() : mPtr(nullptr), mSize(0), mCapacity(0){}
+
+    /// @brief Constructor that specifies both the size and capacity
+    /// @param size size of the buffer in bytes, indication what is actually used
+    /// @param capacity number of bytes in the virtual page table, i.e max size for growing
+    /// @note Capacity can be over-estimated to allow for future growth. Memory is not allocated
+    ///       with this constructor, only a page table. Allocation happens on usage or when calling prefetch
+    UnifiedBuffer(size_t size, size_t capacity) : mPtr(nullptr), mSize(size), mCapacity(capacity)
+    {
+        assert(mSize <= mCapacity);
+        cudaCheck(cudaMallocManaged(&mPtr, mCapacity, cudaMemAttachGlobal));
+    }
+
+     /// @brief Similar to the constructor above except the size and capacity are equal, so no future growth is supported
+    UnifiedBuffer(size_t size) : UnifiedBuffer(size, size){}
+
+    /// @brief Constructor that specifies the size, capacity, and device (for prefetching)
+    /// @param size
+    /// @param capacity
+    /// @param device
+    /// @param stream
+    UnifiedBuffer(uint64_t size, uint64_t capacity, int device, cudaStream_t stream = 0) : mPtr(nullptr), mSize(size), mCapacity(size)
+    {
+        assert(mSize <= mCapacity);
+        cudaCheck(cudaMallocManaged(&mPtr, mCapacity, cudaMemAttachGlobal));
+        cudaCheck(util::cuda::memAdvise(mPtr, size, cudaMemAdviseSetPreferredLocation, device));
+        cudaCheck(util::cuda::memPrefetchAsync(mPtr, size, device, stream));
+    }
+
+    /// @brief Constructor with a specified device
+    /// @param size
+    /// @param device
+    /// @param stream
+    UnifiedBuffer(uint64_t size, int device, cudaStream_t stream = 0) : UnifiedBuffer(size, size, device, stream){}
+
+     /// @brief Disallow copy-construction
+    UnifiedBuffer(const UnifiedBuffer&) = delete;
+
+    /// @brief Move copy-constructor
+    UnifiedBuffer(UnifiedBuffer&& other) noexcept
+        : mPtr(other.mPtr)
+        , mSize(other.mSize)
+        , mCapacity(other.mCapacity)
+    {
+        other.mPtr = nullptr;
+        other.mSize = other.mCapacity = 0;
+    }
+
+    /// @brief Destructor
+    ~UnifiedBuffer(){cudaCheck(cudaFree(mPtr));}
+
+    ///////////////////////////////////////////////////////////////////////
+
+    //@{
+    /// @brief Factory methods that create an UnifiedBuffer instance and returns it with move semantics
+    static UnifiedBuffer create(size_t size, size_t capacity) {return UnifiedBuffer(size, capacity);}
+    static UnifiedBuffer create(size_t size) {return UnifiedBuffer(size);}
+    ///@}
+
+    //@{
+    /// @brief Factory methods that create a shared pointer to an UnifiedBuffer instance
+    static PtrT createPtr(size_t size, size_t capacity) {return std::make_shared<UnifiedBuffer>(size, capacity);}
+    static PtrT createPtr(size_t size) {return std::make_shared<UnifiedBuffer>(size);}
+    ///@}
+
+    /// @brief Legacy factory method that mirrors DeviceBuffer. It creates a UnifiedBuffer from a size and a reference buffer.
+    ///        If a reference buffer is provided and its non-empty, it is used to defined the capacity of the new buffer
+    /// @param size Size on bytes of the new buffer
+    /// @param reference reference buffer optionally used to define the capacity
+    /// @param host Ignored for now
+    /// @param stream cuda stream
+    /// @return An instance of a new UnifiedBuffer using move semantics
+    static UnifiedBuffer create(size_t size, const UnifiedBuffer* reference, int device, cudaStream_t stream)
+    {
+        const size_t capacity = (reference && reference->capacity()) ? reference->capacity() : size;
+        UnifiedBuffer buffer(size, capacity);
+        cudaCheck(util::cuda::memAdvise(buffer.mPtr, size, cudaMemAdviseSetPreferredLocation, device));
+        cudaCheck(util::cuda::memPrefetchAsync(buffer.mPtr, size, device, stream));
+        return buffer;
+    }
+
+    /// @brief Factory method that created a buffer on the host of the specified size. If the
+    ///        reference buffer has a capacity it is used. Also the buffer is prefetched to the host
+    /// @param size byte size of buffer initiated on the host
+    /// @param reference optional reference buffer from which the capacity is derived
+    static UnifiedBuffer create(size_t size, const UnifiedBuffer* reference){return create(size, reference, cudaCpuDeviceId, (cudaStream_t)0);}
+
+    /// @brief Factory method that created a buffer on the host or device of the specified size. If the
+    ///        reference buffer has a capacity it is used. Also the buffer is prefetched to the host or (current) device
+    /// @param size byte size of buffer initiated on the device or host
+    /// @param reference optional reference buffer from which the capacity is derived
+    /// @param host If true the buffer will be prefetched to the host, else to the current device
+    /// @param stream optional cuda stream
+    static UnifiedBuffer create(size_t size, const UnifiedBuffer* reference, bool host, void* stream = nullptr)
+    {
+        int device = cudaCpuDeviceId;
+        if (!host) cudaGetDevice(&device);
+        return create(size, reference, device, (cudaStream_t)stream);
+    }
+
+    /// @brief Free all memory and reset this instance to empty
+    void clear()
+    {
+        cudaCheck(cudaFree(mPtr));
+        mPtr = nullptr;
+        mSize = mCapacity = 0;
+    }
+
+    /// @brief Disallow copy assignment operation
+    UnifiedBuffer& operator=(const UnifiedBuffer&) = delete;
+
+    /// @brief Allow move assignment operation
+    UnifiedBuffer& operator=(UnifiedBuffer&& other)
+    {
+        cudaCheck(cudaFree(mPtr));
+        mPtr = other.mPtr;
+        mSize = other.mSize;
+        mCapacity = other.mCapacity;
+        other.mPtr = nullptr;
+        other.mSize = other.mCapacity = 0;
+        return *this;
+    }
+
+    /// @brief initialize buffer as a new with the specified size and capacity
+    /// @param size size of memory block to be used in bytes
+    /// @param capacity size of page table in bytes
+    void init(size_t size, size_t capacity)
+    {
+        NANOVDB_ASSERT(size <= capacity);
+        cudaCheck(cudaFree(mPtr));
+        mSize = size;
+        mCapacity = capacity;
+        cudaCheck(cudaMallocManaged(&mPtr, capacity, cudaMemAttachGlobal));
+    }
+
+    /// @brief Resize the memory block managed by this buffer. If the current capacity is larger than the new size this method
+    ///        simply redefines size. Otherwise a new page-table is defined, with the specified advice, and the old block is copied to the new block.
+    /// @param size size of the new memory block
+    /// @param dev the device ID on which to apply each advice provided in list, cudaCpuDeviceId = -1, 0, 1, ...
+    /// @param list advices to be applied to the resized range
+    void resize(size_t size, int dev = cudaCpuDeviceId, std::initializer_list<cudaMemoryAdvise> list = {cudaMemAdviseSetPreferredLocation})
+    {
+        if (size <= mCapacity) {
+            mSize = size;
+        } else {
+            void *ptr = 0;
+            cudaCheck(cudaMallocManaged(&ptr, size, cudaMemAttachGlobal));
+            if (dev > -2) for (auto a : list) cudaCheck(util::cuda::memAdvise(ptr, size, a, dev));
+            if (mSize > 0) {// copy over data from the old memory block
+                cudaCheck(cudaMemcpy(ptr, mPtr, std::min(mSize, size), cudaMemcpyDefault));
+                cudaCheck(cudaFree(mPtr));
+            }
+            mPtr = ptr;
+            mSize = mCapacity = size;
+        }
+    }
+
+    /// @brief Apply a single advise to a memory block
+    /// @param byteOffset offset in bytes marking the beginning of the memory block to be advised
+    /// @param size size in bytes of the memory block to be advised.
+    /// @param dev the device ID on which to apply the advice provided in adv, cudaCpuDeviceId = -1, 0, 1, ...
+    /// @param adv advice to be applied to the resized range
+    void advise(ptrdiff_t byteOffset, size_t size, int dev, cudaMemoryAdvise adv) const
+    {
+        cudaCheck(util::cuda::memAdvise(util::PtrAdd(mPtr, byteOffset), size, adv, dev));
+    }
+
+    /// @brief Apply a list of advices to a memory block
+    /// @param byteOffset offset in bytes marking the beginning of the memory block to be advised
+    /// @param size size in bytes of the memory block to be advised.
+    /// @param dev the device ID to prefetch to, cudaCpuDeviceId = -1, 0, 1, ...
+    /// @param list list of cuda advises
+    void advise(ptrdiff_t byteOffset, size_t size, int dev, std::initializer_list<cudaMemoryAdvise> list) const
+    {
+        void *ptr = util::PtrAdd(mPtr, byteOffset);
+        for (auto a : list)  cudaCheck(util::cuda::memAdvise(ptr, size, a, dev));
+    }
+
+    /// @brief Prefetches data to the specified device, i.e. ensure the device has an up-to-date copy of the memory specified
+    /// @param byteOffset offset in bytes marking the beginning of the memory block to be prefetched
+    /// @param size size in bytes of the memory block to be prefetched. The default value of zero means copy all @c this->size() bytes.
+    /// @param dev the device ID to prefetch to, cudaCpuDeviceId = -1, 0, 1, ...
+    /// @param stream  cuda stream
+    void prefetch(ptrdiff_t byteOffset = 0, size_t size = 0, int dev = cudaCpuDeviceId, cudaStream_t stream = cudaStreamPerThread) const
+    {
+        cudaCheck(util::cuda::memPrefetchAsync(util::PtrAdd(mPtr, byteOffset), size ? size : mSize, dev, stream));
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Prefetches all data to the specified device
+    /// @param device device ID, cudaCpuDeviceId = -1, 0, 1, ...
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous
+    /// @note Legacy method included for compatibility with DeviceBuffer
+    void deviceUpload(int device = 0, cudaStream_t stream = cudaStreamPerThread, bool sync = false) const
+    {
+        cudaCheck(util::cuda::memPrefetchAsync(mPtr, mSize, device, stream));
+        if (sync) cudaCheck(cudaStreamSynchronize(stream));
+    }
+    void deviceUpload(int device, void* stream, bool sync) const{this->deviceUpload(device, cudaStream_t(stream));}
+
+    /// @brief Prefetches all data to the current device, as given by cudaGetDevice
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous
+    /// @note Legacy method included for compatibility with DeviceBuffer
+    void deviceUpload(void* stream, bool sync) const{
+        int device = 0;
+        cudaCheck(cudaGetDevice(&device));
+        this->deviceUpload(device, cudaStream_t(stream), sync);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Prefetches all data to the host
+    /// @param stream cuda stream
+    /// @param sync if false the memory copy is asynchronous
+    void deviceDownload(cudaStream_t stream = 0, bool sync = false) const
+    {
+        cudaCheck(util::cuda::memPrefetchAsync(mPtr, mSize, cudaCpuDeviceId, stream));
+        if (sync) cudaCheck(cudaStreamSynchronize(stream));
+    }
+
+    /// @brief Legacy
+    /// @param stream
+    /// @param sync
+    void deviceDownload(void* stream, bool sync) const{this->deviceDownload(cudaStream_t(stream), sync);}
+
+    // used by GridHandle
+    void deviceDownload(int dummmy, void* stream, bool sync) const{this->deviceDownload(cudaStream_t(stream), sync);}
+
+    ///////////////////////////////////////////////////////////////////////
+
+    /// @brief Returns a raw pointer to the unified memory managed by this instance.
+    /// @warning Note that the pointer can be NULL!
+    void* data() const {return mPtr;}
+
+    /// @brief Returns an offset pointer of a specific type from the allocated unified memory
+    /// @tparam T Type of the pointer returned
+    /// @param count Numbers of elements of @c parameter type T to skip (or offset) the return pointer
+    /// @warning assumes that this instance is not empty!
+    template <typename T>
+    T* data(ptrdiff_t count = 0) const {
+        NANOVDB_ASSERT(mPtr != nullptr || count == 0);
+        return reinterpret_cast<T*>(mPtr) + count;
+    }
+
+    /// @brief Returns a byte offset void pointer from the unified memory
+    /// @param byteOffset Number of bytes to skip (or offset) the return pointer
+    /// @warning assumes that this instance is not empty!
+    void* data(ptrdiff_t byteOffset) const {
+        NANOVDB_ASSERT(mPtr != nullptr || byteOffset == 0);
+        return util::PtrAdd(mPtr, byteOffset);
+    }
+
+    /// @brief Legacy
+    /// @return
+    void* deviceData()    const {return mPtr;}
+    void* deviceData(int) const {return mPtr;}
+
+    /// @brief Size of the allocated pages in this instance
+    /// @return number bytes allocated by this instance
+    size_t size() const {return mSize;}
+
+    /// @brief Capacity of this instance, i.e. room in page table
+    /// @return number of bytes reserved, but not necessarily allocated, by this instance
+    size_t capacity() const {return mCapacity;}
+
+    //@{
+    /// @brief Returns true if this allocator is empty, i.e. has no allocated memory
+    inline bool empty() const { return mPtr == nullptr; }
+    inline bool isEmpty() const { return this->empty(); }
+    //@}
+
+};// UnifiedBuffer
+
+}// namespace cuda
+
+template<>
+struct BufferTraits<cuda::UnifiedBuffer>
+{
+    static constexpr bool hasDeviceDual = true;
+};
+
+}// namespace nanovdb
+
+#endif // end of NANOVDB_CUDA_UNIFIEDBUFFER_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/math/HDDA.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/math/HDDA.h
@@ -74,9 +74,23 @@ public:
     {
         if (mDim == dim)
             return false;
+
+        // compute valid voxel range
+        Coord voxelMax = (mVoxel + Coord(mDim - 1)) & (~(dim - 1));
+        Coord voxelMin = mVoxel & (~(dim - 1));
+
         mDim = dim;
         const Vec3T &pos = ray(mT0), &inv = ray.invDir();
         mVoxel = RoundDown<CoordT>(pos) & (~(dim - 1));
+
+        // clamp mVoxel to valid range
+        mVoxel[0] = nanovdb::math::Min(mVoxel[0], voxelMax[0]);
+        mVoxel[1] = nanovdb::math::Min(mVoxel[1], voxelMax[1]);
+        mVoxel[2] = nanovdb::math::Min(mVoxel[2], voxelMax[2]);
+        mVoxel[0] = nanovdb::math::Max(mVoxel[0], voxelMin[0]);
+        mVoxel[1] = nanovdb::math::Max(mVoxel[1], voxelMin[1]);
+        mVoxel[2] = nanovdb::math::Max(mVoxel[2], voxelMin[2]);
+
         for (int axis = 0; axis < 3; ++axis) {
             if (mStep[axis] == 0)
                 continue;

--- a/devices/rtx/external/nanovdb/include/nanovdb/math/Math.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/math/Math.h
@@ -17,6 +17,10 @@
 
 #include <nanovdb/util/Util.h>// for __hostdev__ and lots of other utility functions
 
+#if defined(__CUDA_ARCH__)
+#include <cuda/std/limits>// for ::cuda::std::numeric_limits
+#endif
+
 namespace nanovdb {// =================================================================
 
 namespace math {// =============================================================
@@ -83,7 +87,13 @@ struct Delta<double>
 /// Maximum floating-point values
 template<typename T>
 struct Maximum;
-#if defined(__CUDA_ARCH__) || defined(__HIP__)
+#if defined(__CUDA_ARCH__)
+template<typename T>
+struct Maximum
+{
+    __hostdev__ static T value() { return ::cuda::std::numeric_limits<T>::max(); }
+};
+#elif defined(__HIP__)
 template<>
 struct Maximum<int>
 {
@@ -576,6 +586,774 @@ public:
     __hostdev__ inline Coord round() const { return *this; }
 }; // Coord class
 
+
+/// @brief Type alias for Coord so we have a consistent naming convention
+using Coord3 = Coord;
+
+
+template <typename T>
+class Vec2;
+
+/// @brief Signed (i, j) 32-bit integer coordinate class, similar to openvdb::math::Coord
+class Coord2
+{
+    int32_t mVec[2]; // private member data - three signed index coordinates
+public:
+    using ValueType = int32_t;
+    using IndexType = uint32_t;
+
+    /// @brief Initialize all coordinates to zero.
+    __hostdev__ Coord2()
+        : mVec{0, 0}
+    {
+    }
+
+    /// @brief Initializes all coordinates to the given signed integer.
+    __hostdev__ explicit Coord2(ValueType n)
+        : mVec{n, n}
+    {
+    }
+
+    /// @brief Initializes coordinate to the given signed integers.
+    __hostdev__ Coord2(ValueType i, ValueType j)
+        : mVec{i, j}
+    {
+    }
+
+    __hostdev__ Coord2(ValueType* ptr)
+        : mVec{ptr[0], ptr[1]}
+    {
+    }
+
+    __hostdev__ int32_t x() const { return mVec[0]; }
+    __hostdev__ int32_t y() const { return mVec[1]; }
+
+    __hostdev__ int32_t& x() { return mVec[0]; }
+    __hostdev__ int32_t& y() { return mVec[1]; }
+
+    __hostdev__ static Coord2 max() { return Coord2(int32_t((1u << 31) - 1)); }
+
+    __hostdev__ static Coord2 min() { return Coord2(-int32_t((1u << 31) - 1) - 1); }
+
+    __hostdev__ static size_t memUsage() { return sizeof(Coord2); }
+
+    /// @brief Return a const reference to the given Coord component.
+    /// @warning The argument is assumed to be 0 or 1,
+    __hostdev__ const ValueType& operator[](IndexType i) const { return mVec[i]; }
+
+    /// @brief Return a non-const reference to the given Coord component.
+    /// @warning The argument is assumed to be 0 or 1.
+    __hostdev__ ValueType& operator[](IndexType i) { return mVec[i]; }
+
+    /// @brief Assignment operator that works with openvdb::Coord
+    template<typename CoordT>
+    __hostdev__ Coord2& operator=(const CoordT& other)
+    {
+        static_assert(sizeof(Coord2) == sizeof(CoordT), "Mis-matched sizeof");
+        mVec[0] = other[0];
+        mVec[1] = other[1];
+        return *this;
+    }
+
+    /// @brief Return a new instance with coordinates masked by the given unsigned integer.
+    __hostdev__ Coord2 operator&(IndexType n) const { return Coord2(mVec[0] & n, mVec[1] & n); }
+
+    // @brief Return a new instance with coordinates left-shifted by the given unsigned integer.
+    __hostdev__ Coord2 operator<<(IndexType n) const { return Coord2(mVec[0] << n, mVec[1] << n); }
+
+    // @brief Return a new instance with coordinates right-shifted by the given unsigned integer.
+    __hostdev__ Coord2 operator>>(IndexType n) const { return Coord2(mVec[0] >> n, mVec[1] >> n); }
+
+    /// @brief Return true if this Coord is lexicographically less than the given Coord.
+    __hostdev__ bool operator<(const Coord2& rhs) const
+    {
+        return mVec[0] < rhs[0] ? true
+             : mVec[0] > rhs[0] ? false
+             : mVec[1] < rhs[1] ? true : false;
+    }
+
+    /// @brief Return true if this Coord is lexicographically less or equal to the given Coord.
+    __hostdev__ bool operator<=(const Coord2& rhs) const
+    {
+        return mVec[0] < rhs[0] ? true
+             : mVec[0] > rhs[0] ? false
+             : mVec[1] <= rhs[1] ? true : false;
+    }
+
+    // @brief Return true if this Coord is lexicographically greater than the given Coord.
+    __hostdev__ bool operator>(const Coord2& rhs) const
+    {
+        return mVec[0] > rhs[0] ? true
+             : mVec[0] < rhs[0] ? false
+             : mVec[1] > rhs[1] ? true : false;
+    }
+
+    // @brief Return true if this Coord is lexicographically greater or equal to the given Coord.
+    __hostdev__ bool operator>=(const Coord2& rhs) const
+    {
+        return mVec[0] > rhs[0] ? true
+             : mVec[0] < rhs[0] ? false
+             : mVec[1] >= rhs[1] ? true : false;
+    }
+
+    // @brief Return true if the Coord components are identical.
+    __hostdev__ bool   operator==(const Coord2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    __hostdev__ bool   operator!=(const Coord2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    __hostdev__ Coord2& operator&=(int n)
+    {
+        mVec[0] &= n;
+        mVec[1] &= n;
+        return *this;
+    }
+    __hostdev__ Coord2& operator<<=(uint32_t n)
+    {
+        mVec[0] <<= n;
+        mVec[1] <<= n;
+        return *this;
+    }
+    __hostdev__ Coord2& operator>>=(uint32_t n)
+    {
+        mVec[0] >>= n;
+        mVec[1] >>= n;
+        return *this;
+    }
+    __hostdev__ Coord2& operator+=(int n)
+    {
+        mVec[0] += n;
+        mVec[1] += n;
+        return *this;
+    }
+    __hostdev__ Coord2  operator+(const Coord2& rhs) const { return Coord2(mVec[0] + rhs[0], mVec[1] + rhs[1]); }
+    __hostdev__ Coord2  operator-(const Coord2& rhs) const { return Coord2(mVec[0] - rhs[0], mVec[1] - rhs[1]); }
+    __hostdev__ Coord2  operator-() const { return Coord2(-mVec[0], -mVec[1]); }
+    __hostdev__ Coord2& operator+=(const Coord2& rhs)
+    {
+        mVec[0] += rhs[0];
+        mVec[1] += rhs[1];
+        return *this;
+    }
+    __hostdev__ Coord2& operator-=(const Coord2& rhs)
+    {
+        mVec[0] -= rhs[0];
+        mVec[1] -= rhs[1];
+        return *this;
+    }
+
+    /// @brief Perform a component-wise minimum with the other Coord.
+    __hostdev__ Coord2& minComponent(const Coord2& other)
+    {
+        if (other[0] < mVec[0])
+            mVec[0] = other[0];
+        if (other[1] < mVec[1])
+            mVec[1] = other[1];
+        return *this;
+    }
+
+    /// @brief Perform a component-wise maximum with the other Coord.
+    __hostdev__ Coord2& maxComponent(const Coord2& other)
+    {
+        if (other[0] > mVec[0])
+            mVec[0] = other[0];
+        if (other[1] > mVec[1])
+            mVec[1] = other[1];
+        return *this;
+    }
+#if defined(__CUDACC__) // the following functions only run on the GPU!
+    __device__ inline Coord2& minComponentAtomic(const Coord2& other)
+    {
+        atomicMin(&mVec[0], other[0]);
+        atomicMin(&mVec[1], other[1]);
+        return *this;
+    }
+    __device__ inline Coord2& maxComponentAtomic(const Coord2& other)
+    {
+        atomicMax(&mVec[0], other[0]);
+        atomicMax(&mVec[1], other[1]);
+        return *this;
+    }
+#endif
+
+    __hostdev__ Coord2 offsetBy(ValueType dx, ValueType dy) const
+    {
+        return Coord2(mVec[0] + dx, mVec[1] + dy);
+    }
+
+    __hostdev__ Coord2 offsetBy(ValueType n) const { return this->offsetBy(n, n); }
+
+    /// Return true if any of the components of @a a are smaller than the
+    /// corresponding components of @a b.
+    __hostdev__ static inline bool lessThan(const Coord2& a, const Coord2& b)
+    {
+        return (a[0] < b[0] || a[1] < b[1]);
+    }
+
+    /// @brief Return the largest integer coordinates that are not greater
+    /// than @a xyz (node centered conversion).
+    template<typename Vec2T>
+    __hostdev__ static Coord2 Floor(const Vec2T& xy) { return Coord2(math::Floor(xy[0]), math::Floor(xy[1])); }
+
+    /// @brief Return a single precision floating-point vector of this coordinate
+    __hostdev__ inline Vec2<float> asVec2s() const;
+
+    /// @brief Return a double precision floating-point vector of this coordinate
+    __hostdev__ inline Vec2<double> asVec2d() const;
+
+    // returns a copy of itself, so it mimics the behaviour of Vec3<T>::round()
+    __hostdev__ inline Coord2 round() const { return *this; }
+}; // Coord2 class
+
+// ----------------------------> Vec2 <--------------------------------------
+
+/// @brief A simple vector class with three components, similar to openvdb::math::Vec3
+template<typename T>
+class Vec2
+{
+    T mVec[2];
+
+public:
+    static const int SIZE = 2;
+    static const int size = 2; // in openvdb::math::Tuple
+    using ValueType = T;
+    Vec2() = default;
+    __hostdev__ explicit Vec2(T x)
+        : mVec{x, x}
+    {
+    }
+    __hostdev__ Vec2(T x, T y)
+        : mVec{x, y}
+    {
+    }
+    template<template<class> class Vec2T, class T2>
+    __hostdev__ Vec2(const Vec2T<T2>& v)
+        : mVec{T(v[0]), T(v[1])}
+    {
+        static_assert(Vec2T<T2>::size == size, "expected Vec2T::size==2!");
+    }
+    template<typename T2>
+    __hostdev__ explicit Vec2(const Vec2<T2>& v)
+        : mVec{T(v[0]), T(v[1])}
+    {
+    }
+    __hostdev__ explicit Vec2(const Coord2& ijk)
+        : mVec{T(ijk[0]), T(ijk[1])}
+    {
+    }
+    __hostdev__ bool operator==(const Vec2& rhs) const { return mVec[0] == rhs[0] && mVec[1] == rhs[1]; }
+    __hostdev__ bool operator!=(const Vec2& rhs) const { return mVec[0] != rhs[0] || mVec[1] != rhs[1]; }
+    template<template<class> class Vec2T, class T2>
+    __hostdev__ Vec2& operator=(const Vec2T<T2>& rhs)
+    {
+        static_assert(Vec2T<T2>::size == size, "expected Vec2T::size==2!");
+        mVec[0] = rhs[0];
+        mVec[1] = rhs[1];
+        return *this;
+    }
+    __hostdev__ const T& operator[](int i) const { return mVec[i]; }
+    __hostdev__ T&       operator[](int i) { return mVec[i]; }
+    template<typename Vec2T>
+    __hostdev__ T dot(const Vec2T& v) const { return mVec[0] * v[0] + mVec[1] * v[1]; }
+    __hostdev__ T lengthSqr() const
+    {
+        return mVec[0] * mVec[0] + mVec[1] * mVec[1]; // 3 flops
+    }
+    __hostdev__ T     length() const { return Sqrt(this->lengthSqr()); }
+    __hostdev__ Vec2  operator-() const { return Vec2(-mVec[0], -mVec[1]); }
+    __hostdev__ Vec2  operator*(const Vec2& v) const { return Vec2(mVec[0] * v[0], mVec[1] * v[1]); }
+    __hostdev__ Vec2  operator/(const Vec2& v) const { return Vec2(mVec[0] / v[0], mVec[1] / v[1]); }
+    __hostdev__ Vec2  operator+(const Vec2& v) const { return Vec2(mVec[0] + v[0], mVec[1] + v[1]); }
+    __hostdev__ Vec2  operator-(const Vec2& v) const { return Vec2(mVec[0] - v[0], mVec[1] - v[1]); }
+    __hostdev__ Vec2  operator+(const Coord& ijk) const { return Vec2(mVec[0] + ijk[0], mVec[1] + ijk[1]); }
+    __hostdev__ Vec2  operator-(const Coord& ijk) const { return Vec2(mVec[0] - ijk[0], mVec[1] - ijk[1]); }
+    __hostdev__ Vec2  operator*(const T& s) const { return Vec2(s * mVec[0], s * mVec[1]); }
+    __hostdev__ Vec2  operator/(const T& s) const { return (T(1) / s) * (*this); }
+    __hostdev__ Vec2& operator+=(const Vec2& v)
+    {
+        mVec[0] += v[0];
+        mVec[1] += v[1];
+        return *this;
+    }
+    __hostdev__ Vec2& operator+=(const Coord& ijk)
+    {
+        mVec[0] += T(ijk[0]);
+        mVec[1] += T(ijk[1]);
+        return *this;
+    }
+    __hostdev__ Vec2& operator-=(const Vec2& v)
+    {
+        mVec[0] -= v[0];
+        mVec[1] -= v[1];
+        return *this;
+    }
+    __hostdev__ Vec2& operator-=(const Coord& ijk)
+    {
+        mVec[0] -= T(ijk[0]);
+        mVec[1] -= T(ijk[1]);
+        return *this;
+    }
+    __hostdev__ Vec2& operator*=(const T& s)
+    {
+        mVec[0] *= s;
+        mVec[1] *= s;
+        return *this;
+    }
+    __hostdev__ Vec2& operator/=(const T& s) { return (*this) *= T(1) / s; }
+    __hostdev__ Vec2& normalize() { return (*this) /= this->length(); }
+    /// @brief Perform a component-wise minimum with the other Coord.
+    __hostdev__ Vec2& minComponent(const Vec2& other)
+    {
+        if (other[0] < mVec[0])
+            mVec[0] = other[0];
+        if (other[1] < mVec[1])
+            mVec[1] = other[1];
+        return *this;
+    }
+
+    /// @brief Perform a component-wise maximum with the other Coord.
+    __hostdev__ Vec2& maxComponent(const Vec2& other)
+    {
+        if (other[0] > mVec[0])
+            mVec[0] = other[0];
+        if (other[1] > mVec[1])
+            mVec[1] = other[1];
+        return *this;
+    }
+    /// @brief Return the smallest vector component
+    __hostdev__ ValueType min() const
+    {
+        return mVec[0] < mVec[1] ? mVec[0] : mVec[1];
+    }
+    /// @brief Return the largest vector component
+    __hostdev__ ValueType max() const
+    {
+        return mVec[0] > mVec[1] ? mVec[0] : mVec[1];
+    }
+    /// @brief Round each component if this Vec<T> up to its integer value
+    /// @return Return an integer Coord
+    __hostdev__ Coord2 floor() const { return Coord2(Floor(mVec[0]), Floor(mVec[1])); }
+    /// @brief Round each component if this Vec<T> down to its integer value
+    /// @return Return an integer Coord
+    __hostdev__ Coord2 ceil() const { return Coord2(Ceil(mVec[0]), Ceil(mVec[1])); }
+    /// @brief Round each component if this Vec<T> to its closest integer value
+    /// @return Return an integer Coord
+    __hostdev__ Coord2 round() const
+    {
+        if constexpr(util::is_same<T, float>::value) {
+            return Coord2(Floor(mVec[0] + 0.5f), Floor(mVec[1] + 0.5f));
+        } else if constexpr(util::is_same<T, int>::value) {
+            return Coord2(mVec[0], mVec[1]);
+        } else {
+            return Coord2(Floor(mVec[0] + 0.5), Floor(mVec[1] + 0.5));
+        }
+    }
+
+    /// @brief return a non-const raw constant pointer to array of three vector components
+    __hostdev__ T* asPointer() { return mVec; }
+    /// @brief return a const raw constant pointer to array of three vector components
+    __hostdev__ const T* asPointer() const { return mVec; }
+}; // Vec2<T>
+
+template<typename T1, typename T2>
+__hostdev__ inline Vec2<T2> operator*(T1 scalar, const Vec2<T2>& vec)
+{
+    return Vec2<T2>(scalar * vec[0], scalar * vec[1]);
+}
+template<typename T1, typename T2>
+__hostdev__ inline Vec2<T2> operator/(T1 scalar, const Vec2<T2>& vec)
+{
+    return Vec2<T2>(scalar / vec[0], scalar / vec[1]);
+}
+
+/// @brief Return a single precision floating-point vector of this coordinate
+__hostdev__ inline Vec2<float> Coord2::asVec2s() const
+{
+    return Vec2<float>(float(mVec[0]), float(mVec[1]));
+}
+
+/// @brief Return a double precision floating-point vector of this coordinate
+__hostdev__ inline Vec2<double> Coord2::asVec2d() const
+{
+    return Vec2<double>(double(mVec[0]), double(mVec[1]));
+}
+
+
+// Matrix base class
+template<typename T, int ROWS, int COLS>
+class MatBase {
+protected:
+    T mData[ROWS * COLS];  // 1D array storage
+
+    static constexpr int rows() { return ROWS; }
+    static constexpr int cols() { return COLS; }
+    static constexpr int size() { return ROWS * COLS; }
+
+public:
+    MatBase() = default;
+
+    template<typename S>
+    __hostdev__ MatBase(S* array) {
+        for (int i = 0; i < ROWS * COLS; ++i) {
+            mData[i] = static_cast<T>(array[i]);
+        }
+    }
+
+    // 2D array access
+    __hostdev__ T* operator[](int row) {
+        return &mData[row * COLS];
+    }
+    __hostdev__ const T* operator[](int row) const {
+        return &mData[row * COLS];
+    }
+};
+
+// Forward declarations
+template<typename T> class Mat2;
+template<typename T> class Mat2x3;
+template<typename T> class Mat3x2;
+template<typename T> class Mat3;
+template<typename T> class Mat4;
+
+
+
+template <typename T>
+class Mat2 : public MatBase<T, 2, 2> {
+    using Base = MatBase<T, 2, 2>;
+public:
+    Mat2() = default;
+    /// @brief Constructor given individual array elements, the ordering is in row major form:
+    /** @verbatim
+        a b
+        c d
+        @endverbatim */
+    __hostdev__ Mat2(T a, T b, T c, T d) {
+        this->mData[0] = a; this->mData[1] = b;
+        this->mData[2] = c; this->mData[3] = d;
+    }
+
+    /// @brief Constructor given array of elements, the ordering is in row major form
+    template<typename Source>
+    __hostdev__ Mat2(Source* array) : Base(array) {}
+
+    __hostdev__ Mat2  operator-() const { return Mat2(-(*this)[0][0], -(*this)[0][1], -(*this)[1][0], -(*this)[1][1]); }
+
+    /// @brief Multiply by 2x2 matrix @a m and return the resulting matrix.
+    __hostdev__ Mat2<T> operator*(const Mat2<T>& m) const {
+        return Mat2<T>(
+            (*this)[0][0] * m[0][0] + (*this)[0][1] * m[1][0],
+            (*this)[0][0] * m[0][1] + (*this)[0][1] * m[1][1],
+            (*this)[1][0] * m[0][0] + (*this)[1][1] * m[1][0],
+            (*this)[1][0] * m[0][1] + (*this)[1][1] * m[1][1]
+        );
+    }
+
+    /// @brief Add each element of the given matrix to the corresponding element of this matrix.
+    __hostdev__ Mat2<T>& operator+=(const Mat2<T>& m) {
+        (*this)[0][0] += m[0][0];
+        (*this)[0][1] += m[0][1];
+        (*this)[1][0] += m[1][0];
+        (*this)[1][1] += m[1][1];
+        return *this;
+    }
+
+    /// @brief returns transpose of this
+    __hostdev__ Mat2<T> transpose() const {
+        return Mat2<T>((*this)[0][0], (*this)[1][0], (*this)[0][1], (*this)[1][1]);
+    }
+
+    /// @brief returns inverse of this
+    __hostdev__ Mat2<T> inverse() const {
+        T det = (*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0];
+        if (isApproxZero(det)) {
+            return Mat2<T>();
+        }
+        T invDet   = 1.f / det;
+        return Mat2<T>((*this)[1][1] * invDet, -(*this)[0][1] * invDet, -(*this)[1][0] * invDet, (*this)[0][0] * invDet);
+    }
+};
+
+template <typename T>
+class Mat2x3 : public MatBase<T, 2, 3> {
+    using Base = MatBase<T, 2, 3>;
+public:
+    Mat2x3() = default;
+    /// @brief Constructor given individual array elements, the ordering is in row major form:
+    /** @verbatim
+        a b c
+        d e f
+        @endverbatim */
+    __hostdev__ Mat2x3(T a, T b, T c, T d, T e, T f) {
+        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
+        this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
+    }
+
+    /// @brief Constructor given array of elements, the ordering is in row major form
+    template<typename Source>
+    __hostdev__ Mat2x3(Source* array) : Base(array) {}
+
+
+    /// @brief Add two matrices and return the resulting matrix.
+    __hostdev__ Mat2x3<T> operator+(const Mat2x3<T>& m) const {
+        return Mat2x3<T>(
+            (*this)[0][0] + m[0][0], (*this)[0][1] + m[0][1], (*this)[0][2] + m[0][2],
+            (*this)[1][0] + m[1][0], (*this)[1][1] + m[1][1], (*this)[1][2] + m[1][2]
+        );
+    }
+
+    /// @brief Add a 2x3 matrix to this matrix.
+    __hostdev__ Mat2x3<T>& operator+=(const Mat2x3<T>& m) {
+        (*this)[0][0] += m[0][0]; (*this)[0][1] += m[0][1]; (*this)[0][2] += m[0][2];
+        (*this)[1][0] += m[1][0]; (*this)[1][1] += m[1][1]; (*this)[1][2] += m[1][2];
+        return *this;
+    }
+
+    /// @brief returns transpose of this
+    __hostdev__ Mat3x2<T> transpose() const {
+        return Mat3x2<T>(
+            (*this)[0][0], (*this)[1][0],  // First row
+            (*this)[0][1], (*this)[1][1],  // Second row
+            (*this)[0][2], (*this)[1][2]   // Third row
+        );
+    }
+};
+
+template <typename T>
+class Mat3x2: public MatBase<T, 3, 2> {
+    using Base = MatBase<T, 3, 2>;
+public:
+    Mat3x2() = default;
+
+    /// @brief Constructor given individual array elements, the ordering is in row major form:
+    /** @verbatim
+        a b
+        c d
+        e f
+        @endverbatim */
+    template<typename Source>
+    __hostdev__ Mat3x2(Source a, Source b, Source c, Source d, Source e, Source f)
+    {
+        this->mData[0] = a; this->mData[1] = b;
+        this->mData[2] = c; this->mData[3] = d;
+        this->mData[4] = e; this->mData[5] = f;
+    }
+
+    /// @brief Constructor given array of elements, the ordering is in row major form
+    template<typename Source>
+    __hostdev__ Mat3x2(Source *a): Base(a) {}
+
+    /// @brief returns transpose of this
+    __hostdev__ Mat2x3<T> transpose() const {
+        return Mat2x3<T>((*this)[0][0], (*this)[1][0], (*this)[2][0], // First row
+                   (*this)[0][1], (*this)[1][1], (*this)[2][1]); // Second row
+    }
+
+};
+
+template <typename T>
+class Mat3 : public MatBase<T, 3, 3> {
+    using Base = MatBase<T, 3, 3>;
+public:
+    Mat3() = default;
+
+    /// @brief Constructor given individual array elements, the ordering is in row major form:
+    /** @verbatim
+        a b c
+        d e f
+        g h i
+        @endverbatim */
+    template<typename Source>
+    __hostdev__ Mat3(Source a, Source b, Source c,
+         Source d, Source e, Source f,
+         Source g, Source h, Source i)
+    {
+        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c;
+        this->mData[3] = d; this->mData[4] = e; this->mData[5] = f;
+        this->mData[6] = g; this->mData[7] = h; this->mData[8] = i;
+    }
+
+    /// @brief Constructor given array of elements, the ordering is in row major form
+    template<typename Source>
+    __hostdev__ Mat3(Source *a): Base(a) {}
+
+
+    /// @brief Add two matrices and return the resulting matrix.
+    __hostdev__ Mat3<T> operator+(const Mat3<T>& m) const {
+        return Mat3<T>(
+            (*this)[0][0] + m[0][0], (*this)[0][1] + m[0][1], (*this)[0][2] + m[0][2],
+            (*this)[1][0] + m[1][0], (*this)[1][1] + m[1][1], (*this)[1][2] + m[1][2],
+            (*this)[2][0] + m[2][0], (*this)[2][1] + m[2][1], (*this)[2][2] + m[2][2]
+        );
+    }
+
+    /// @brief Multiply by @a v and return the resulting vector.
+    __hostdev__ Vec3<T> operator*(const Vec3<T>& v) const {
+        return Vec3<T>(
+            (*this)[0][0] * v[0] + (*this)[0][1] * v[1] + (*this)[0][2] * v[2],
+            (*this)[1][0] * v[0] + (*this)[1][1] * v[1] + (*this)[1][2] * v[2],
+            (*this)[2][0] * v[0] + (*this)[2][1] * v[1] + (*this)[2][2] * v[2]
+        );
+    }
+
+    /// @brief Multiply by 3x3 matrix @a m and return the resulting matrix.
+    __hostdev__ Mat3<T> operator*(const Mat3<T>& m) const {
+        return Mat3<T>(
+            (*this)[0][0] * m[0][0] + (*this)[0][1] * m[1][0] + (*this)[0][2] * m[2][0],
+            (*this)[0][0] * m[0][1] + (*this)[0][1] * m[1][1] + (*this)[0][2] * m[2][1],
+            (*this)[0][0] * m[0][2] + (*this)[0][1] * m[1][2] + (*this)[0][2] * m[2][2],
+            (*this)[1][0] * m[0][0] + (*this)[1][1] * m[1][0] + (*this)[1][2] * m[2][0],
+            (*this)[1][0] * m[0][1] + (*this)[1][1] * m[1][1] + (*this)[1][2] * m[2][1],
+            (*this)[1][0] * m[0][2] + (*this)[1][1] * m[1][2] + (*this)[1][2] * m[2][2],
+            (*this)[2][0] * m[0][0] + (*this)[2][1] * m[1][0] + (*this)[2][2] * m[2][0],
+            (*this)[2][0] * m[0][1] + (*this)[2][1] * m[1][1] + (*this)[2][2] * m[2][1],
+            (*this)[2][0] * m[0][2] + (*this)[2][1] * m[1][2] + (*this)[2][2] * m[2][2]
+        );
+    }
+
+    /// @brief Add each element of the given matrix to the corresponding element of this matrix.
+    __hostdev__ Mat3<T>& operator+=(const Mat3<T>& m) {
+        (*this)[0][0] += m[0][0]; (*this)[0][1] += m[0][1]; (*this)[0][2] += m[0][2];
+        (*this)[1][0] += m[1][0]; (*this)[1][1] += m[1][1]; (*this)[1][2] += m[1][2];
+        (*this)[2][0] += m[2][0]; (*this)[2][1] += m[2][1]; (*this)[2][2] += m[2][2];
+        return *this;
+    }
+
+    /// @brief returns transpose of this
+    __hostdev__ Mat3 transpose() const {
+        return Mat3((*this)[0][0], (*this)[1][0], (*this)[2][0],
+                   (*this)[0][1], (*this)[1][1], (*this)[2][1],
+                   (*this)[0][2], (*this)[1][2], (*this)[2][2]);
+    }
+};
+
+template <typename T>
+class Mat4 : public MatBase<T, 4, 4> {
+    using Base = MatBase<T, 4, 4>;
+public:
+    Mat4() = default;
+
+    /// @brief Constructor given individual array elements, the ordering is in row major form:
+    /** @verbatim
+        a b c d
+        e f g h
+        i j k l
+        m n o p
+        @endverbatim */
+    template<typename Source>
+    __hostdev__ Mat4(Source a, Source b, Source c, Source d,
+         Source e, Source f, Source g, Source h,
+         Source i, Source j, Source k, Source l,
+         Source m, Source n, Source o, Source p)
+    {
+        this->mData[0] = a; this->mData[1] = b; this->mData[2] = c; this->mData[3] = d;
+        this->mData[4] = e; this->mData[5] = f; this->mData[6] = g; this->mData[7] = h;
+        this->mData[8] = i; this->mData[9] = j; this->mData[10] = k; this->mData[11] = l;
+        this->mData[12] = m; this->mData[13] = n; this->mData[14] = o; this->mData[15] = p;
+    }
+
+    /// @brief Constructor given array of elements, the ordering is in row major form
+    template<typename Source>
+    __hostdev__ Mat4(Source *a): Base(a) {}
+
+    /// @brief returns transpose of this
+    __hostdev__ Mat4 transpose() const {
+        return Mat4((*this)[0][0], (*this)[1][0], (*this)[2][0], (*this)[3][0],
+                   (*this)[0][1], (*this)[1][1], (*this)[2][1], (*this)[3][1],
+                   (*this)[0][2], (*this)[1][2], (*this)[2][2], (*this)[3][2],
+                   (*this)[0][3], (*this)[1][3], (*this)[2][3], (*this)[3][3]);
+    }
+};
+
+/// @brief Multiply a scalar by a 2x2 matrix, result is a 2x2 matrix
+template<typename T>
+__hostdev__ Mat2<T> operator*(const T& s, const Mat2<T>& m) {
+    return Mat2<T>(m[0][0] * s, m[0][1] * s, m[1][0] * s, m[1][1] * s);
+}
+
+/// @brief Multiply a 2x3 matrix by a 3x2 matrix, result is a 2x2 matrix
+template<typename T>
+__hostdev__ Mat2<T> operator*(const Mat2x3<T>& lhs, const Mat3x2<T>& rhs) {
+    return Mat2<T>(
+        // First row
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0],    // [0][0]
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1],    // [0][1]
+
+        // Second row
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0],    // [1][0]
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]     // [1][1]
+    );
+}
+/// @brief Multiply a 3x3 matrix by a 2x3 matrix, result is a 2x3 matrix
+template<typename T>
+__hostdev__ Mat2x3<T> operator*(const Mat3<T>& lhs, const Mat2x3<T>& rhs) {
+    return Mat2x3<T>(
+        // First row
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
+        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
+
+        // Second row
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
+        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2]
+    );
+}
+/// @brief Multiply a 2x3 matrix by a 3x3 matrix, result is a 2x3 matrix
+template<typename T>
+__hostdev__ Mat2x3<T> operator*(const Mat2x3<T>& lhs, const Mat3<T>& rhs) {
+    return Mat2x3<T>(
+        // First row (3 elements)
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0],
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1],
+        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2] + lhs[0][2] * rhs[2][2],
+
+        // Second row (3 elements)
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0],
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1],
+        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2] + lhs[1][2] * rhs[2][2]
+    );
+}
+/// @brief Multiply a 3x2 matrix by a 2x2 matrix, result is a 3x2 matrix
+template<typename T>
+__hostdev__ Mat3x2<T> operator*(const Mat3x2<T>& lhs, const Mat2<T>& rhs) {
+    return Mat3x2<T>(
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
+        lhs[2][0] * rhs[0][0] + lhs[2][1] * rhs[1][0],
+        lhs[2][0] * rhs[0][1] + lhs[2][1] * rhs[1][1]
+    );
+}
+/// @brief Multiply a 2x2 matrix by a 2x3 matrix, result is a 2x3 matrix
+template<typename T>
+__hostdev__ Mat2x3<T> operator*(const Mat2<T>& lhs, const Mat2x3<T>& rhs) {
+    return Mat2x3<T>(
+        // First row (3 elements)
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
+        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
+
+        // Second row (3 elements)
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
+        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2]
+    );
+}
+/// @brief Multiply a 3x2 matrix by a 2x3 matrix, result is a 3x3 matrix
+template<typename T>
+__hostdev__ Mat3<T> operator*(const Mat3x2<T>& lhs, const Mat2x3<T>& rhs) {
+    return Mat3<T>(
+        lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0],
+        lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1],
+        lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2],
+
+        lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0],
+        lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1],
+        lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2],
+
+        lhs[2][0] * rhs[0][0] + lhs[2][1] * rhs[1][0],
+        lhs[2][0] * rhs[0][1] + lhs[2][1] * rhs[1][1],
+        lhs[2][0] * rhs[0][2] + lhs[2][1] * rhs[1][2]
+    );
+}
 // ----------------------------> Vec3 <--------------------------------------
 
 /// @brief A simple vector class with three components, similar to openvdb::math::Vec3
@@ -633,6 +1411,14 @@ public:
         return Vec3(mVec[1] * v[2] - mVec[2] * v[1],
                     mVec[2] * v[0] - mVec[0] * v[2],
                     mVec[0] * v[1] - mVec[1] * v[0]);
+    }
+    /// @brief Outer product of a 3x1 vector and a 1x3 vector, result is a 3x3 matrix
+    template<typename Vec3T>
+    __hostdev__ Mat3<ValueType> outer(const Vec3T& v) const
+    {
+        return Mat3<ValueType>(mVec[0] * v[0], mVec[0] * v[1], mVec[0] * v[2],
+                    mVec[1] * v[0], mVec[1] * v[1], mVec[1] * v[2],
+                    mVec[2] * v[0], mVec[2] * v[1], mVec[2] * v[2]);
     }
     __hostdev__ T lengthSqr() const
     {
@@ -892,6 +1678,19 @@ __hostdev__ inline Vec4<T2> operator/(T1 scalar, const Vec4<T2>& vec)
 {
     return Vec4<T2>(scalar / vec[0], scalar / vec[1], scalar / vec[2], scalar / vec[3]);
 }
+/// @brief Return the matrix vector product of a 4x4 matrix and a 4d vector
+/// @param m 4x4 matrix
+/// @param v 4d vector
+/// @return result of matrix-vector multiplication, i.e. m x v
+template <typename T>
+__hostdev__ inline Vec4<T> operator*(const Mat4<T>& m, const Vec4<T>& v) {
+    return Vec4<T>(
+        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2] + m[0][3] * v[3],
+        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2] + m[1][3] * v[3],
+        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2] + m[2][3] * v[3],
+        m[3][0] * v[0] + m[3][1] * v[1] + m[3][2] * v[2] + m[3][3] * v[3]
+    );
+}
 
 // ----------------------------> matMult <--------------------------------------
 
@@ -1042,10 +1841,10 @@ struct BaseBBox
         return *this;
     }
 
-    //__hostdev__ BaseBBox expandBy(typename Vec3T::ValueType padding) const
-    //{
-    //    return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
-    //}
+//    __hostdev__ BaseBBox expandBy(typename Vec3T::ValueType padding) const
+//    {
+//        return BaseBBox(mCoord[0].offsetBy(-padding),mCoord[1].offsetBy(padding));
+//    }
     __hostdev__ bool isInside(const Vec3T& xyz)
     {
         if (xyz[0] < mCoord[0][0] || xyz[1] < mCoord[0][1] || xyz[2] < mCoord[0][2])

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/CreatePrimitives.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/CreatePrimitives.h
@@ -617,7 +617,7 @@ initSphere(double              radius, // radius of sphere in world units
     grid->setTransform(voxelSize, origin);
 
     // Define radius of sphere with narrow-band in voxel units
-    const ValueT r0 = radius / ValueT(voxelSize), rmax = r0 + ValueT(halfWidth);
+    const ValueT r0 = ValueT(radius / voxelSize), rmax = r0 + ValueT(halfWidth);
 
     // Radius below the Nyquist frequency
     if (r0 < ValueT(1.5f)) return grid;
@@ -689,7 +689,7 @@ initTorus(double              radius1, // major radius of torus in world units
     grid->setTransform(voxelSize, origin);
 
     // Define size of torus with narrow-band in voxel units
-    const ValueT r1 = radius1 / ValueT(voxelSize), r2 = radius2 / ValueT(voxelSize), rmax1 = r1 + r2 + ValueT(halfWidth), rmax2 = r2 + ValueT(halfWidth);
+    const ValueT r1 = ValueT(radius1 / voxelSize), r2 = ValueT(radius2 / voxelSize), rmax1 = r1 + r2 + ValueT(halfWidth), rmax2 = r2 + ValueT(halfWidth);
 
     // Radius below the Nyquist frequency
     if (r2 < ValueT(1.5)) return grid;
@@ -1706,7 +1706,7 @@ createPointScatter(const NanoGrid<SrcBuildT>& srcGrid, // origin of grid in worl
         dstLeaf->mValueMask = srcLeaf.valueMask();
         for (uint32_t j = 0, m = 0; j < 512; ++j) {
             if (dstLeaf->mValueMask.isOn(j)) {
-                const Vec3f ijk = dstLeaf->offsetToGlobalCoord(j).asVec3s();// floating-point representatrion of index coorindates
+                const Vec3f ijk = dstLeaf->offsetToGlobalCoord(j).asVec3s();// floating-point representation of index coordinates
                 for (int n = 0; n < pointsPerVoxel; ++n) xyz.push_back(srcGrid.indexToWorld(randomPoint() + ijk));
                 m += pointsPerVoxel;
             }// active voxels

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/GridBuilder.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/GridBuilder.h
@@ -1158,7 +1158,7 @@ struct LeafNode
         ValueIterator& operator=(const ValueIterator&) = default;
         ValueType operator*() const { NANOVDB_ASSERT(*this); return mParent->mValues[mPos];}
         Coord getCoord() const { NANOVDB_ASSERT(*this); return mParent->offsetToGlobalCoord(mPos);}
-        bool isActive() const { NANOVDB_ASSERT(*this); return mParent->isActive(mPos);}
+        bool isActive() const { NANOVDB_ASSERT(*this); return mParent->mValueMask.isOn(mPos);}
         operator bool() const {return mPos < SIZE;}
         ValueIterator& operator++() {++mPos; return *this;}
         ValueIterator operator++(int) {
@@ -1968,7 +1968,7 @@ void Grid<BuildT>::operator()(const Func& func, const CoordBBox& bbox, ValueType
                 NANOVDB_ASSERT(leaf == nullptr);
             }
         }// loop over sub-part of leafBBox
-        if (leaf) delete leaf;
+        delete leaf;
     });
 
     // Prune leaf and tile nodes

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/GridStats.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/GridStats.h
@@ -18,6 +18,7 @@
 #include <nanovdb/NanoVDB.h>
 
 #ifdef NANOVDB_USE_TBB
+#include <memory>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_reduce.h>
 #endif

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/NanoToOpenVDB.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/NanoToOpenVDB.h
@@ -15,179 +15,317 @@
 
 #include <nanovdb/NanoVDB.h> // manages and streams the raw memory buffer of a NanoVDB grid.
 #include <nanovdb/GridHandle.h>
+#include <nanovdb/util/Util.h>
 #include <nanovdb/util/ForEach.h>
 
 #include <openvdb/openvdb.h>
+#include <openvdb/tools/SignedFloodFill.h>
 
 #ifndef NANOVDB_TOOLS_NANOTOOPENVDB_H_HAS_BEEN_INCLUDED
 #define NANOVDB_TOOLS_NANOTOOPENVDB_H_HAS_BEEN_INCLUDED
-
-template<typename T>
-struct ConvertTrait {using Type = T;};
-
-template<typename T>
-struct ConvertTrait<nanovdb::math::Vec3<T>> {using Type = openvdb::math::Vec3<T>;};
-
-template<typename T>
-struct ConvertTrait<nanovdb::math::Vec4<T>> {using Type = openvdb::math::Vec4<T>;};
-
-template<>
-struct ConvertTrait<nanovdb::Fp4> {using Type = float;};
-
-template<>
-struct ConvertTrait<nanovdb::Fp8> {using Type = float;};
-
-template<>
-struct ConvertTrait<nanovdb::Fp16> {using Type = float;};
-
-template<>
-struct ConvertTrait<nanovdb::FpN> {using Type = float;};
-
-template<>
-struct ConvertTrait<nanovdb::ValueMask> {using Type = openvdb::ValueMask;};
 
 namespace nanovdb {
 
 namespace tools {
 
-/// @brief Forward declaration of free-standing function that de-serializes a typed NanoVDB grid into an OpenVDB Grid
-template<typename NanoBuildT>
-typename openvdb::Grid<typename openvdb::tree::Tree4<typename ConvertTrait<NanoBuildT>::Type>::Type>::Ptr
-nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid, int verbose = 0);
+namespace trait {
 
-/// @brief Forward declaration of free-standing function that de-serializes a NanoVDB GridHandle into an OpenVDB GridBase
+/// @brief Struct that maps all nanovdb types to corresponding openvdb types.
+/// @tparam T NanoVDB build type, e.g. nanovdb::ValueMask -> openvdb::ValueMask
+///         nanovdb::Fp8 -> float, nanovdb::ValueIndex -> uin64_t, float -> float
+/// @note Since Windows appears to always template instantiate the return_type in
+///       enable_if<bool, return_type>, MapToOpen is designed to work for all types T,
+///       even types like ValueOnIndex that doesn't have an openvdb analogue!
+template<typename T>// see below for more template specializations
+struct MapToOpen { using type = typename BuildToValueMap<T>::type; };
+
+template<typename T>
+using MapToOpenT = typename MapToOpen<T>::type;
+
+template <typename T>
+using OpenTree = typename openvdb::tree::Tree4<trait::MapToOpenT<T>, 5, 4, 3>::Type;
+
+template <typename T>
+using OpenGrid = openvdb::Grid< OpenTree<T> >;
+
+template <typename T>
+using OpenGridPtr = typename OpenGrid< T >::Ptr;
+
+}// trait namespace
+
+/// @brief Free-standing function that de-serializes a typed NanoVDB grid into an OpenVDB Grid
+/// @tparam NanoBuildT Template build type for the @c grid
+/// @param grid NanoVDB grid to be converted to an OpenVDB grid
+/// @return If NanoBuildT is an index type, e.g. ValueOnIndex, a shared pointer to an OpenVDB GridBase
+///         is returned. Otherwise a shared pointer to an OpenVDB Grid of a matching type
+///.        (trait::OpenGridPtr<NanoBuildT>) is returned.
+template<typename NanoBuildT>
+auto nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid);
+
+/// @brief Free-standing function that de-serializes an IndexGrid with a sidecar into an OpenVDB Grid
+/// @tparam NanoValueT Template type of the sidecar data accompanying the index @c grid
+/// @param grid IndexGrid into the sidecar data
+/// @param sideCar Linear array of sidecar data
+/// @param gridClass GridClass corresponding to the sidecar data
+/// @param gridName Name of the output grid
+/// @return Shared pointer to an OpenVDB Grid of a matching type (trait::OpenGridPtr<NanoValueT>)
+template<typename NanoBuildT, typename NanoValueT>
+util::enable_if_t<BuildTraits<NanoBuildT>::is_index, trait::OpenGridPtr<NanoValueT>>
+nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid,
+              const NanoValueT *sideCar,
+              GridClass gridClass = GridClass::Unknown,
+              const char *gridName = nullptr);
+
+/// @brief Forward declaration of free-standing function that de-serializes a grid in a NanoVDB GridHandle into an OpenVDB GridBase
+/// @tparam BufferT Template type of the buffer used to allocate the grid handle
+/// @param handle Handle for the input grid to be converted
+/// @param gridID ID of the grid in the GridHandle to be converted (defaults to first grid)
+/// @return Shared pointer to an OpenVDB BaseGrid
+/// @note If grid number @c gridID in @c handle has GridType IndexGrid, then the first suitable blind data is used as the sidecar data
 template<typename BufferT>
 openvdb::GridBase::Ptr
-nanoToOpenVDB(const GridHandle<BufferT>& handle, int verbose = 0, uint32_t n = 0);
+nanoToOpenVDB(const GridHandle<BufferT>& handle, uint32_t gridID = 0);
+
+// ================================================================================================
+
+namespace trait {
+
+template<>
+struct MapToOpen<ValueMask> {using type = openvdb::ValueMask;};
+
+template<typename T>
+struct MapToOpen<math::Vec3<T>>{using type = openvdb::math::Vec3<T>;};
+
+template<typename T>
+struct MapToOpen<math::Vec4<T>>{using type = openvdb::math::Vec4<T>;};
+
+template<typename T, uint32_t LEVEL>
+struct OpenNode;
+
+// Partial template specialization of the OpenNode struct
+template<typename T>
+struct OpenNode<T, 0> {using type = openvdb::tree::LeafNode<MapToOpenT<T>, 3>;};
+
+template<typename T>
+struct OpenNode<T, 1> {using type = openvdb::tree::InternalNode<typename OpenNode<T, 0>::type, 4>;};
+
+template<typename T>
+struct OpenNode<T, 2> {using type = openvdb::tree::InternalNode<typename OpenNode<T, 1>::type, 5>;};
+
+template<typename T, uint32_t LEVEL>
+using OpenNodeT = typename OpenNode<T, LEVEL>::type;
+
+/// @brief Maps from nanovdb::GridClass to openvdb::GridClass
+/// @param gridClass nanovdb::GridClass
+/// @return openvdb::GridClass
+static openvdb::GridClass toOpenGridClass(GridClass gridClass)
+{
+    switch (gridClass) {
+    case GridClass::LevelSet:
+        return openvdb::GRID_LEVEL_SET;
+    case GridClass::FogVolume:
+        return openvdb::GRID_FOG_VOLUME;
+    case GridClass::Staggered:
+        return openvdb::GRID_STAGGERED;
+    case GridClass::PointIndex:
+        throw std::runtime_error("NanoToOpenVDB does not yet support PointIndexGrids");
+    case GridClass::PointData:
+        throw std::runtime_error("NanoToOpenVDB does not yet support PointDataGrids");
+    default:
+        return openvdb::GRID_UNKNOWN;
+    }
+}
+
+template<typename T>
+static const auto* mapPtr(const T *v) {return reinterpret_cast<const typename MapToOpen<T>::type*>(v);}
+
+static openvdb::Coord mapCoord(const Coord &ijk){return openvdb::Coord(ijk[0], ijk[1], ijk[2]);}
+template<uint32_t LOG2DIM>
+
+static auto mapMask(const Mask<LOG2DIM> &m){return reinterpret_cast<const openvdb::util::NodeMask<LOG2DIM>&>(m);}
+
+}// trait namespace
 
 /// @brief This class will serialize an OpenVDB grid into a NanoVDB grid managed by a GridHandle.
-template<typename NanoBuildT>
 class NanoToOpenVDB
 {
-    using NanoNode0  = nanovdb::LeafNode<NanoBuildT, openvdb::Coord, openvdb::util::NodeMask>; // note that it's using openvdb coord nd mask types!
-    using NanoNode1  = nanovdb::InternalNode<NanoNode0>;
-    using NanoNode2  = nanovdb::InternalNode<NanoNode1>;
-    using NanoRootT  = nanovdb::RootNode<NanoNode2>;
-    using NanoTreeT  = nanovdb::Tree<NanoRootT>;
-    using NanoGridT  = nanovdb::Grid<NanoTreeT>;
-    using NanoValueT = typename NanoGridT::ValueType;
-
-    using OpenBuildT = typename ConvertTrait<NanoBuildT>::Type; // e.g. float -> float but nanovdb::math::Vec3<float> -> openvdb::Vec3<float>
-    using OpenNode0  = openvdb::tree::LeafNode<OpenBuildT, NanoNode0::LOG2DIM>; // leaf
-    using OpenNode1  = openvdb::tree::InternalNode<OpenNode0, NanoNode1::LOG2DIM>; // lower
-    using OpenNode2  = openvdb::tree::InternalNode<OpenNode1, NanoNode2::LOG2DIM>; // upper
-    using OpenRootT  = openvdb::tree::RootNode<OpenNode2>;
-    using OpenTreeT  = openvdb::tree::Tree<OpenRootT>;
-    using OpenGridT  = openvdb::Grid<OpenTreeT>;
-    using OpenValueT = typename OpenGridT::ValueType;
-
 public:
-    /// @brief Construction from an existing const OpenVDB Grid.
-    NanoToOpenVDB(){};
 
-    /// @brief Return a shared pointer to a NanoVDB grid constructed from the specified OpenVDB grid
-    typename OpenGridT::Ptr operator()(const NanoGrid<NanoBuildT>& grid, int verbose = 0);
+    /// @brief Default c-tor
+    NanoToOpenVDB(){}
+
+    /// @brief Converts nanovdb::Grid<T> -> openvdb::Grid<T>::Ptr
+    /// @tparam NanoBuildT Template type for the input NanoVDB grid
+    /// @param grid NanoVDB grid to be converted
+    /// @return Shared pointer to an OpenVDB grid of matching type
+    template<typename NanoBuildT>
+    util::disable_if_t<BuildTraits<NanoBuildT>::is_index, trait::OpenGridPtr<NanoBuildT>>
+    operator()(const NanoGrid<NanoBuildT>& grid);
+
+    /// @brief Converts nanovdb::Grid<Index> + blind data  -> openvdb::GridBase::Ptr
+    /// @param idxGrid NanoVDB IndexGrid with blind data to be converted
+    /// @param blindDataID Id of the bind data to be used as the sidecar. A negative values means
+    ///        pick the first available (relevant) blind data.
+    /// @return shared pointer to an OpenVDB GridBase
+    template<typename NanoIndexT>
+    util::enable_if_t<BuildTraits<NanoIndexT>::is_index, openvdb::GridBase::Ptr>
+    operator()(const NanoGrid<NanoIndexT>& idxGrid, int blindDataID = -1);
+
+    /// @brief Converts nanovdb::Grid<NanoIndexT> + NanoValueT[]  -> openvdb::Grid<NanoValueT>::Ptr
+    /// @tparam NanoValueT Template to of the sidecar data
+    /// @param grid NanoVDB IndexGrid
+    /// @param sideCar Linear array of sidecar data
+    /// @param gridClass GridClass of the @c sideCar data
+    /// @param name Name of the output grid
+    /// @return Shared pointer to an OpenVDB grid of matching type
+    template<typename NanoIndexT, typename NanoValueT>
+    util::enable_if_t<BuildTraits<NanoIndexT>::is_index, trait::OpenGridPtr<NanoValueT>>
+    operator()(const NanoGrid<NanoIndexT>& grid,
+               const NanoValueT *sideCar,
+               GridClass gridClass = GridClass::Unknown,
+               const char *name = nullptr);
 
 private:
 
-    template<typename NanoNodeT, typename OpenNodeT>
-    OpenNodeT* processNode(const NanoNodeT*);
+    template<int LEVEL, typename NanoBuildT>
+    util::disable_if_t<BuildTraits<NanoBuildT>::is_index || LEVEL == 0>
+    process(trait::OpenNodeT<NanoBuildT, LEVEL>*, const NanoNodeT<NanoBuildT, LEVEL>*);
 
-    OpenNode2* process(const NanoNode2* node) {return this->template processNode<NanoNode2, OpenNode2>(node);}
-    OpenNode1* process(const NanoNode1* node) {return this->template processNode<NanoNode1, OpenNode1>(node);}
+    template<int LEVEL, typename NanoIndexT, typename NanoValueT>
+    util::enable_if_t<BuildTraits<NanoIndexT>::is_index && LEVEL != 0>
+    process(trait::OpenNodeT<NanoValueT, LEVEL>*, const NanoNodeT<NanoIndexT, LEVEL>*, const NanoValueT*);
 
-    template <typename NanoLeafT>
-    typename std::enable_if<!std::is_same<bool, typename NanoLeafT::BuildType>::value &&
-                            !std::is_same<ValueMask, typename NanoLeafT::BuildType>::value &&
-                            !std::is_same<Fp4, typename NanoLeafT::BuildType>::value &&
-                            !std::is_same<Fp8, typename NanoLeafT::BuildType>::value &&
-                            !std::is_same<Fp16,typename NanoLeafT::BuildType>::value &&
-                            !std::is_same<FpN, typename NanoLeafT::BuildType>::value,
-                            OpenNode0*>::type
-    process(const NanoLeafT* node);
+    template<int LEVEL, typename NanoBuildT>
+    util::disable_if_t<BuildTraits<NanoBuildT>::is_index || LEVEL != 0>
+    process(trait::OpenNodeT<NanoBuildT, LEVEL>*, const NanoNodeT<NanoBuildT, LEVEL>*);
 
-    template <typename NanoLeafT>
-    typename std::enable_if<std::is_same<Fp4, typename NanoLeafT::BuildType>::value ||
-                            std::is_same<Fp8, typename NanoLeafT::BuildType>::value ||
-                            std::is_same<Fp16,typename NanoLeafT::BuildType>::value ||
-                            std::is_same<FpN, typename NanoLeafT::BuildType>::value,
-                            OpenNode0*>::type
-    process(const NanoLeafT* node);
-
-    template <typename NanoLeafT>
-    typename std::enable_if<std::is_same<ValueMask, typename NanoLeafT::BuildType>::value,
-                            OpenNode0*>::type
-    process(const NanoLeafT* node);
-
-    template <typename NanoLeafT>
-    typename std::enable_if<std::is_same<bool, typename NanoLeafT::BuildType>::value,
-                            OpenNode0*>::type
-    process(const NanoLeafT* node);
-
-    /// converts nanovdb value types to openvdb value types, e.g. nanovdb::Vec3f& -> openvdb::Vec3f&
-    static const OpenValueT& Convert(const NanoValueT &v) {return reinterpret_cast<const OpenValueT&>(v);}
-    static const OpenValueT* Convert(const NanoValueT *v) {return reinterpret_cast<const OpenValueT*>(v);}
+    template<int LEVEL, typename NanoIndexT, typename NanoValueT>
+    util::enable_if_t<BuildTraits<NanoIndexT>::is_index && LEVEL == 0>
+    process(trait::OpenNodeT<NanoValueT, LEVEL>*, const NanoNodeT<NanoIndexT, LEVEL>*, const NanoValueT*);
 
 }; // NanoToOpenVDB class
 
-template<typename NanoBuildT>
-typename NanoToOpenVDB<NanoBuildT>::OpenGridT::Ptr
-NanoToOpenVDB<NanoBuildT>::operator()(const NanoGrid<NanoBuildT>& grid, int /*verbose*/)
-{
-    // since the input nanovdb grid might use nanovdb types (Coord, Mask, Vec3) we cast to use openvdb types
-    const NanoGridT *srcGrid = reinterpret_cast<const NanoGridT*>(&grid);
+// ================================================================================================
 
-    auto dstGrid = openvdb::createGrid<OpenGridT>(Convert(srcGrid->tree().background()));
-    dstGrid->setName(srcGrid->gridName()); // set grid name
-    switch (srcGrid->gridClass()) { // set grid class
-    case nanovdb::GridClass::LevelSet:
-        dstGrid->setGridClass(openvdb::GRID_LEVEL_SET);
-        break;
-    case nanovdb::GridClass::FogVolume:
-        dstGrid->setGridClass(openvdb::GRID_FOG_VOLUME);
-        break;
-    case nanovdb::GridClass::Staggered:
-        dstGrid->setGridClass(openvdb::GRID_STAGGERED);
-        break;
-    case nanovdb::GridClass::PointIndex:
-        throw std::runtime_error("NanoToOpenVDB does not yet support PointIndexGrids");
-    case nanovdb::GridClass::PointData:
-        throw std::runtime_error("NanoToOpenVDB does not yet support PointDataGrids");
-    default:
-        dstGrid->setGridClass(openvdb::GRID_UNKNOWN);
-    }
-    // set transform
-    const nanovdb::Map& nanoMap = reinterpret_cast<const GridData*>(srcGrid)->mMap;
-    auto                mat = openvdb::math::Mat4<double>::identity();
+template<typename NanoBuildT>
+util::disable_if_t<BuildTraits<NanoBuildT>::is_index, trait::OpenGridPtr<NanoBuildT>>
+NanoToOpenVDB::operator()(const NanoGrid<NanoBuildT>& srcGrid)
+{
+    // Create an empty OpenVDB destination grid
+    auto dstGrid = openvdb::createGrid<trait::OpenGrid<NanoBuildT>>(*trait::mapPtr(&srcGrid.tree().background()));
+    dstGrid->setName(srcGrid.gridName()); // set grid name
+    dstGrid->setGridClass(trait::toOpenGridClass(srcGrid.gridClass()));
+
+    // set world to index transform
+    const Map& nanoMap = reinterpret_cast<const GridData&>(srcGrid).mMap;
+    auto  mat = openvdb::math::Mat4<double>::identity();
     mat.setMat3(openvdb::math::Mat3<double>(nanoMap.mMatD));
-    mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3
+    mat = mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3
     mat.setTranslation(openvdb::math::Vec3<double>(nanoMap.mVecD));
     dstGrid->setTransform(openvdb::math::Transform::createLinearTransform(mat)); // calls simplify!
 
-    // process root node
+    // process root node and recursively call its child inner nodes
     auto &root = dstGrid->tree().root();
-    auto *data = srcGrid->tree().root().data();
+    auto *data = srcGrid.tree().root().data();
     for (uint32_t i=0; i<data->mTableSize; ++i) {
         auto *tile = data->tile(i);
         if (tile->isChild()) {
-            root.addChild( this->process( data->getChild(tile)) );
+            auto *dstChild = new trait::OpenNodeT<NanoBuildT, 2>();// un-initialized
+            this->template process<2, NanoBuildT>( dstChild, data->getChild(tile) );
+            root.addChild( dstChild );
         } else {
-            root.addTile(tile->origin(), Convert(tile->value), tile->state);
+            root.addTile(trait::mapCoord(tile->origin()), *trait::mapPtr(&tile->value), tile->state);
         }
     }
 
     return dstGrid;
-}
+}// NanoToOpenVDB::operator()(const NanoGrid<NanoBuildT>& grid)
 
-template<typename T>
-template<typename SrcNodeT, typename DstNodeT>
-DstNodeT*
-NanoToOpenVDB<T>::processNode(const SrcNodeT *srcNode)
+template<typename NanoIndexT, typename NanoValueT>
+util::enable_if_t<BuildTraits<NanoIndexT>::is_index, trait::OpenGridPtr<NanoValueT>>
+NanoToOpenVDB::operator()(const NanoGrid<NanoIndexT>& indexGrid,
+                          const NanoValueT *sideCar,
+                          GridClass gridClass,
+                          const char *name)
 {
-    DstNodeT *dstNode = new DstNodeT(); // un-initialized for fast construction
-    dstNode->setOrigin(srcNode->origin());
-    const auto& childMask = srcNode->childMask();
-    const_cast<typename DstNodeT::NodeMaskType&>(dstNode->getValueMask()) = srcNode->valueMask();
+    // Create an empty OpenVDB destination grid
+    auto dstGrid = openvdb::createGrid<trait::OpenGrid<NanoValueT>>(*trait::mapPtr(sideCar));//background is always the first value
+    if (name) dstGrid->setName(name); // set grid name
+    dstGrid->setGridClass(trait::toOpenGridClass(gridClass));
+
+    // set world to index transform
+    const Map& nanoMap = reinterpret_cast<const GridData&>(indexGrid).mMap;
+    auto  mat = openvdb::math::Mat4<double>::identity();
+    mat.setMat3(openvdb::math::Mat3<double>(nanoMap.mMatD));
+    mat = mat.transpose(); // the 3x3 in nanovdb is transposed relative to openvdb's 3x3
+    mat.setTranslation(openvdb::math::Vec3<double>(nanoMap.mVecD));
+    dstGrid->setTransform(openvdb::math::Transform::createLinearTransform(mat)); // calls simplify!
+
+    // process root node and recursively call its child inner nodes
+    auto &root = dstGrid->tree().root();
+    auto *data = indexGrid.tree().root().data();
+    for (uint32_t i=0; i<data->mTableSize; ++i) {
+        auto *tile = data->tile(i);
+        if (tile->isChild()) {
+            auto *dstChild = new trait::OpenNodeT<NanoValueT, 2>();// un-initialized
+            this->template process<2, NanoIndexT, NanoValueT>( dstChild, data->getChild(tile), sideCar );
+            root.addChild( dstChild );
+        } else {
+            root.addTile(trait::mapCoord(tile->origin()), *trait::mapPtr(sideCar + tile->value), tile->state);
+        }
+    }
+
+    if constexpr(util::is_same_v<NanoIndexT, ValueOnIndex>) {
+        if (gridClass == GridClass::LevelSet) openvdb::tools::signedFloodFill(dstGrid->tree());
+    }
+
+    return dstGrid;
+}// NanoToOpenVDB::operator()(const NanoGrid<ValueIndex>& grid, const NanoValueT*)
+
+template<typename NanoIndexT>
+util::enable_if_t<BuildTraits<NanoIndexT>::is_index, openvdb::GridBase::Ptr>
+NanoToOpenVDB::operator()(const NanoGrid<NanoIndexT>& idxGrid, int blindDataID)
+{
+    for (uint32_t i=0; i<idxGrid.blindDataCount(); ++i) {
+        if (blindDataID >= 0 && int(i) != blindDataID) continue;
+        const auto &metaData = idxGrid.blindMetaData(i);
+        if (metaData.mDataClass != GridBlindDataClass::ChannelArray ||
+            idxGrid.valueCount() != metaData.mValueCount) continue;
+
+        const GridClass gridClass = toGridClass(metaData.mSemantic);
+        switch (metaData.mDataType){
+        case GridType::Float:
+            NANOVDB_ASSERT(metaData.mValueSize == sizeof(float));
+            return (*this)(idxGrid, idxGrid.template getBlindData<float>(i), gridClass);
+        case GridType::Double:
+            NANOVDB_ASSERT(metaData.mValueSize == sizeof(double));
+            return (*this)(idxGrid, idxGrid.template getBlindData<double>(i), gridClass);
+        case GridType::Int32:
+            NANOVDB_ASSERT(metaData.mValueSize == sizeof(int32_t));
+            return (*this)(idxGrid, idxGrid.template getBlindData<int32_t>(i), gridClass);
+        case GridType::Vec3f:
+            NANOVDB_ASSERT(metaData.mValueSize == sizeof(Vec3f));
+            return (*this)(idxGrid, idxGrid.template getBlindData<Vec3f>(i), gridClass);
+        default:// required to avoid compiler warning
+            break;
+        }
+    }
+    OPENVDB_THROW(openvdb::RuntimeError, "No valid sidecar located in the blind data!");
+}// NanoToOpenVDB::operator()(const NanoGrid<NanoIndexT>& idxGrid)
+
+// ================================================================================================
+
+template<int LEVEL, typename NanoBuildT>
+util::disable_if_t<BuildTraits<NanoBuildT>::is_index || LEVEL == 0>
+NanoToOpenVDB::process(trait::OpenNodeT<NanoBuildT, LEVEL> *dstNode,
+                       const NanoNodeT<NanoBuildT, LEVEL>  *srcNode)
+{
+    using DstNodeT = trait::OpenNodeT<NanoBuildT, LEVEL>;
+    using SrcNodeT = NanoNodeT<NanoBuildT, LEVEL>;
+    dstNode->setOrigin(trait::mapCoord(srcNode->origin()));
+    const auto &childMask = trait::mapMask(srcNode->childMask());
+    const auto &valueMask = trait::mapMask(srcNode->valueMask());
+    const_cast<typename DstNodeT::NodeMaskType&>(dstNode->getValueMask()) = valueMask;
     const_cast<typename DstNodeT::NodeMaskType&>(dstNode->getChildMask()) = childMask;
     auto* dstTable = const_cast<typename DstNodeT::UnionType*>(dstNode->getTable());
     auto* srcData  = srcNode->data();
@@ -198,13 +336,17 @@ NanoToOpenVDB<T>::processNode(const SrcNodeT *srcNode)
         if (childMask.isOn(n)) {
             childNodes.emplace_back(n, srcData->getChild(n));
         } else {
-            dstTable[n].setValue(Convert(srcData->mTable[n].value));
+            dstTable[n].setValue(*trait::mapPtr(&srcData->mTable[n].value));
         }
     }
+    // Extract type alias before lambda for MSVC compatibility
+    using DstChildNodeType = typename DstNodeT::ChildNodeType;
     auto kernel = [&](const auto& r) {
         for (auto i = r.begin(); i != r.end(); ++i) {
             auto &p = childNodes[i];
-            dstTable[p.first].setChild( this->process(p.second) );
+            auto* dstChild = new DstChildNodeType();// un-initialized
+            this->template process<LEVEL-1, NanoBuildT>(dstChild, p.second);
+            dstTable[p.first].setChild( dstChild );
         }
     };
 
@@ -213,129 +355,181 @@ NanoToOpenVDB<T>::processNode(const SrcNodeT *srcNode)
 #else
     util::forEach(0, childCount, 1, kernel);
 #endif
-    return dstNode;
-} // processNode
+} // NanoToOpenVDB::process(const SrcNodeT *srcNode, DstNodeT *dstNode)
 
-template<typename T>
-template <typename NanoLeafT>
-inline typename std::enable_if<!std::is_same<bool, typename NanoLeafT::BuildType>::value &&
-                               !std::is_same<ValueMask, typename NanoLeafT::BuildType>::value &&
-                               !std::is_same<Fp4, typename NanoLeafT::BuildType>::value &&
-                               !std::is_same<Fp8, typename NanoLeafT::BuildType>::value &&
-                               !std::is_same<Fp16,typename NanoLeafT::BuildType>::value &&
-                               !std::is_same<FpN, typename NanoLeafT::BuildType>::value,
-                               typename NanoToOpenVDB<T>::OpenNode0*>::type
-NanoToOpenVDB<T>::process(const NanoLeafT *srcNode)
+template<int LEVEL, typename NanoIndexT, typename NanoValueT>
+util::enable_if_t<BuildTraits<NanoIndexT>::is_index && LEVEL != 0>
+NanoToOpenVDB::process(trait::OpenNodeT<NanoValueT, LEVEL> *dstNode,
+                       const NanoNodeT<NanoIndexT, LEVEL>  *srcNode,
+                       const NanoValueT* sideCar)
 {
-    static_assert(std::is_same<NanoLeafT, NanoNode0>::value, "NanoToOpenVDB<FpN>::process assert failed");
-    OpenNode0* dstNode = new OpenNode0(); // un-initialized for fast construction
-    dstNode->setOrigin(srcNode->origin());
-    dstNode->setValueMask(srcNode->valueMask());
-
-    const auto* src = Convert(srcNode->data()->mValues);// doesn't work for compressed data, bool or ValueMask
-    for (auto *dst = dstNode->buffer().data(), *end = dst + OpenNode0::SIZE; dst != end; dst += 4, src += 4) {
-        dst[0] = src[0];
-        dst[1] = src[1];
-        dst[2] = src[2];
-        dst[3] = src[3];
+    using DstNodeT = trait::OpenNodeT<NanoValueT, LEVEL>;
+    using SrcNodeT = NanoNodeT<NanoIndexT, LEVEL>;
+    dstNode->setOrigin(trait::mapCoord(srcNode->origin()));
+    const auto &childMask = trait::mapMask(srcNode->childMask());
+    const auto &valueMask = trait::mapMask(srcNode->valueMask());
+    const_cast<typename DstNodeT::NodeMaskType&>(dstNode->getValueMask()) = valueMask;
+    const_cast<typename DstNodeT::NodeMaskType&>(dstNode->getChildMask()) = childMask;
+    auto* dstTable = const_cast<typename DstNodeT::UnionType*>(dstNode->getTable());
+    auto* srcData  = srcNode->data();
+    std::vector<std::pair<uint32_t, const typename SrcNodeT::ChildNodeType*>> childNodes;
+    const auto childCount = childMask.countOn();
+    childNodes.reserve(childCount);
+    for (uint32_t n = 0; n < DstNodeT::NUM_VALUES; ++n) {
+        if (childMask.isOn(n)) {
+            childNodes.emplace_back(n, srcData->getChild(n));
+        } else {
+            dstTable[n].setValue(*trait::mapPtr(sideCar + srcData->mTable[n].value));
+        }
     }
+    // Extract type alias before lambda for MSVC compatibility
+    using DstChildNodeType = typename DstNodeT::ChildNodeType;
+    auto kernel = [&](const auto& r) {
+        for (auto i = r.begin(); i != r.end(); ++i) {
+            auto &p = childNodes[i];
+            auto *dstChild = new DstChildNodeType();// un-initialized
+            this->template process<LEVEL-1, NanoIndexT, NanoValueT>(dstChild, p.second, sideCar);
+            dstTable[p.first].setChild( dstChild );
+        }
+    };
 
-    return dstNode;
-} // process(NanoNode0)
+#if 0
+    kernel(Range1D(0, childCount));
+#else
+    util::forEach(0, childCount, 1, kernel);
+#endif
+} // NanoToOpenVDB::process(const SrcNodeT* srcNode, const ValueT* sideCar)
 
-template<typename T>
-template <typename NanoLeafT>
-inline typename std::enable_if<std::is_same<Fp4, typename NanoLeafT::BuildType>::value ||
-                               std::is_same<Fp8, typename NanoLeafT::BuildType>::value ||
-                               std::is_same<Fp16,typename NanoLeafT::BuildType>::value ||
-                               std::is_same<FpN, typename NanoLeafT::BuildType>::value,
-                               typename NanoToOpenVDB<T>::OpenNode0*>::type
-NanoToOpenVDB<T>::process(const NanoLeafT *srcNode)
+// ================================================================================================
+
+template<int LEVEL, typename NanoBuildT>
+util::disable_if_t<BuildTraits<NanoBuildT>::is_index || LEVEL != 0>
+NanoToOpenVDB::process(trait::OpenNodeT<NanoBuildT, LEVEL> *dstLeaf,
+                       const NanoNodeT<NanoBuildT, LEVEL>  *srcLeaf)
 {
-    static_assert(std::is_same<NanoLeafT, NanoNode0>::value, "NanoToOpenVDB<T>::process assert failed");
-    OpenNode0* dstNode = new OpenNode0(); // un-initialized for fast construction
-    dstNode->setOrigin(srcNode->origin());
-    dstNode->setValueMask(srcNode->valueMask());
-    float *dst = dstNode->buffer().data();
-    for (int i=0; i!=512; i+=4) {
-        *dst++ = srcNode->getValue(i);
-        *dst++ = srcNode->getValue(i+1);
-        *dst++ = srcNode->getValue(i+2);
-        *dst++ = srcNode->getValue(i+3);
+    dstLeaf->setOrigin(trait::mapCoord(srcLeaf->origin()));
+    dstLeaf->setValueMask(trait::mapMask(srcLeaf->valueMask()));
+
+    if constexpr(!BuildTraits<NanoBuildT>::is_special) {
+        const auto *src = trait::mapPtr(srcLeaf->data()->mValues);// doesn't work for compressed data, bool or ValueMask
+#if 1
+        std::copy(src, src + 512, dstLeaf->buffer().data());
+#else
+        for (auto *dst = dstLeaf->buffer().data(), *end = dst + 512; dst != end; dst += 4, src += 4) {
+            dst[0] = src[0];
+            dst[1] = src[1];
+            dst[2] = src[2];
+            dst[3] = src[3];
+        }
+#endif
+    } else if constexpr(BuildTraits<NanoBuildT>::is_Fp) {
+        float *dst = dstLeaf->buffer().data();
+        for (int i=0; i!=512; i+=4) {
+            *dst++ = srcLeaf->getValue(i);
+            *dst++ = srcLeaf->getValue(i+1);
+            *dst++ = srcLeaf->getValue(i+2);
+            *dst++ = srcLeaf->getValue(i+3);
+        }
+    } else if constexpr(util::is_same_v<NanoBuildT, bool>) {
+        reinterpret_cast<openvdb::util::NodeMask<3>&>(dstLeaf->buffer()) = trait::mapMask(srcLeaf->data()->mValues);
+    } else if constexpr(!util::is_same_v<NanoBuildT, ValueMask>) {
+        OPENVDB_THROW(openvdb::RuntimeError, "Unsupported NanoBuildT in NanoToOpenVDB::process(NanoLeaf<NanoBuildT>)");
     }
+}// NanoToOpenVDB::process(const NanoLeaf<NanoBuildT>* srcLeaf)
 
-    return dstNode;
-} // process(NanoNode0)
-
-template<typename T>
-template <typename NanoLeafT>
-inline typename std::enable_if<std::is_same<ValueMask, typename NanoLeafT::BuildType>::value,
-                               typename NanoToOpenVDB<T>::OpenNode0*>::type
-NanoToOpenVDB<T>::process(const NanoLeafT *srcNode)
+template<int LEVEL, typename NanoIndexT, typename NanoValueT>
+util::enable_if_t<BuildTraits<NanoIndexT>::is_index && LEVEL == 0>
+NanoToOpenVDB::process(trait::OpenNodeT<NanoValueT, LEVEL> *dstLeaf,
+                       const NanoNodeT<NanoIndexT, LEVEL>  *srcLeaf,
+                       const NanoValueT *sideCar)
 {
-    static_assert(std::is_same<NanoLeafT, NanoNode0>::value, "NanoToOpenVDB<ValueMask>::process assert failed");
-    OpenNode0* dstNode = new OpenNode0(); // un-initialized for fast construction
-    dstNode->setOrigin(srcNode->origin());
-    dstNode->setValueMask(srcNode->valueMask());
+    dstLeaf->setOrigin(trait::mapCoord(srcLeaf->origin()));
+    dstLeaf->setValueMask(trait::mapMask(srcLeaf->valueMask()));
 
-    return dstNode;
-} // process(NanoNode0)
+    if constexpr(!BuildTraits<NanoValueT>::is_special) {
+        if constexpr(util::is_same_v<NanoIndexT, ValueIndex>) {
+            const auto *src = trait::mapPtr(sideCar + srcLeaf->data()->mOffset);
+#if 1
+            std::copy(src, src + 512, dstLeaf->buffer().data());
+#else
+            for (auto *dst = dstLeaf->buffer().data(), *end = dst + 512; dst != end; dst += 4, src += 4) {
+                dst[0] = src[0];
+                dst[1] = src[1];
+                dst[2] = src[2];
+                dst[3] = src[3];
+            }
+#endif
+        } else {
+            const auto* src = trait::mapPtr(sideCar);
+            auto *dst = dstLeaf->buffer().data();
+            for (int i = 0; i < 512; i += 4) {
+                *dst++ = src[srcLeaf->getValue(i  )];
+                *dst++ = src[srcLeaf->getValue(i+1)];
+                *dst++ = src[srcLeaf->getValue(i+2)];
+                *dst++ = src[srcLeaf->getValue(i+3)];
+            }
+        }
+    } else {
+        OPENVDB_THROW(openvdb::RuntimeError, "Unsupported NanoValueT in NanoToOpenVDB::process(NanoLeaf<NanoIndexT>, NanoValueT*)");
+    }
+}// NanoToOpenVDB::process(const NanoLeaf<NanoIndexT>* srcLeaf, const NanoValueT *sideCar)
 
-template<typename T>
-template <typename NanoLeafT>
-inline typename std::enable_if<std::is_same<bool, typename NanoLeafT::BuildType>::value,
-                               typename NanoToOpenVDB<T>::OpenNode0*>::type
-NanoToOpenVDB<T>::process(const NanoLeafT *srcNode)
-{
-    static_assert(std::is_same<NanoLeafT, NanoNode0>::value, "NanoToOpenVDB<ValueMask>::process assert failed");
-    OpenNode0* dstNode = new OpenNode0(); // un-initialized for fast construction
-    dstNode->setOrigin(srcNode->origin());
-    dstNode->setValueMask(srcNode->valueMask());
-    reinterpret_cast<openvdb::util::NodeMask<3>&>(dstNode->buffer()) = srcNode->data()->mValues;
-
-    return dstNode;
-} // process(NanoNode0)
+// ================================================================================================
 
 template<typename NanoBuildT>
-inline typename openvdb::Grid<typename openvdb::tree::Tree4<typename ConvertTrait<NanoBuildT>::Type>::Type>::Ptr
-nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid, int verbose)
+auto nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid)
 {
-    NanoToOpenVDB<NanoBuildT> tmp;
-    return tmp(grid, verbose);
+    NanoToOpenVDB tmp;
+    return tmp(grid);
+}
+
+template<typename NanoBuildT, typename NanoValueT>
+util::enable_if_t<BuildTraits<NanoBuildT>::is_index, trait::OpenGridPtr<NanoValueT>>
+nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid,
+              const NanoValueT *sideCar,
+              GridClass gridClass,
+              const char *gridName)
+{
+    NanoToOpenVDB tmp;
+    return tmp(grid, sideCar, gridClass, gridName);
 }
 
 template<typename BufferT>
 openvdb::GridBase::Ptr
-nanoToOpenVDB(const GridHandle<BufferT>& handle, int verbose, uint32_t n)
+nanoToOpenVDB(const GridHandle<BufferT>& handle, uint32_t n)
 {
     if (auto grid = handle.template grid<float>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
+        return tools::nanoToOpenVDB(*grid);
     } else if (auto grid = handle.template grid<double>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
+        return tools::nanoToOpenVDB(*grid);
     } else if (auto grid = handle.template grid<int32_t>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
+        return tools::nanoToOpenVDB(*grid);
     } else if (auto grid = handle.template grid<int64_t>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
+        return tools::nanoToOpenVDB(*grid);
     } else if (auto grid = handle.template grid<bool>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Fp4>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Fp8>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Fp16>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::FpN>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::ValueMask>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Vec3f>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Vec3d>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Vec4f>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
-    } else if (auto grid = handle.template grid<nanovdb::Vec4d>(n)) {
-        return tools::nanoToOpenVDB(*grid, verbose);
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Fp4>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Fp8>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Fp16>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<FpN>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<ValueMask>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Vec3f>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Vec3d>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Vec4f>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<Vec4d>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<ValueOnIndex>(n)) {
+        return tools::nanoToOpenVDB(*grid);
+    } else if (auto grid = handle.template grid<ValueIndex>(n)) {
+        return tools::nanoToOpenVDB(*grid);
     } else {
         OPENVDB_THROW(openvdb::RuntimeError, "Unsupported NanoVDB grid type!");
     }
@@ -346,19 +540,17 @@ nanoToOpenVDB(const GridHandle<BufferT>& handle, int verbose, uint32_t n)
 /// @brief Forward declaration of free-standing function that de-serializes a typed NanoVDB grid into an OpenVDB Grid
 template<typename NanoBuildT>
 [[deprecated("Use nanovdb::tools::nanoToOpenVDB instead.")]]
-typename openvdb::Grid<typename openvdb::tree::Tree4<typename ConvertTrait<NanoBuildT>::Type>::Type>::Ptr
-nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid, int verbose = 0)
+tools::trait::OpenGridPtr<NanoBuildT> nanoToOpenVDB(const NanoGrid<NanoBuildT>& grid)
 {
-    return tools::nanoToOpenVDB(grid, verbose);
+    return tools::nanoToOpenVDB(grid);
 }
 
 /// @brief Forward declaration of free-standing function that de-serializes a NanoVDB GridHandle into an OpenVDB GridBase
 template<typename BufferT>
 [[deprecated("Use nanovdb::tools::nanoToOpenVDB instead.")]]
-openvdb::GridBase::Ptr
-nanoToOpenVDB(const GridHandle<BufferT>& handle, int verbose = 0, uint32_t n = 0)
+openvdb::GridBase::Ptr nanoToOpenVDB(const GridHandle<BufferT>& handle, uint32_t n = 0)
 {
-    return tools::nanoToOpenVDB(handle, verbose, n);
+    return tools::nanoToOpenVDB(handle, n);
 }
 
 } // namespace nanovdb

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/VoxelBlockManager.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/VoxelBlockManager.h
@@ -1,0 +1,148 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/VoxelBlockManager.h
+
+    \author Eftychios Sifakis
+
+    \date July 24, 2025
+
+    \brief Implements a handle class holding the metadata involved in invocations
+           of the VoxelBlockManager structure.
+           The VoxelBlockManager is an acceleration structure for sequential access
+           and stencil operations over solely the active voxels of an OnIndexGrid
+           which enables SIMT parallelism independent of occupancy.
+*/
+
+
+#ifndef NANOVDB_VOXELBLOCKMANAGER_H_HAS_BEEN_INCLUDED
+#define NANOVDB_VOXELBLOCKMANAGER_H_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/util/cuda/Util.h>
+
+namespace nanovdb {
+
+namespace tools {
+
+/// @brief This class serves to manage the raw memory buffers for the metadata of a NanoVDB VoxelBlockManager
+template<typename BufferT>
+class VoxelBlockManagerHandle
+{
+    BufferT mFirstLeafID;
+    BufferT mJumpMap;
+    uint64_t mBlockCount{0};
+    uint64_t mFirstOffset{0};
+    uint64_t mLastOffset{0};
+    uint32_t mLowerCount{0};
+
+public:
+    /// @brief Move constructor from metadata buffers
+    VoxelBlockManagerHandle(BufferT&& firstLeafID, BufferT&& jumpMap, const uint64_t blockCount,
+        const uint64_t firstOffset, const uint64_t lastOffset, const uint64_t lowerCount) {
+        mFirstLeafID = std::move(firstLeafID);
+        mJumpMap = std::move(jumpMap);
+        mBlockCount = blockCount;
+        mFirstOffset = firstOffset;
+        mLastOffset = lastOffset;
+        mLowerCount = lowerCount;
+    }
+
+    VoxelBlockManagerHandle() = default;
+    VoxelBlockManagerHandle(const VoxelBlockManagerHandle&) = delete;
+    VoxelBlockManagerHandle& operator=(const VoxelBlockManagerHandle&) = delete;
+
+    VoxelBlockManagerHandle& operator=(VoxelBlockManagerHandle&& other) noexcept {
+        mFirstLeafID = std::move(other.mFirstLeafID);
+        mJumpMap = std::move(other.mJumpMap);
+        mBlockCount = other.mblockCount;
+        mFirstOffset = other.mfirstOffset;
+        mLastOffset = other.mlastOffset;
+        mLowerCount = other.mlowerCount;
+        return *this;
+    }
+
+    VoxelBlockManagerHandle(VoxelBlockManagerHandle&& other) noexcept {
+        mFirstLeafID = std::move(other.mFirstLeafID);
+        mJumpMap = std::move(other.mJumpMap);
+        mBlockCount = other.mblockCount;
+        mFirstOffset = other.mfirstOffset;
+        mLastOffset = other.mlastOffset;
+        mLowerCount = other.mlowerCount;
+    }
+
+    ~VoxelBlockManagerHandle() { this->reset(); }
+    /// @brief clear the buffer
+    void reset() { mFirstLeafID.clear(); mJumpMap.clear(); mBlockCount = 0; }
+
+    /// @brief Returns a non-const pointer to the firstLeafID device-hosted data
+    ///
+    /// @warning Note that the return pointer can be NULL if the VoxelBlockManagerHandle was not initialized
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, uint32_t*>::type
+    deviceFirstLeafID() { return static_cast<uint32_t*>(mFirstLeafID.deviceData()); }
+
+    /// @brief Returns a const pointer to the firstLeafID device-hosted data
+    ///
+    /// @warning Note that the return pointer can be NULL if the VoxelBlockManagerHandle was not initialized
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, const uint32_t*>::type
+    deviceFirstLeafID() const { return static_cast<const uint32_t*>(mFirstLeafID.deviceData()); }
+
+    /// @brief Returns a non-const pointer to the jumpMap device-hosted data
+    ///
+    /// @warning Note that the return pointer can be NULL if the VoxelBlockManagerHandle was not initialized
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, uint64_t*>::type
+    deviceJumpMap() { return static_cast<uint64_t*>(mJumpMap.deviceData()); }
+
+    /// @brief Returns a const pointer to the jumpMap device-hosted data
+    ///
+    /// @warning Note that the return pointer can be NULL if the VoxelBlockManagerHandle was not initialized
+    template<typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, const uint64_t*>::type
+    deviceJumpMap() const { return static_cast<const uint64_t*>(mJumpMap.deviceData()); }
+
+    /// @brief Returns the number of voxel blocks in the VoxelBlockManager
+    uint64_t blockCount() const { return mBlockCount; }
+
+    /// @brief Sets the first and last voxel indices (linear offsets) associated with this VoxelBlockManager
+    void setOffsets(const uint64_t firstOffset, const uint64_t lastOffset) { mFirstOffset = firstOffset; mLastOffset = lastOffset; }
+
+    /// @brief Returns the first voxel index (linear offset) associated with this VoxelBlockManager
+    uint64_t firstOffset() const { return mFirstOffset; }
+
+    /// @brief Returns the last voxel index (linear offset) associated with this VoxelBlockManager
+    uint64_t lastOffset() const { return mLastOffset; }
+
+    /// @brief Sets the count of lower internal nodes in the IndexGrid associated with this VoxelBlockManager
+    void setLowerCount(const uint32_t lowerCount) { mLowerCount = lowerCount; }
+
+    /// @brief Returns the count of lower internal nodes in the IndexGrid associated with this VoxelBlockManager
+    uint32_t lowerCount() const { return mLowerCount; }
+
+    /// @brief Allocates new buffers for metadata, adequate for storing a VoxelBlockManager of the specified block size
+    template<int BlockWidthLog2, typename U = BufferT>
+    typename util::enable_if<BufferTraits<U>::hasDeviceDual, void>::type
+    deviceResize(const uint64_t blockCount, cudaStream_t stream = 0) {
+        static constexpr int BlockWidth = 1 << BlockWidthLog2;
+        reset();
+        int device = 0;
+        cudaCheck(cudaGetDevice(&device));
+        mBlockCount = blockCount;
+        mFirstLeafID = BufferT::create(blockCount*sizeof(uint32_t), nullptr, device, stream);
+        mJumpMap = BufferT::create(blockCount*(BlockWidth/8), nullptr, device, stream);
+    }
+
+}; // VoxelBlockManagerHandle
+
+} // namespace tools
+
+} // namespace nanovdb
+
+#if defined(__CUDACC__)
+#include <nanovdb/tools/cuda/VoxelBlockManager.cuh>
+#endif// defined(__CUDACC__)
+
+#endif // NANOVDB_VOXELBLOCKMANAGER_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/AddBlindData.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/AddBlindData.cuh
@@ -14,8 +14,8 @@
              to only include it in .cu files (or other .cuh files)
 */
 
-#ifndef NVIDIA_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED
-#define NVIDIA_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED
+#ifndef NANOVDB_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/cuda/DeviceBuffer.h>
@@ -143,4 +143,4 @@ cudaAddBlindData(const NanoGrid<BuildT> *d_grid,
 
 }// namespace nanovdb
 
-#endif // NVIDIA_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED
+#endif // NANOVDB_TOOLS_CUDA_ADDBLINDDATA_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/CoarsenGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/CoarsenGrid.cuh
@@ -1,0 +1,252 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/CoarsenGrid.cuh
+
+    \authors Efty Sifakis
+
+    \brief 2x Topological coarsening of NanoVDB indexGrids on the device
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_COARSENGRID_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_COARSENGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Morphology.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h>
+
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class CoarsenGrid
+{
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param deviceGrid source device grid to be coarsened
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    CoarsenGrid(const GridT* d_srcGrid, cudaStream_t stream = 0)
+        : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrid(d_srcGrid) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable){mBuilder.mChecksum = mode;}
+
+    /// @brief Creates a handle to the coarsened grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+private:
+    void coarsenRoot();
+
+    void coarsenInternalNodes();
+
+    void processGridTreeRoot();
+
+    void coarsenLeafNodes();
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT> mBuilder;
+    cudaStream_t            mStream{0};
+    util::cuda::Timer       mTimer;
+    int                     mVerbose{0};
+    const GridT             *mDeviceSrcGrid;
+    TreeData                mSrcTreeData;
+};// tools::cuda::CoarsenGrid<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+CoarsenGrid<BuildT>::getHandle(const BufferT &pool)
+{
+    // Copy TreeData from GPU -> CPU
+    cudaStreamSynchronize(mStream);
+    mSrcTreeData = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid);
+
+    // Ensure that the input grid contains no tile values
+    if (mSrcTreeData.mTileCount[2] || mSrcTreeData.mTileCount[1] || mSrcTreeData.mTileCount[0])
+        throw std::runtime_error("Topological operations not supported on grids with value tiles");
+
+    // Coarsen root node
+    if (mVerbose==1) mTimer.start("\nCoarsening root node");
+    coarsenRoot();
+
+    // Allocate memory for coarsened upper/lower masks
+    if (mVerbose==1) mTimer.restart("Allocating internal node mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+
+    // Coarsen masks of upper/lower nodes
+    if (mVerbose==1) mTimer.restart("Coarsening internal nodes");
+    coarsenInternalNodes();
+
+    // Enumerate tree nodes
+    if (mVerbose==1) mTimer.restart("Count coarsened tree nodes");
+    mBuilder.countNodes(mStream);
+
+    cudaStreamSynchronize(mStream);
+
+    // Allocate new device grid buffer for coarsened result
+    if (mVerbose==1) mTimer.restart("Allocating coarsened grid buffer");
+    auto buffer = mBuilder.getBuffer(pool, mStream);
+
+    // Process GridData/TreeData/RootData of coarsened result
+    if (mVerbose==1) mTimer.restart("Processing grid/tree/root");
+    processGridTreeRoot();
+
+    // Process upper nodes of coarsened result
+    if (mVerbose==1) mTimer.restart("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+
+    // Process lower nodes of coarsened result
+    if (mVerbose==1) mTimer.restart("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+
+    // Coarsen leaf node active masks into new topology
+    if (mVerbose==1) mTimer.restart("Coarsen leaf nodes");
+    coarsenLeafNodes();
+
+    // Process bounding boxes
+    if (mVerbose==1) mTimer.restart("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+
+    // Post-process Grid/Tree data
+    if (mVerbose==1) mTimer.restart("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// CoarsenGrid<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void CoarsenGrid<BuildT>::coarsenRoot()
+{
+    // This method coarsens the root tiles, to accommodate for the overall downsamping operation.
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    std::map<uint64_t, typename RootT::DataType::Tile> coarsenedTiles;
+
+    // This encoding scheme mirrors the one used in PointsToGrid; note that it is different from Tile::key
+    auto coordToKey = [](const Coord &ijk)->uint64_t{
+        // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+        static constexpr int64_t kOffset = 1 << 31;
+        return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+    };// coordToKey lambda functor
+
+    if (mSrcTreeData.mVoxelCount) { // If the input grid is not empty
+        // Make a host copy of the Root topology
+        auto deviceSrcRoot = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid, GridT::memUsage() + mSrcTreeData.mNodeOffset[3]));
+        uint64_t rootSize = mSrcTreeData.mNodeOffset[2] - mSrcTreeData.mNodeOffset[3];
+        auto srcRootBuffer = nanovdb::HostBuffer::create(rootSize);
+        cudaCheck(cudaMemcpyAsync(srcRootBuffer.data(), deviceSrcRoot, rootSize, cudaMemcpyDeviceToHost, mStream));
+        auto srcRoot = static_cast<RootT*>(srcRootBuffer.data());
+
+        // Add all root tiles, reordering if necessary
+        for (uint32_t t = 0; t < srcRoot->tileCount(); t++) {
+            auto coarsenedOrigin = util::morphology::coarsenCoord(srcRoot->tile(t)->origin());
+            auto sortKey = coordToKey(coarsenedOrigin); // key used in the radix sort, in accordance with PointsToGrid
+            auto tileKey = RootT::CoordToKey(coarsenedOrigin); // encoding used in the NanoVDB tile
+            typename RootT::Tile coarsenedTile{tileKey}; // Only the key value is needed; child pointer & value will be unused
+            coarsenedTiles.emplace(sortKey, coarsenedTile);
+        }
+    }
+
+    // Package the new root topology into a RootNode plus Tile list; upload to the GPU
+    uint64_t rootSize = RootT::memUsage(coarsenedTiles.size());
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto coarsenedRootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    coarsenedRootPtr->mTableSize = coarsenedTiles.size();
+    uint32_t t = 0;
+    for (const auto& [key, tile] : coarsenedTiles)
+        *coarsenedRootPtr->tile(t++) = tile;
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+}// CoarsenGrid<BuildT>::coarsenRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void CoarsenGrid<BuildT>::coarsenInternalNodes()
+{
+    // Computes the masks of upper and (densified) lower internal nodes, as a result of the coarsening operation
+    // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
+    // as if every upper node had a full set of 32^3 lower children
+    if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::CoarsenInternalNodesFunctor<BuildT>(),
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+    }
+}// CoarsenGrid<BuildT>::coarsenInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void CoarsenGrid<BuildT>::processGridTreeRoot()
+{
+    // Copy GridData from source grid
+    // By convention: this will duplicate grid name and map. Others will be reset later
+    cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
+    cudaCheckError();
+}// CoarsenGrid<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void CoarsenGrid<BuildT>::coarsenLeafNodes()
+{
+    // Coarsens the active masks of the source grid (as indicated at the leaf level), into a new grid that
+    // has been already topologically coarsened to include all necessary leaf nodes.
+    auto srcLeafCount = mSrcTreeData.mNodeCount[0];
+    if (srcLeafCount) { // Unless grid is empty
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::CoarsenLeafMasksFunctor<BuildT>(), mDeviceSrcGrid, &mBuilder.data()->getGrid());
+    }
+
+    // Update leaf offsets and prefix sums
+    mBuilder.processLeafOffsets(mStream);
+}// CoarsenGrid<BuildT>::coarsenLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_COARSENGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/DilateGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/DilateGrid.cuh
@@ -1,0 +1,296 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/DilateGrid.cuh
+
+    \authors Efty Sifakis
+
+    \brief Morphological dilation of NanoVDB indexGrids on the device
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_DILATEGRID_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_DILATEGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Morphology.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h>
+
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class DilateGrid
+{
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param deviceGrid source device grid to be dilated
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    DilateGrid(const GridT* d_srcGrid, cudaStream_t stream = 0)
+        : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrid(d_srcGrid) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable){mBuilder.mChecksum = mode;}
+
+    /// @brief Set type of dilation operation
+    /// @param op: NN_FACE=face neighbors, NN_FACE_EDGE=face and edge neibhros, NN_FACE_EDGE_VERTEX=26-connected neighbors
+    void setOperation(morphology::NearestNeighbors op) { mOp = op; }
+
+    /// @brief Creates a handle to the dilated grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+private:
+    void dilateRoot();
+
+    void dilateInternalNodes();
+
+    void processGridTreeRoot();
+
+    void dilateLeafNodes();
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT>      mBuilder;
+    cudaStream_t                 mStream{0};
+    util::cuda::Timer            mTimer;
+    int                          mVerbose{0};
+    const GridT                  *mDeviceSrcGrid;
+    morphology::NearestNeighbors mOp{morphology::NN_FACE_EDGE_VERTEX};
+    TreeData                     mSrcTreeData;
+};// tools::cuda::DilateGrid<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+DilateGrid<BuildT>::getHandle(const BufferT &pool)
+{
+    // Copy TreeData from GPU -> CPU
+    cudaStreamSynchronize(mStream);
+    mSrcTreeData = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid);
+
+    // Ensure that the input grid contains no tile values
+    if (mSrcTreeData.mTileCount[2] || mSrcTreeData.mTileCount[1] || mSrcTreeData.mTileCount[0])
+        throw std::runtime_error("Topological operations not supported on grids with value tiles");
+
+    // Speculatively dilate root node
+    if (mVerbose==1) mTimer.start("\nDilating root node");
+    dilateRoot();
+
+    // Allocate memory for dilated upper/lower masks
+    if (mVerbose==1) mTimer.restart("Allocating internal node mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+
+    // Dilate masks of upper/lower nodes
+    if (mVerbose==1) mTimer.restart("Dilate internal nodes");
+    dilateInternalNodes();
+
+    // Enumerate tree nodes
+    if (mVerbose==1) mTimer.restart("Count dilated tree nodes");
+    mBuilder.countNodes(mStream);
+
+    cudaStreamSynchronize(mStream);
+
+    // Allocate new device grid buffer for dilated result
+    if (mVerbose==1) mTimer.restart("Allocating dilated grid buffer");
+    auto buffer = mBuilder.getBuffer(pool, mStream);
+
+    // Process GridData/TreeData/RootData of dilated result
+    if (mVerbose==1) mTimer.restart("Processing grid/tree/root");
+    processGridTreeRoot();
+
+    // Process upper nodes of dilated result
+    if (mVerbose==1) mTimer.restart("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+
+    // Process lower nodes of dilated result
+    if (mVerbose==1) mTimer.restart("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+
+    // Dilate leaf node active masks into new topology
+    if (mVerbose==1) mTimer.restart("Dilating leaf nodes");
+    dilateLeafNodes();
+
+    // Process bounding boxes
+    if (mVerbose==1) mTimer.restart("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+
+    // Post-process Grid/Tree data
+    if (mVerbose==1) mTimer.restart("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// DilateGrid<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void DilateGrid<BuildT>::dilateRoot()
+{
+    // This method conservatively and speculatively dilates the root tiles, to accommodate
+    // any new root nodes that might be introduced by the dilation operation.
+    // The index-space bounding box of each tile is examined, and if it is within a 1-pixel of
+    // intersecting any of the 26-connected neighboring root tiles, those are preemptively
+    // introduced into the root topology.
+    // (As of the present implementation this presumes a maximum of 1-voxel radius in dilation)
+    // Root tiles that were preemptively introduced, but end up having no active contents will
+    // be pruned in later stages of processing.
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    std::map<uint64_t, typename RootT::DataType::Tile> dilatedTiles;
+
+    // This encoding scheme mirrors the one used in PointsToGrid; note that it is different from Tile::key
+    auto coordToKey = [](const Coord &ijk)->uint64_t{
+        // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+        static constexpr int64_t kOffset = 1 << 31;
+        return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+    };// coordToKey lambda functor
+
+    if (mSrcTreeData.mVoxelCount) { // If the input grid is not empty
+        // Make a host copy of the source topology RootNode *and* the Upper Nodes (needed for BBox'es)
+        // TODO: Consider avoiding to copy the entire set of upper nodes
+        auto deviceSrcRoot = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid, GridT::memUsage() + mSrcTreeData.mNodeOffset[3]));
+        uint64_t rootAndUpperSize = mSrcTreeData.mNodeOffset[1] - mSrcTreeData.mNodeOffset[3];
+        auto srcRootAndUpperBuffer = nanovdb::HostBuffer::create(rootAndUpperSize);
+        cudaCheck(cudaMemcpyAsync(srcRootAndUpperBuffer.data(), deviceSrcRoot, rootAndUpperSize, cudaMemcpyDeviceToHost, mStream));
+        auto srcRootAndUpper = static_cast<RootT*>(srcRootAndUpperBuffer.data());
+
+        // For each original root tile, consider adding those tiles in its 26-connected neighborhood
+        for (uint32_t t = 0; t < srcRootAndUpper->tileCount(); t++) {
+            auto srcUpper = srcRootAndUpper->getChild(srcRootAndUpper->tile(t));
+            const auto dilatedBBox = srcUpper->bbox().expandBy(1); // TODO: update/specialize if larger dilation neighborhoods are used
+
+            static constexpr int32_t rootTileDim = UpperT::DIM; // 4096
+            for (int di = -rootTileDim; di <= rootTileDim; di += rootTileDim)
+            for (int dj = -rootTileDim; dj <= rootTileDim; dj += rootTileDim)
+            for (int dk = -rootTileDim; dk <= rootTileDim; dk += rootTileDim) {
+                auto testBBox = nanovdb::CoordBBox::createCube(srcUpper->origin().offsetBy(di,dj,dk), rootTileDim);
+                auto sortKey = coordToKey(testBBox.min()); // key used in the radix sort, in accordance with PointsToGrid
+                auto tileKey = RootT::CoordToKey(testBBox.min()); // encoding used in the NanoVDB tile
+                if (testBBox.hasOverlap(dilatedBBox) & (dilatedTiles.count(sortKey) == 0)) {
+                    typename RootT::Tile neighborTile{tileKey}; // Only the key value is needed; child pointer & value will be unused
+                    dilatedTiles.emplace(sortKey, neighborTile);
+                }
+            }
+        }
+    }
+
+    // Package the new root topology into a RootNode plus Tile list; upload to the GPU
+    uint64_t rootSize = RootT::memUsage(dilatedTiles.size());
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto dilatedRootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    dilatedRootPtr->mTableSize = dilatedTiles.size();
+    uint32_t t = 0;
+    for (const auto& [key, tile] : dilatedTiles)
+        *dilatedRootPtr->tile(t++) = tile;
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+}// DilateGrid<BuildT>::dilateRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void DilateGrid<BuildT>::dilateInternalNodes()
+{
+    // Computes the masks of upper and (densified) lower internal nodes, as a result of the dilation operation
+    // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
+    // as if every upper node had a full set of 32^3 lower children
+    if (mSrcTreeData.mNodeCount[1]) { // Unless it's an empty grid
+        if (mOp == morphology::NN_FACE) {
+            using Op = util::morphology::cuda::DilateInternalNodesFunctor<BuildT, morphology::NN_FACE>;
+            util::cuda::operatorKernel<Op>
+                <<<dim3(mSrcTreeData.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+                (mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks()); }
+        else if (mOp == morphology::NN_FACE_EDGE) {
+            using Op = util::morphology::cuda::DilateInternalNodesFunctor<BuildT, morphology::NN_FACE_EDGE>;
+            util::cuda::operatorKernel<Op>
+                <<<dim3(mSrcTreeData.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+                (mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks()); }
+        else if (mOp == morphology::NN_FACE_EDGE_VERTEX) {
+            using Op = util::morphology::cuda::DilateInternalNodesFunctor<BuildT, morphology::NN_FACE_EDGE_VERTEX>;
+            util::cuda::operatorKernel<Op>
+                <<<dim3(mSrcTreeData.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+                (mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks()); }
+    }
+}// DilateGrid<BuildT>::dilateInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void DilateGrid<BuildT>::processGridTreeRoot()
+{
+    // Copy GridData from source grid
+    // By convention: this will duplicate grid name and map. Others will be reset later
+    cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
+    cudaCheckError();
+}// DilateGrid<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void DilateGrid<BuildT>::dilateLeafNodes()
+{
+    // Dilates the active masks of the source grid (as indicated at the leaf level), into a new grid that
+    // has been already topologically dilated to include all necessary leaf nodes.
+    if (mBuilder.data()->nodeCount[1]) { // Unless output grid is empty
+        if (mOp == morphology::NN_FACE) {
+            using Op = util::morphology::cuda::DilateLeafNodesFunctor<BuildT, morphology::NN_FACE>;
+            util::cuda::operatorKernel<Op>
+                <<<dim3(mBuilder.data()->nodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+                (mDeviceSrcGrid, static_cast<GridT*>(mBuilder.data()->d_bufferPtr)); }
+        else if (mOp == morphology::NN_FACE_EDGE)
+            throw std::runtime_error("dilateLeafNodes() not implemented for NN_FACE_EDGE stencil");
+        else if (mOp == morphology::NN_FACE_EDGE_VERTEX) {
+            using Op = util::morphology::cuda::DilateLeafNodesFunctor<BuildT, morphology::NN_FACE_EDGE_VERTEX>;
+            util::cuda::operatorKernel<Op>
+                <<<dim3(mBuilder.data()->nodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock>>>
+                (mDeviceSrcGrid, static_cast<GridT*>(mBuilder.data()->d_bufferPtr)); }
+    }
+
+    // Update leaf offsets and prefix sums
+    mBuilder.processLeafOffsets(mStream);
+}// DilateGrid<BuildT>::dilateLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_DILATEGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/DistributedPointsToGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/DistributedPointsToGrid.cuh
@@ -1,0 +1,1078 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/DistributedPointsToGrid.cuh
+
+    \brief Generates NanoVDB grids from a list of voxels or points
+           in parallel using multiple GPUs
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NANOVDB_TOOLS_CUDA_DISTRIBUTEDPOINTSTOGRID_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_TOOLS_CUDA_DISTRIBUTEDPOINTSTOGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/DeviceMesh.h>
+#include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/cuda/UnifiedBuffer.h>
+#include <nanovdb/tools/cuda/PointsToGrid.cuh>
+#include <nanovdb/util/cuda/Util.h>
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+/// @brief Strided iterator for per-device leaf counts which are interleaved with upper and lower counts
+struct LeafCountIterator
+{
+    LeafCountIterator(uint32_t* nodeCounts) : mNodeCounts(nodeCounts) {}
+
+    template <typename Distance>
+    uint32_t operator[](Distance n) const { return mNodeCounts[3 * n]; }
+
+private:
+    uint32_t* mNodeCounts;
+};
+
+/// @brief Indicator functor that returns 1 if the input value matches the member value, 0 otherwise
+template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+struct EqualityIndicator
+{
+    EqualityIndicator(const T* value) : mValue(value) {}
+
+    __hostdev__
+    T operator()(const T& x) const
+    {
+        return x == (*mValue);
+    }
+private:
+    const T* mValue;
+};
+
+/// @brief Implements the merge path binary search algorithm in order to find the median across two sorted input key arrays
+template<typename KeyIteratorIn>
+__device__
+void mergePath(KeyIteratorIn keys1, size_t keys1Count, KeyIteratorIn keys2, size_t keys2Count, ptrdiff_t* key1Intervals, ptrdiff_t* key2Intervals, int intervalIndex)
+{
+    using key_type = typename ::cuda::std::iterator_traits<KeyIteratorIn>::value_type;
+
+    const size_t combinedIndex = intervalIndex * (keys1Count + keys2Count) / 2;
+    size_t leftTop = combinedIndex > keys1Count ? keys1Count : combinedIndex;
+    size_t rightTop = combinedIndex > keys1Count ? combinedIndex - keys1Count : 0;
+    size_t leftBottom = rightTop;
+
+    key_type leftKey;
+    key_type rightKey;
+    while(true)
+    {
+        ptrdiff_t offset = (leftTop - leftBottom) / 2;
+        ptrdiff_t leftMid = leftTop - offset;
+        ptrdiff_t rightMid = rightTop + offset;
+
+        if (leftMid > keys1Count - 1 || rightMid < 1) {
+            leftKey = 1;
+            rightKey = 0;
+        }
+        else {
+            leftKey = *(keys1 + leftMid);
+            rightKey = *(keys2 + rightMid - 1);
+        }
+
+        if (leftKey > rightKey) {
+            if (rightMid > keys2Count - 1 || leftMid < 1) {
+                leftKey = 0;
+                rightKey = 1;
+            }
+            else {
+                leftKey = *(keys1 + leftMid - 1);
+                rightKey = *(keys2 + rightMid);
+            }
+
+            if (leftKey <= rightKey) {
+                *key1Intervals = leftMid;
+                *key2Intervals = rightMid;
+                break;
+            }
+            else {
+                leftTop = leftMid - 1;
+                rightTop = rightMid + 1;
+            }
+        }
+        else {
+            leftBottom = leftMid + 1;
+        }
+    }
+}
+
+namespace kernels {
+
+/// @brief Kernel wrapper for the merge path algorithm
+template<typename KeyIteratorIn>
+__global__
+void mergePathKernel(KeyIteratorIn keys1, size_t keys1Count, KeyIteratorIn keys2, size_t keys2Count, ptrdiff_t* key1Intervals, ptrdiff_t* key2Intervals, size_t intervalOffset)
+{
+    const unsigned int intervalIndex = threadIdx.x + blockIdx.x * blockDim.x + intervalOffset;
+    mergePath(keys1, keys1Count, keys2, keys2Count, key1Intervals, key2Intervals, intervalIndex);
+}
+
+/// @brief Extends or shortens the left end of an array interval
+template<typename DistanceIteratorIn, typename CountIteratorOut, typename OffsetIteratorOut>
+__global__
+void leftRebalanceKernel(DistanceIteratorIn leftDistance, DistanceIteratorIn rightDistance, CountIteratorOut leftCount, OffsetIteratorOut leftOffset)
+{
+    if (*leftDistance < *rightDistance) {
+        *leftCount -= *leftDistance;
+    }
+    else {
+        *leftCount += *rightDistance;
+    }
+}
+
+/// @brief Extends or shortens the right end of an array interval
+template<typename DistanceIteratorIn, typename CountIteratorOut, typename OffsetIteratorOut>
+__global__
+void rightRebalanceKernel(DistanceIteratorIn leftDistance, DistanceIteratorIn rightDistance, CountIteratorOut rightCount, OffsetIteratorOut rightOffset)
+{
+    if (*leftDistance < *rightDistance) {
+        *rightCount += *leftDistance;
+        *rightOffset -= *leftDistance;
+    }
+    else {
+        *rightCount -= *rightDistance;
+        *rightOffset += *rightDistance;
+    }
+}
+
+} // namespace kernels
+
+// Define utility macro used to call cub functions that use dynamic temporary storage
+#ifndef CUB_LAUNCH
+#ifdef _WIN32
+#define CUB_LAUNCH(func, pool, stream, ...) \
+    cudaCheck(cub::func(nullptr, pool.requestedSize(), __VA_ARGS__, stream)); \
+    pool.reallocate(stream); \
+    cudaCheck(cub::func(pool.data(), pool.size(), __VA_ARGS__, stream));
+#else// fdef _WIN32
+#define CUB_LAUNCH(func, pool, stream, args...) \
+    cudaCheck(cub::func(nullptr, pool.requestedSize(), args, stream)); \
+    pool.reallocate(stream); \
+    cudaCheck(cub::func(pool.data(), pool.size(), args, stream));
+#endif// ifdef _WIN32
+#endif// ifndef CUB_LAUNCH
+
+template<typename KeyT, typename ValueT, typename NumItemsT, typename OffsetT, typename CountT>
+void radixSortAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cuda::TempDevicePool* pools, KeyT* keysIn, KeyT* keysOut, ValueT* valuesIn, ValueT* valuesOut, NumItemsT numItems, OffsetT* mergeIntervals, const OffsetT* offsets, const CountT* counts, cudaEvent_t* preEvents, cudaEvent_t* postEvents)
+{
+    // Radix sort the subset of keys assigned to each device in parallel
+    for (const auto& [deviceId, stream] : deviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaCheck(cudaEventSynchronize(preEvents[deviceId]));
+
+        const KeyT* deviceKeysIn = keysIn + offsets[deviceId];
+        const ValueT* deviceValuesIn = valuesIn + offsets[deviceId];
+        KeyT* deviceKeysOut = keysOut + offsets[deviceId];
+        ValueT* deviceValuesOut = valuesOut + offsets[deviceId];
+
+        cudaCheck(util::cuda::memPrefetchAsync(deviceKeysIn, counts[deviceId] * sizeof(KeyT), deviceId, stream));
+
+        // TODO: Add begin and end bit support
+        CUB_LAUNCH(DeviceRadixSort::SortPairs, pools[deviceId], stream, deviceKeysIn, deviceKeysOut, deviceValuesIn, deviceValuesOut, counts[deviceId], 0, sizeof(KeyT) * 8);
+        cudaCheck(cudaEventRecord(postEvents[deviceId], stream));
+    }
+
+    // TODO: Generalize to numbers of GPUs that aren't powers of two
+    // For each pair of devices, merge the local sorts by first computing the median across the two devices followed by merging
+    // the elements less than and greater than/equal to the median onto the first and second device of the pair respectively.
+    // This avoids the allocating memory for and gathering the values from both devices onto a single device.
+    const int log2DeviceCount = log2(deviceMesh.deviceCount());
+    OffsetT* leftIntervals = mergeIntervals;
+    OffsetT* rightIntervals = mergeIntervals + deviceMesh.deviceCount();
+    for (int deviceExponent = 0; deviceExponent < log2DeviceCount; ++deviceExponent) {
+        std::swap(keysIn, keysOut);
+        std::swap(valuesIn, valuesOut);
+        const int deviceIncrement = 1 << deviceExponent;
+
+        std::vector<std::thread> threads;
+        for (int leftDeviceId = 0; leftDeviceId < static_cast<int>(deviceMesh.deviceCount()); leftDeviceId += 2 * deviceIncrement) {
+            threads.emplace_back([&, leftDeviceId]() {
+                const int rightDeviceId = leftDeviceId + deviceIncrement;
+
+                CountT leftDeviceItemCount = 0;
+                for (int deviceId = leftDeviceId; deviceId < rightDeviceId; ++deviceId)
+                    leftDeviceItemCount += counts[deviceId];
+
+                CountT rightDeviceItemCount = 0;
+                for (int deviceId = rightDeviceId; deviceId < rightDeviceId + deviceIncrement; ++deviceId)
+                    rightDeviceItemCount += counts[deviceId];
+
+                const KeyT* leftDeviceKeysIn = keysIn + offsets[leftDeviceId];
+                const ValueT* leftDeviceValuesIn = valuesIn + offsets[leftDeviceId];
+                const KeyT* rightDeviceKeysIn = keysIn + offsets[leftDeviceId] + leftDeviceItemCount;
+                const ValueT* rightDeviceValuesIn = valuesIn + offsets[leftDeviceId] + leftDeviceItemCount;
+
+                // Wait on the prior sort to finish on both devices before computing the median across both devices
+                auto mergePathSubfunc = [&](int deviceId, int otherDeviceId, int intervalIndex) {
+                    cudaCheck(cudaSetDevice(deviceId));
+
+                    cudaCheck(cudaStreamWaitEvent(deviceMesh[deviceId].stream, postEvents[otherDeviceId]));
+                    kernels::mergePathKernel<<<1, 1, 0, deviceMesh[deviceId].stream>>>(leftDeviceKeysIn, leftDeviceItemCount, rightDeviceKeysIn, rightDeviceItemCount, leftIntervals + deviceId, rightIntervals + deviceId, intervalIndex);
+                    cudaCheck(cudaEventRecord(postEvents[deviceId], deviceMesh[deviceId].stream));
+                };
+                mergePathSubfunc(leftDeviceId, rightDeviceId, 0);
+                mergePathSubfunc(rightDeviceId, leftDeviceId, 1);
+
+                cudaCheck(cudaEventSynchronize(postEvents[leftDeviceId]));
+                cudaCheck(cudaEventSynchronize(postEvents[rightDeviceId]));
+
+                // Merge the pairs less than the median to the left device
+                {
+                    cudaCheck(cudaSetDevice(leftDeviceId));
+
+                    const KeyT* leftKeysIn = leftDeviceKeysIn + leftIntervals[leftDeviceId];
+                    const ValueT* leftValuesIn = leftDeviceValuesIn + leftIntervals[leftDeviceId];
+                    CountT leftCount = leftIntervals[rightDeviceId] - leftIntervals[leftDeviceId];
+
+                    const KeyT* rightKeysIn = rightDeviceKeysIn + rightIntervals[leftDeviceId];
+                    const ValueT* rightValuesIn = rightDeviceValuesIn + rightIntervals[leftDeviceId];
+                    CountT rightCount = rightIntervals[rightDeviceId] - rightIntervals[leftDeviceId];
+
+                    OffsetT outputOffset = offsets[leftDeviceId] + leftIntervals[leftDeviceId] + rightIntervals[leftDeviceId];
+
+                    CUB_LAUNCH(DeviceMerge::MergePairs, pools[leftDeviceId], deviceMesh[leftDeviceId].stream, leftKeysIn, leftValuesIn, leftCount, rightKeysIn, rightValuesIn, rightCount, keysOut + outputOffset, valuesOut + outputOffset, {});
+                    cudaCheck(cudaEventRecord(postEvents[leftDeviceId], deviceMesh[leftDeviceId].stream));
+                };
+
+                // Merge the pairs greater than/equal to the median to the right device
+                {
+                    cudaCheck(cudaSetDevice(rightDeviceId));
+
+                    const KeyT* leftKeysIn = leftDeviceKeysIn + leftIntervals[rightDeviceId];
+                    const ValueT* leftValuesIn = leftDeviceValuesIn + leftIntervals[rightDeviceId];
+                    CountT leftCount = leftDeviceItemCount - leftIntervals[rightDeviceId];
+
+                    const KeyT* rightKeysIn = rightDeviceKeysIn + rightIntervals[rightDeviceId];
+                    const ValueT* rightValuesIn = rightDeviceValuesIn + rightIntervals[rightDeviceId];
+                    CountT rightCount = rightDeviceItemCount - rightIntervals[rightDeviceId];
+
+                    OffsetT outputOffset = offsets[leftDeviceId] + leftIntervals[rightDeviceId] + rightIntervals[rightDeviceId];
+
+                    CUB_LAUNCH(DeviceMerge::MergePairs, pools[rightDeviceId], deviceMesh[rightDeviceId].stream, leftKeysIn, leftValuesIn, leftCount, rightKeysIn, rightValuesIn, rightCount, keysOut + outputOffset, valuesOut + outputOffset, {});
+                    cudaCheck(cudaEventRecord(postEvents[rightDeviceId], deviceMesh[rightDeviceId].stream));
+                };
+
+                cudaCheck(cudaEventSynchronize(postEvents[leftDeviceId]));
+                cudaCheck(cudaEventSynchronize(postEvents[rightDeviceId]));
+            });
+        }
+        std::for_each(threads.begin(), threads.end(), [](std::thread& t) { t.join(); });
+    }
+
+    // There is no merging required for a single device so we simply copy the sorted result to the destination array (where the sort would have been merged to).
+    if (log2DeviceCount % 2) {
+        std::swap(keysIn, keysOut);
+        std::swap(valuesIn, valuesOut);
+        for (const auto& [deviceId, stream] : deviceMesh) {
+            cudaCheck(cudaSetDevice(deviceId));
+
+            cudaMemcpyAsync(keysOut + offsets[deviceId], keysIn + offsets[deviceId], counts[deviceId] * sizeof(KeyT), cudaMemcpyDefault, stream);
+            cudaMemcpyAsync(valuesOut + offsets[deviceId], valuesIn + offsets[deviceId], counts[deviceId] * sizeof(ValueT), cudaMemcpyDefault, stream);
+
+            cudaEventRecord(postEvents[deviceId], stream);
+        }
+    }
+}
+
+template<typename KeyT, typename ValueT, typename NumItemsT, typename OffsetT, typename CountT>
+void radixSortAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cuda::TempDevicePool* pools, KeyT* keysIn, KeyT* keysOut, ValueT* valuesIn, ValueT* valuesOut, NumItemsT numItems, const OffsetT* offsets, const CountT* counts, cudaEvent_t* preEvents, cudaEvent_t* postEvents)
+{
+    ptrdiff_t* mergeIntervals = nullptr;
+    cudaCheck(cudaMallocManaged(&mergeIntervals, 2 * deviceMesh.deviceCount() * sizeof(ptrdiff_t)));
+    radixSortAsync(deviceMesh, pools, keysIn, keysOut, valuesIn, valuesOut, numItems, mergeIntervals, offsets, counts, preEvents, postEvents);
+    cudaCheck(cudaFree(mergeIntervals));
+}
+
+/// @brief Launches an async exclusive sum operation across multiple devices. The operator waits on the per-device preEvents[deviceId] before summing over that device's contributions and records postEvents[deviceId] when the device's contribution is summed.
+template<typename InputIteratorT, typename OutputIteratorT, typename CountIteratorT, int NumThreads = 128>
+void exclusiveSumAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cuda::TempDevicePool* pools, InputIteratorT in, OutputIteratorT out, CountIteratorT counts, cudaEvent_t* preEvents, cudaEvent_t* postEvents)
+{
+    InputIteratorT deviceIn = in;
+    OutputIteratorT deviceOut = out;
+    for (const auto& [deviceId, stream] : deviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        // Required for the host to pass the correct value of counts[deviceId]
+        cudaCheck(cudaEventSynchronize(preEvents[deviceId]));
+        uint32_t deviceNumItems = counts[deviceId];
+        CUB_LAUNCH(DeviceScan::ExclusiveSum, pools[deviceId], stream, deviceIn, deviceOut, deviceNumItems);
+        cudaCheck(cudaEventRecord(preEvents[deviceId], stream));
+        deviceIn += counts[deviceId];
+        deviceOut += counts[deviceId];
+    }
+
+    deviceIn = in;
+    deviceOut = out;
+    auto partialExclusiveSum = 0;
+    for (const auto& [deviceId, stream] : deviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        // Required for the host to read-back the per-segment inclusive sum
+        cudaCheck(cudaEventSynchronize(preEvents[deviceId]));
+        if (counts[deviceId]) {
+            auto segmentExclusiveSum = deviceOut[counts[deviceId] - 1] + deviceIn[counts[deviceId] - 1];
+
+            unsigned int numBlocks = (counts[deviceId] + NumThreads - 1) / NumThreads;
+            util::cuda::lambdaKernel<<<numBlocks, NumThreads, 0, stream>>>(counts[deviceId], [=] __device__ (size_t tid) { deviceOut[tid] += partialExclusiveSum; });
+            cudaCheckError();
+
+            partialExclusiveSum += segmentExclusiveSum;
+        }
+        cudaCheck(cudaEventRecord(postEvents[deviceId], stream));
+        deviceIn += counts[deviceId];
+        deviceOut += counts[deviceId];
+    }
+}
+
+/// @brief Launches an async inclusive sum operation across multiple devices. The operator waits on the per-device preEvents[deviceId] before summing over that device's contributions and records postEvents[deviceId] when the device's contribution is summed.
+template<typename InputIteratorT, typename OutputIteratorT, typename CountIteratorT, int NumThreads = 128>
+void inclusiveSumAsync(const nanovdb::cuda::DeviceMesh& deviceMesh, nanovdb::cuda::TempDevicePool* pools, InputIteratorT in, OutputIteratorT out, CountIteratorT counts, cudaEvent_t* preEvents, cudaEvent_t* postEvents)
+{
+    InputIteratorT deviceIn = in;
+    OutputIteratorT deviceOut = out;
+    for (const auto& [deviceId, stream] : deviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        // Required for the host to pass the correct value of counts[deviceId]
+        cudaCheck(cudaEventSynchronize(preEvents[deviceId]));
+        uint32_t deviceNumItems = counts[deviceId];
+        CUB_LAUNCH(DeviceScan::InclusiveSum, pools[deviceId], stream, deviceIn, deviceOut, deviceNumItems);
+        cudaCheck(cudaEventRecord(preEvents[deviceId], stream));
+        deviceIn += counts[deviceId];
+        deviceOut += counts[deviceId];
+    }
+
+    deviceIn = in;
+    deviceOut = out;
+    auto partialInclusiveSum = 0;
+    for (const auto& [deviceId, stream] : deviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        // Required for the host to read-back the per-segment inclusive sum
+        cudaCheck(cudaEventSynchronize(preEvents[deviceId]));
+        if (counts[deviceId]) {
+            auto segmentInclusiveSum = deviceOut[counts[deviceId] - 1];
+
+            unsigned int numBlocks = (counts[deviceId] + NumThreads - 1) / NumThreads;
+            util::cuda::lambdaKernel<<<numBlocks, NumThreads, 0, stream>>>(counts[deviceId], [=] __device__ (size_t tid) { deviceOut[tid] += partialInclusiveSum; });
+            cudaCheckError();
+
+            partialInclusiveSum += segmentInclusiveSum;
+        }
+        cudaCheck(cudaEventRecord(postEvents[deviceId], stream));
+        deviceIn += counts[deviceId];
+        deviceOut += counts[deviceId];
+    }
+}
+
+/// @brief This class implements a multiGPU approach for building NanoVDB grids from input arrays of points
+template <typename BuildT>
+class DistributedPointsToGrid
+{
+public:
+    /// @brief Constructor that specifies the devices on which to execute and the map for the output grid
+    /// @param deviceMesh DeviceMesh on which to run/distribute the operation
+    /// @param map Map to be used for the output grid
+    DistributedPointsToGrid(const nanovdb::cuda::DeviceMesh& deviceMesh, const Map &map);
+    /// @brief Constructor that specifies the devices on which to execute and the scale and translation used to create the map for the output grid
+    /// @param deviceMesh DeviceMesh on which to run/distribute the operation
+    /// @param scale optional scale factor
+    /// @param trans optional translation
+    DistributedPointsToGrid(const nanovdb::cuda::DeviceMesh& deviceMesh, const double scale = 1.0, const Vec3d &trans = Vec3d(0.0));
+
+    /// @brief Destructor
+    ~DistributedPointsToGrid();
+
+    /// @brief Creates a handle to a grid with the specified build type from a list of points in index or world space
+    /// @tparam BuildT Build type of the output grid, i.e NanoGrid<BuildT>
+    /// @tparam PtrT Template type to a raw or fancy-pointer of point coordinates in world or index space.
+    /// @tparam BufferT Template type of buffer used for memory allocation on the device. Must support Unified Memory.
+    /// @param points device pointer to an array of points or voxels
+    /// @param pointCount number of input points or voxels
+    /// @param buffer Optional buffer to guide the allocation
+    /// @return returns a handle with a grid of type NanoGrid<BuildT> in unified memory
+    template <typename PtrT, typename BufferT = nanovdb::cuda::UnifiedBuffer>
+    GridHandle<BufferT> getHandle(const PtrT points,
+                                  size_t pointCount,
+                                  const BufferT &buffer = BufferT());
+
+    template <typename PtrT>
+    void countNodes(const PtrT coords, size_t coordCount);
+
+    template <typename PtrT, typename BufferT = nanovdb::cuda::UnifiedBuffer>
+    BufferT getBuffer(const PtrT, size_t pointCount, const BufferT &buffer);
+
+    template <typename PtrT>
+    void processGridTreeRoot(const PtrT points, size_t pointCount);
+
+    void processNodes();
+
+    template <typename PtrT>
+    void processPoints(const PtrT points, size_t pointCount);
+
+    void processBBox();
+
+private:
+    static constexpr unsigned int mNumThreads = 128;
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    uint32_t* deviceNodeCount(int deviceId) const { return mNodeCounts + 3 * deviceId; }
+
+    uint32_t* deviceNodeOffset(int deviceId) const { return mNodeOffsets + 3 * deviceId; }
+
+    const nanovdb::cuda::DeviceMesh& mDeviceMesh;
+    nanovdb::cuda::TempDevicePool* mTempDevicePools;
+
+    PointType mPointType;
+    std::string mGridName;
+    PointsToGridData<BuildT> *mData;
+    CheckMode mChecksum{CheckMode::Disable};
+
+    size_t* mStripeCounts;
+    ptrdiff_t* mStripeOffsets;
+    uint32_t* mNodeCounts;
+    uint32_t* mNodeOffsets;
+    uint32_t* mVoxelCounts;
+    uint32_t* mVoxelOffsets;
+    ptrdiff_t* mIntervals;
+
+    uint64_t* mKeys;
+    uint32_t* mIndices;
+    uint32_t* mPointsPerTile;
+    uint64_t* mValueIndex;
+    uint64_t* mValueIndexPrefix;
+};
+
+template <typename BuildT>
+DistributedPointsToGrid<BuildT>::DistributedPointsToGrid(const nanovdb::cuda::DeviceMesh& deviceMesh, const Map &map)
+    : mDeviceMesh(deviceMesh), mPointType(PointType::Disable)
+{
+    mTempDevicePools = new nanovdb::cuda::TempDevicePool[mDeviceMesh.deviceCount()];
+
+    cudaCheck(cudaMallocManaged(&mData, sizeof(PointsToGridData<BuildT>)));
+    mData->map = map;
+
+    mStripeCounts = nullptr;
+    cudaCheck(cudaMallocManaged(&mStripeCounts, mDeviceMesh.deviceCount() * sizeof(size_t)));
+    mStripeOffsets = nullptr;
+    cudaCheck(cudaMallocManaged(&mStripeOffsets, mDeviceMesh.deviceCount() * sizeof(ptrdiff_t)));
+    mNodeCounts = nullptr;
+    cudaCheck(cudaMallocManaged(&mNodeCounts, 3 * mDeviceMesh.deviceCount() * sizeof(uint32_t)));
+    mNodeOffsets = nullptr;
+    cudaCheck(cudaMallocManaged(&mNodeOffsets, 3 * mDeviceMesh.deviceCount() * sizeof(uint32_t)));
+    mVoxelCounts = nullptr;
+    cudaCheck(cudaMallocManaged(&mVoxelCounts, mDeviceMesh.deviceCount() * sizeof(uint32_t)));
+    mVoxelOffsets = nullptr;
+    cudaCheck(cudaMallocManaged(&mVoxelOffsets, mDeviceMesh.deviceCount() * sizeof(uint32_t)));
+    mIntervals = nullptr;
+    cudaCheck(cudaMallocManaged(&mIntervals, 2 * mDeviceMesh.deviceCount() * sizeof(ptrdiff_t)));
+}
+
+template <typename BuildT>
+DistributedPointsToGrid<BuildT>::DistributedPointsToGrid(const nanovdb::cuda::DeviceMesh& deviceMesh, const double scale, const Vec3d &trans)
+    : DistributedPointsToGrid(deviceMesh, Map(scale, trans))
+{
+}
+
+template <typename BuildT>
+DistributedPointsToGrid<BuildT>::~DistributedPointsToGrid()
+{
+    cudaCheck(cudaFree(mIntervals));
+    cudaCheck(cudaFree(mVoxelOffsets));
+    cudaCheck(cudaFree(mVoxelCounts));
+    cudaCheck(cudaFree(mNodeOffsets));
+    cudaCheck(cudaFree(mNodeCounts));
+    cudaCheck(cudaFree(mStripeOffsets));
+    cudaCheck(cudaFree(mStripeCounts));
+
+    cudaCheck(cudaFree(mData));
+
+    delete[] mTempDevicePools;
+}
+
+template<typename BuildT>
+template<typename PtrT, typename BufferT>
+inline GridHandle<BufferT>
+DistributedPointsToGrid<BuildT>::getHandle(const PtrT points, size_t pointCount, const BufferT &pool)
+{
+    this->countNodes(points, pointCount);
+
+    auto buffer = this->getBuffer<PtrT, BufferT>(points, pointCount, pool);
+
+    this->processGridTreeRoot(points, pointCount);
+
+    this->processNodes();
+
+    this->processPoints(points, pointCount);
+
+    this->processBBox();
+
+    {
+        int deviceId = 0;
+        auto stream = mDeviceMesh[deviceId].stream;
+        cudaCheck(cudaSetDevice(deviceId));
+        tools::cuda::updateChecksum((GridData*)buffer.deviceData(), mChecksum, stream);
+        cudaCheck(cudaStreamSynchronize(stream));
+    }
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// DistributedPointsToGrid<BuildT>::getHandle
+
+template <typename BuildT>
+template <typename PtrT>
+void DistributedPointsToGrid<BuildT>::countNodes(const PtrT coords, size_t coordCount)
+{
+    // Use cudaMallocManaged calls for now in order to share the PointsToGrid::Data structure
+    cudaCheck(cudaMallocManaged(&mData->d_keys, coordCount * sizeof(uint64_t)));
+    cudaCheck(cudaMallocManaged(&mData->d_tile_keys, coordCount * sizeof(uint64_t))); // oversubscribe to avoid sync point later
+    cudaCheck(cudaMallocManaged(&mData->d_lower_keys, coordCount * sizeof(uint64_t))); // oversubscribe to avoid sync point later
+    cudaCheck(cudaMallocManaged(&mData->d_leaf_keys, coordCount * sizeof(uint64_t))); // oversubscribe to avoid sync point later
+    cudaCheck(cudaMallocManaged(&mData->d_indx, coordCount * sizeof(uint32_t)));
+
+    cudaCheck(cudaMallocManaged(&mData->pointsPerLeaf, coordCount * sizeof(uint32_t)));
+    cudaCheck(cudaMallocManaged(&mData->pointsPerLeafPrefix, coordCount * sizeof(uint32_t)));
+
+    cudaCheck(cudaMallocManaged(&mData->pointsPerVoxel, coordCount * sizeof(uint32_t)));
+    cudaCheck(cudaMallocManaged(&mData->pointsPerVoxelPrefix, coordCount * sizeof(uint32_t)));
+
+    cudaCheck(cudaMallocManaged(&mKeys, coordCount * sizeof(uint64_t)));
+    cudaCheck(cudaMallocManaged(&mIndices, coordCount * sizeof(uint32_t)));
+
+    cudaCheck(cudaMallocManaged(&mPointsPerTile, coordCount * sizeof(uint32_t)));
+
+    if constexpr(BuildTraits<BuildT>::is_onindex) {
+        cudaCheck(cudaMallocManaged(&mValueIndex, coordCount * sizeof(uint64_t))); // oversubscribe to avoid sync point later
+        cudaCheck(cudaMallocManaged(&mValueIndexPrefix, coordCount * sizeof(uint64_t))); // oversubscribe to avoid sync point later
+    }
+
+    // Create events required for host-device and cross-device synchronization. Disable timing if not needed in order
+    // to reduce overhead.
+    std::vector<cudaEvent_t> sortEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> runLengthEncodeEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> transformReduceEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> rebalanceEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> tilePrefixSumEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> voxelCountEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> leafCountEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> lowerCountEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> voxelPrefixSumEvents(mDeviceMesh.deviceCount());
+    std::vector<cudaEvent_t> leafPrefixSumEvents(mDeviceMesh.deviceCount());
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaEventCreateWithFlags(&sortEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&runLengthEncodeEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&transformReduceEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&rebalanceEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&tilePrefixSumEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&voxelCountEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&leafCountEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&lowerCountEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&voxelPrefixSumEvents[deviceId], cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&leafPrefixSumEvents[deviceId], cudaEventDisableTiming);
+    }
+
+    // Advise per-coord quantities to be split even across devices
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        size_t deviceStripeCount = (coordCount + mDeviceMesh.deviceCount() - 1) / mDeviceMesh.deviceCount();
+        const ptrdiff_t deviceStripeOffset = deviceStripeCount * deviceId;
+        deviceStripeCount = std::min(deviceStripeCount, coordCount - deviceStripeOffset);
+
+        mStripeCounts[deviceId] = deviceStripeCount;
+        mStripeOffsets[deviceId] = deviceStripeOffset;
+
+        nanovdb::Coord* deviceCoords = coords + deviceStripeOffset;
+        uint64_t* deviceInputKeys = mKeys + deviceStripeOffset;
+        uint32_t* deviceInputIndices = mIndices + deviceStripeOffset;
+        uint64_t* deviceOutputKeys = mData->d_keys + deviceStripeOffset;
+        uint32_t* deviceOutputIndices = mData->d_indx + deviceStripeOffset;
+
+        util::cuda::memAdvise(deviceCoords, deviceStripeCount * sizeof(nanovdb::Coord), cudaMemAdviseSetPreferredLocation, deviceId);
+        util::cuda::memAdvise(deviceCoords, deviceStripeCount * sizeof(nanovdb::Coord), cudaMemAdviseSetReadMostly, deviceId);
+
+        util::cuda::memAdvise(deviceInputKeys, deviceStripeCount * sizeof(uint64_t), cudaMemAdviseSetPreferredLocation, deviceId);
+        util::cuda::memAdvise(deviceInputIndices, deviceStripeCount * sizeof(uint32_t), cudaMemAdviseSetPreferredLocation, deviceId);
+        util::cuda::memAdvise(deviceOutputKeys, deviceStripeCount * sizeof(uint64_t), cudaMemAdviseSetPreferredLocation, deviceId);
+        util::cuda::memAdvise(deviceOutputIndices, deviceStripeCount * sizeof(uint32_t), cudaMemAdviseSetPreferredLocation, deviceId);
+
+        uint32_t* devicePointsPerTile = mPointsPerTile + deviceStripeOffset;
+        util::cuda::memAdvise(devicePointsPerTile, deviceStripeCount * sizeof(uint32_t), cudaMemAdviseSetPreferredLocation, deviceId);
+        util::cuda::memAdvise(deviceNodeCount(deviceId), 3 * sizeof(uint32_t), cudaMemAdviseSetPreferredLocation, deviceId);
+    }
+
+    // Radix sort the subset of keys assigned to each device in parallel
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        auto deviceStripeCount = mStripeCounts[deviceId];
+        auto deviceStripeOffset = mStripeOffsets[deviceId];
+
+        util::cuda::memPrefetchAsync(coords, coordCount * sizeof(nanovdb::Coord), deviceId, stream);
+
+        util::cuda::offsetLambdaKernel<<<numBlocks(deviceStripeCount), mNumThreads, 0, stream>>>(deviceStripeCount, deviceStripeOffset, TileKeyFunctor<BuildT, PtrT>(), mData, coords, mData->d_keys, mData->d_indx);
+    }
+
+    radixSortAsync(mDeviceMesh, mTempDevicePools, mData->d_keys, mKeys, mData->d_indx, mIndices, coordCount, mIntervals, mStripeOffsets, mStripeCounts, sortEvents.data(), sortEvents.data());
+
+    // For each segment of sorted keys on each device, we count how many of the leftmost key occur past the left boundary of the segment. The same is done for the rightmost key with the right boundary of the segment.
+    auto leftIntervals = mIntervals;
+    auto rightIntervals = mIntervals + mDeviceMesh.deviceCount();
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        auto deviceStripeCount = mStripeCounts[deviceId];
+        auto deviceStripeOffset = mStripeOffsets[deviceId];
+        uint64_t* deviceInputKeys = mKeys + deviceStripeOffset;
+
+        if (deviceId > 0) {
+            cudaStreamWaitEvent(stream, sortEvents[deviceId - 1]);
+            EqualityIndicator<uint64_t> indicator(deviceInputKeys - 1);
+            CUB_LAUNCH(DeviceReduce::TransformReduce, mTempDevicePools[deviceId], stream, deviceInputKeys, rightIntervals + deviceId, deviceStripeCount, ::cuda::std::plus(), indicator, 0);
+        }
+        else {
+            rightIntervals[deviceId] = 0;
+        }
+
+        if (deviceId < static_cast<int>(mDeviceMesh.deviceCount() - 1)) {
+            cudaStreamWaitEvent(stream, sortEvents[deviceId + 1]);
+            EqualityIndicator<uint64_t> indicator(deviceInputKeys + deviceStripeCount);
+            CUB_LAUNCH(DeviceReduce::TransformReduce, mTempDevicePools[deviceId], stream, deviceInputKeys, leftIntervals + deviceId, deviceStripeCount, ::cuda::std::plus(), indicator, 0);
+        }
+        else {
+            leftIntervals[deviceId] = 0;
+        }
+        cudaEventRecord(transformReduceEvents[deviceId], stream);
+    }
+
+    // Rebalance the segments so that a device segment boundary also corresponds to a change in key value. Effectively, this aligns upper node boundaries with device ownership boundaries.
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        if (deviceId > 0)
+        {
+            cudaStreamWaitEvent(stream, transformReduceEvents[deviceId - 1]);
+            kernels::rightRebalanceKernel<<<1, 1, 0, stream>>>(leftIntervals + deviceId - 1, rightIntervals + deviceId, mStripeCounts + deviceId, mStripeOffsets + deviceId);
+        }
+
+        if (deviceId < static_cast<int>(mDeviceMesh.deviceCount() - 1))
+        {
+            cudaStreamWaitEvent(stream, transformReduceEvents[deviceId + 1]);
+            kernels::leftRebalanceKernel<<<1, 1, 0, stream>>>(leftIntervals + deviceId, rightIntervals + deviceId + 1, mStripeCounts + deviceId, mStripeOffsets + deviceId);
+        }
+        cudaEventRecord(rebalanceEvents[deviceId], stream);
+    }
+
+    // Parallel RLE in order to obtain tiles
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        cudaCheck(cudaEventSynchronize(rebalanceEvents[deviceId]));
+
+        auto deviceStripeCount = mStripeCounts[deviceId];
+        auto deviceStripeOffset = mStripeOffsets[deviceId];
+
+        uint64_t* deviceInputKeys = mKeys + deviceStripeOffset;
+        uint64_t* deviceOutputKeys = mData->d_keys + deviceStripeOffset;
+        uint32_t* devicePointsPerTile = mPointsPerTile + deviceStripeOffset;
+
+        // util::cuda::memPrefetchAsync(deviceInputKeys, deviceStripeCount * sizeof(uint64_t), deviceId, stream);
+
+        CUB_LAUNCH(DeviceRunLengthEncode::Encode, mTempDevicePools[deviceId], stream, deviceInputKeys, deviceOutputKeys, devicePointsPerTile, deviceNodeCount(deviceId) + 2, deviceStripeCount);
+        cudaCheck(cudaEventRecord(runLengthEncodeEvents[deviceId], stream));
+    }
+
+    uint32_t upperOffset = 0;
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaCheck(cudaEventSynchronize(runLengthEncodeEvents[deviceId]));
+        auto deviceStripeOffset = mStripeOffsets[deviceId];
+        uint64_t* deviceKeys = mData->d_keys + deviceStripeOffset;
+        cudaCheck(cudaMemcpyAsync(mData->d_tile_keys + upperOffset, deviceKeys, sizeof(uint64_t) * deviceNodeCount(deviceId)[2], cudaMemcpyDefault, stream));
+        deviceNodeOffset(deviceId)[2] = upperOffset;
+        upperOffset += deviceNodeCount(deviceId)[2];
+    }
+
+    // For each tile in parallel, we construct another set of keys for the lower nodes, leaf nodes, and voxels within that tile followed by a radix sort of these keys.
+    for (int deviceId = 0, id = 0; deviceId < static_cast<int>(mDeviceMesh.deviceCount()); ++deviceId) {
+        auto stream = mDeviceMesh[deviceId].stream;
+        cudaCheck(cudaSetDevice(deviceId));
+
+        uint32_t* devicePointsPerTile = mPointsPerTile + mStripeOffsets[deviceId];
+        for (uint32_t i = 0, tileOffset = 0; i < deviceNodeCount(deviceId)[2]; ++i) {
+            if (!devicePointsPerTile[i]) continue;
+
+            util::cuda::offsetLambdaKernel<<<numBlocks(devicePointsPerTile[i]), mNumThreads, 0, stream>>>(devicePointsPerTile[i], tileOffset + mStripeOffsets[deviceId], VoxelKeyFunctor<BuildT, PtrT>(), mData, coords, id, mKeys, mIndices);
+
+            uint64_t* tileInputKeys = mKeys + tileOffset + mStripeOffsets[deviceId];
+            uint32_t* tileInputIndices = mIndices + tileOffset + mStripeOffsets[deviceId];
+            uint64_t* tileOutputKeys = mData->d_keys + tileOffset + mStripeOffsets[deviceId];
+            uint32_t* tileOutputIndices = mData->d_indx + tileOffset + mStripeOffsets[deviceId];
+
+            CUB_LAUNCH(DeviceRadixSort::SortPairs, mTempDevicePools[deviceId], stream, tileInputKeys, tileOutputKeys, tileInputIndices, tileOutputIndices, devicePointsPerTile[i], 0, 36);// 9+12+15=36
+            ++id;
+            tileOffset += devicePointsPerTile[i];
+        }
+    }
+
+    // For each of the following operations, the input on the current device depends on the output of the prior device. Thus, for maximum throughput, we pipeline these operations.
+    // 1) RLE for pointsPerLeaf
+    // 2) RLE for pointsPerVoxel
+    // Without this pipelining, each operation would have to wait until ALL devices to finish their prior operation instead of just the previous device which significantly degrades scaling.
+    // Based on profiling, we launch the per-device kernels for steps 1 and 2 in a single loop.
+    {
+        uint32_t* devicePointsPerVoxel = mData->pointsPerVoxel;
+        uint32_t* devicePointsPerLeaf = mData->pointsPerLeaf;
+        for (const auto& [deviceId, stream] : mDeviceMesh) {
+            cudaCheck(cudaSetDevice(deviceId));
+
+            uint64_t* deviceInputKeys = mKeys + mStripeOffsets[deviceId];
+            const uint64_t* deviceOutputKeys = mData->d_keys + mStripeOffsets[deviceId];
+
+            if (deviceId == 0) {
+                CUB_LAUNCH(DeviceRunLengthEncode::Encode, mTempDevicePools[deviceId], stream, deviceOutputKeys, deviceInputKeys, devicePointsPerVoxel, mVoxelCounts + deviceId, mStripeCounts[deviceId]);
+                cudaCheck(cudaEventRecord(voxelCountEvents[deviceId], stream));
+
+                CUB_LAUNCH(DeviceRunLengthEncode::Encode, mTempDevicePools[deviceId], stream, thrust::make_transform_iterator(deviceOutputKeys, ShiftRight<9>()), deviceInputKeys, devicePointsPerLeaf, deviceNodeCount(deviceId), mStripeCounts[deviceId]);
+                cudaCheck(cudaEventRecord(leafCountEvents[deviceId], stream));
+            }
+            else
+            {
+                cudaCheck(cudaEventSynchronize(voxelCountEvents[deviceId - 1]));
+                devicePointsPerVoxel += mVoxelCounts[deviceId - 1];
+                CUB_LAUNCH(DeviceRunLengthEncode::Encode, mTempDevicePools[deviceId], stream, deviceOutputKeys, deviceInputKeys, devicePointsPerVoxel, mVoxelCounts + deviceId, mStripeCounts[deviceId]);
+                cudaCheck(cudaEventRecord(voxelCountEvents[deviceId], stream));
+
+                cudaCheck(cudaEventSynchronize(leafCountEvents[deviceId - 1]));
+                devicePointsPerLeaf += deviceNodeCount(deviceId - 1)[0];
+                CUB_LAUNCH(DeviceRunLengthEncode::Encode, mTempDevicePools[deviceId], stream, thrust::make_transform_iterator(deviceOutputKeys, ShiftRight<9>()), deviceInputKeys, devicePointsPerLeaf, deviceNodeCount(deviceId), mStripeCounts[deviceId]);
+                cudaCheck(cudaEventRecord(leafCountEvents[deviceId], stream));
+            }
+        }
+    }
+
+    exclusiveSumAsync(mDeviceMesh, mTempDevicePools, mData->pointsPerVoxel, mData->pointsPerVoxelPrefix, mVoxelCounts, voxelCountEvents.data(), voxelPrefixSumEvents.data());
+    LeafCountIterator leafCountIterator(mNodeCounts);
+    exclusiveSumAsync(mDeviceMesh, mTempDevicePools, mData->pointsPerLeaf, mData->pointsPerLeafPrefix, leafCountIterator, leafCountEvents.data(), leafPrefixSumEvents.data());
+
+    uint32_t leafOffset = 0;
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        uint64_t* deviceKeys = mKeys + mStripeOffsets[deviceId];
+        cudaCheck(cudaMemcpyAsync(mData->d_leaf_keys + leafOffset, deviceKeys, sizeof(uint64_t) * deviceNodeCount(deviceId)[0], cudaMemcpyDefault, stream));
+        deviceNodeOffset(deviceId)[0] = leafOffset;
+        leafOffset += deviceNodeCount(deviceId)[0];
+    }
+
+    // Parallel RLE with (shifted) keys in order to count leaves and points per leaf
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        uint64_t* deviceInputKeys = mKeys + mStripeOffsets[deviceId];
+        uint64_t* deviceOutputKeys = mData->d_keys + mStripeOffsets[deviceId];
+
+        CUB_LAUNCH(DeviceSelect::Unique, mTempDevicePools[deviceId], stream, thrust::make_transform_iterator(deviceOutputKeys, ShiftRight<21>()), deviceInputKeys, deviceNodeCount(deviceId) + 1, mStripeCounts[deviceId]);
+        cudaEventRecord(lowerCountEvents[deviceId], stream);
+    }
+
+    uint32_t lowerOffset = 0;
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaCheck(cudaEventSynchronize(lowerCountEvents[deviceId]));
+        uint64_t* deviceKeys = mKeys + mStripeOffsets[deviceId];
+        cudaCheck(cudaMemcpyAsync(mData->d_lower_keys + lowerOffset, deviceKeys, sizeof(uint64_t) * deviceNodeCount(deviceId)[1], cudaMemcpyDefault, stream));
+        deviceNodeOffset(deviceId)[1] = lowerOffset;
+        lowerOffset += deviceNodeCount(deviceId)[1];
+    }
+
+    uint32_t voxelOffset = 0;
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        mVoxelOffsets[deviceId] = voxelOffset;
+        voxelOffset += mVoxelCounts[deviceId];
+    }
+
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaCheck(cudaStreamSynchronize(stream));
+    }
+
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaEventDestroy(sortEvents[deviceId]);
+        cudaEventDestroy(runLengthEncodeEvents[deviceId]);
+        cudaEventDestroy(transformReduceEvents[deviceId]);
+        cudaEventDestroy(rebalanceEvents[deviceId]);
+        cudaEventDestroy(tilePrefixSumEvents[deviceId]);
+        cudaEventDestroy(voxelCountEvents[deviceId]);
+        cudaEventDestroy(leafCountEvents[deviceId]);
+        cudaEventDestroy(lowerCountEvents[deviceId]);
+        cudaEventDestroy(voxelPrefixSumEvents[deviceId]);
+        cudaEventDestroy(leafPrefixSumEvents[deviceId]);
+    }
+} // DistributedPointsToGrid<BuildT>::countNodes
+
+template <typename BuildT>
+template <typename PtrT, typename BufferT>
+inline BufferT DistributedPointsToGrid<BuildT>::getBuffer(const PtrT, size_t pointCount, const BufferT &pool)
+{
+    auto sizeofPoint = [&]()->size_t{
+        switch (mPointType){
+        case PointType::PointID: return sizeof(uint32_t);
+        case PointType::World64: return sizeof(Vec3d);
+        case PointType::World32: return sizeof(Vec3f);
+        case PointType::Grid64:  return sizeof(Vec3d);
+        case PointType::Grid32:  return sizeof(Vec3f);
+        case PointType::Voxel32: return sizeof(Vec3f);
+        case PointType::Voxel16: return sizeof(Vec3u16);
+        case PointType::Voxel8:  return sizeof(Vec3u8);
+        case PointType::Default: return pointer_traits<PtrT>::element_size;
+        default: return size_t(0);// PointType::Disable
+        }
+    };
+
+    mData->grid  = 0;// grid is always stored at the start of the buffer!
+    mData->tree  = NanoGrid<BuildT>::memUsage(); // grid ends and tree begins
+    mData->root  = mData->tree  + NanoTree<BuildT>::memUsage(); // tree ends and root node begins
+
+    mData->nodeCount[0] = 0;
+    mData->nodeCount[1] = 0;
+    mData->nodeCount[2] = 0;
+    mData->voxelCount = 0;
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        mData->nodeCount[0] += deviceNodeCount(deviceId)[0];
+        mData->nodeCount[1] += deviceNodeCount(deviceId)[1];
+        mData->nodeCount[2] += deviceNodeCount(deviceId)[2];
+        mData->voxelCount += mVoxelCounts[deviceId];
+    }
+
+    mData->upper = mData->root  + NanoRoot<BuildT>::memUsage(mData->nodeCount[2]); // root node ends and upper internal nodes begin
+    mData->lower = mData->upper + NanoUpper<BuildT>::memUsage()*(mData->nodeCount[2]); // upper internal nodes ends and lower internal nodes begin
+    mData->leaf  = mData->lower + NanoLower<BuildT>::memUsage()*(mData->nodeCount[1]); // lower internal nodes ends and leaf nodes begin
+    mData->meta  = mData->leaf  + NanoLeaf<BuildT>::DataType::memUsage()*(mData->nodeCount[0]);// leaf nodes end and blind meta data begins
+    mData->blind = mData->meta  + sizeof(GridBlindMetaData)*int( mPointType!=PointType::Disable ); // meta data ends and blind data begins
+    mData->size  = mData->blind + pointCount*sizeofPoint();// end of buffer
+
+    auto buffer = BufferT::create(mData->size, &pool);
+    mData->d_bufferPtr = buffer.deviceData();
+    if (!mData->d_bufferPtr)
+        throw std::runtime_error("Failed to allocate grid buffer in Unified Memory");
+    return buffer;
+}// DistributedPointsToGrid<BuildT>::getBuffer
+
+template <typename BuildT>
+template <typename PtrT>
+inline void DistributedPointsToGrid<BuildT>::processGridTreeRoot(const PtrT points, size_t pointCount)
+{
+    // Process root node on device 0. Other devices will wait until root node processing is complete.
+    int deviceId = 0;
+    auto stream = mDeviceMesh[deviceId].stream;
+    cudaCheck(cudaSetDevice(deviceId));
+    cudaEvent_t processGridTreeRootEvent;
+    cudaEventCreateWithFlags(&processGridTreeRootEvent, cudaEventDisableTiming);
+    util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, BuildGridTreeRootFunctor<BuildT, PtrT>(), mData, mPointType, pointCount);// lambdaKernel
+    cudaCheckError();
+
+    char *dst = mData->getGrid().mGridName;
+    if (const char *src = mGridName.data()) {
+        cudaCheck(cudaMemcpyAsync(dst, src, GridData::MaxNameSize, cudaMemcpyHostToDevice, stream));
+    } else {
+        cudaCheck(cudaMemsetAsync(dst, 0, GridData::MaxNameSize, stream));
+    }
+    cudaEventRecord(processGridTreeRootEvent);
+
+    for (const auto& [otherDeviceId, otherStream] : mDeviceMesh) {
+        cudaSetDevice(otherDeviceId);
+        cudaStreamWaitEvent(otherStream, processGridTreeRootEvent);
+    }
+
+    cudaCheck(cudaSetDevice(deviceId));
+    cudaEventDestroy(processGridTreeRootEvent);
+}// DistributedPointsToGrid<BuildT>::processGridTreeRoot
+
+template <typename BuildT>
+inline void DistributedPointsToGrid<BuildT>::processNodes()
+{
+    // Parallel construction of upper, lower, and leaf nodes
+    const uint8_t flags = (uint8_t) GridFlags::HasBBox;
+
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+
+        if (deviceNodeCount(deviceId)[2]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[2]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[2], deviceNodeOffset(deviceId)[2], BuildUpperNodesFunctor<BuildT>(), mData);
+            cudaCheckError();
+
+            const uint64_t valueCount = deviceNodeCount(deviceId)[2] << 15;
+            const uint64_t valueOffset = deviceNodeOffset(deviceId)[2] << 15;
+            util::cuda::offsetLambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, stream>>>(valueCount, valueOffset, SetUpperBackgroundValuesFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+        if (deviceNodeCount(deviceId)[1]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[1]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[1], deviceNodeOffset(deviceId)[1], BuildLowerNodesFunctor<BuildT>(), mData);
+            cudaCheckError();
+
+            const uint64_t valueCount = deviceNodeCount(deviceId)[1] << 12;
+            const uint64_t valueOffset = deviceNodeOffset(deviceId)[1] << 12;
+            util::cuda::offsetLambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, stream>>>(valueCount, valueOffset, SetLowerBackgroundValuesFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+
+        if (deviceNodeCount(deviceId)[0]) {
+            // loop over leaf nodes and add it to its parent node
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[0]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[0], deviceNodeOffset(deviceId)[0], ProcessLeafMetaDataFunctor<BuildT>(), mData, flags);
+            cudaCheckError();
+
+            // loop over all active voxels and set LeafNode::mValueMask and LeafNode::mValues
+            util::cuda::offsetLambdaKernel<<<numBlocks(mVoxelCounts[deviceId]), mNumThreads, 0, stream>>>(mVoxelCounts[deviceId], mVoxelOffsets[deviceId], SetLeafActiveVoxelStateAndValuesFunctor<BuildT>(), mData);
+            cudaCheckError();
+
+            const uint64_t denseVoxelCount = deviceNodeCount(deviceId)[0] << 9;
+            const uint64_t denseVoxelOffset = deviceNodeOffset(deviceId)[0] << 9;
+            util::cuda::offsetLambdaKernel<<<numBlocks(denseVoxelCount), mNumThreads, 0, stream>>>(denseVoxelCount, denseVoxelOffset, SetLeafInactiveVoxelValuesFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+    }
+
+    if constexpr(BuildTraits<BuildT>::is_onindex) {
+        std::vector<cudaEvent_t> leafCountEvents(mDeviceMesh.deviceCount());
+        std::vector<cudaEvent_t> valueIndexPrefixSumEvents(mDeviceMesh.deviceCount());
+
+        for (const auto& [deviceId, stream] : mDeviceMesh) {
+            cudaSetDevice(deviceId);
+            cudaEventCreateWithFlags(&leafCountEvents[deviceId], cudaEventDisableTiming);
+            cudaEventCreateWithFlags(&valueIndexPrefixSumEvents[deviceId], cudaEventDisableTiming);
+
+            if (deviceNodeCount(deviceId)[0]) {
+                kernels::fillValueIndexKernel<BuildT><<<numBlocks(deviceNodeCount(deviceId)[0]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[0], deviceNodeOffset(deviceId)[0], mValueIndex, mData);
+                cudaCheckError();
+            }
+        }
+
+        LeafCountIterator leafCountIterator(mNodeCounts);
+        inclusiveSumAsync(mDeviceMesh, mTempDevicePools, mValueIndex, mValueIndexPrefix, leafCountIterator, leafCountEvents.data(), valueIndexPrefixSumEvents.data());
+
+        for (const auto& [deviceId, stream] : mDeviceMesh) {
+            cudaSetDevice(deviceId);
+            cudaStreamWaitEvent(stream, valueIndexPrefixSumEvents.back());
+            if (deviceNodeCount(deviceId)[0]) {
+                kernels::leafPrefixSumKernel<BuildT><<<numBlocks(deviceNodeCount(deviceId)[0]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[0], deviceNodeOffset(deviceId)[0], mValueIndexPrefix, mData);
+                cudaCheckError();
+            }
+        }
+
+        for (const auto& [deviceId, stream] : mDeviceMesh) {
+            cudaSetDevice(deviceId);
+            cudaEventDestroy(valueIndexPrefixSumEvents[deviceId]);
+            cudaEventDestroy(leafCountEvents[deviceId]);
+        }
+    }
+
+}// DistributedPointsToGrid<BuildT>::processNodes
+
+template <typename BuildT>
+template <typename PtrT>
+inline void DistributedPointsToGrid<BuildT>::processPoints(const PtrT, size_t)
+{
+}
+
+template <typename BuildT>
+inline void DistributedPointsToGrid<BuildT>::processBBox()
+{
+    // Compute and propagate bounding boxes for the upper nodes and their descendents belonging to each device in parallel.
+    std::vector<cudaEvent_t> propagateLowerBBoxEvents(mDeviceMesh.deviceCount());
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        // reset bbox in lower nodes
+        if (deviceNodeCount(deviceId)[1]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[1]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[1], deviceNodeOffset(deviceId)[1], ResetLowerNodeBBoxFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+        // update and propagate bbox from leaf -> lower/parent nodes
+        if (deviceNodeCount(deviceId)[0]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[0]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[0], deviceNodeOffset(deviceId)[0], UpdateAndPropagateLeafBBoxFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+        // reset bbox in upper nodes
+        if (deviceNodeCount(deviceId)[2]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[2]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[2], deviceNodeOffset(deviceId)[2], ResetUpperNodeBBoxFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+        // propagate bbox from lower -> upper/parent node
+        if (deviceNodeCount(deviceId)[1]) {
+            util::cuda::offsetLambdaKernel<<<numBlocks(deviceNodeCount(deviceId)[1]), mNumThreads, 0, stream>>>(deviceNodeCount(deviceId)[1], deviceNodeOffset(deviceId)[1], PropagateLowerBBoxFunctor<BuildT>(), mData);
+            cudaCheckError();
+        }
+
+        cudaEventCreate(&propagateLowerBBoxEvents[deviceId]);
+        cudaEventRecord(propagateLowerBBoxEvents[deviceId], stream);
+    }
+
+    // Wait until bounding boxes are computed for each upper node and then compute the root bounding box on the zeroth device
+    {
+        int deviceId = 0;
+        auto stream = mDeviceMesh[deviceId].stream;
+        cudaCheck(cudaSetDevice(deviceId));
+        for (const auto& propagateLowerBBoxEvent : propagateLowerBBoxEvents)
+        {
+            cudaStreamWaitEvent(stream, propagateLowerBBoxEvent);
+        }
+        // propagate bbox from upper -> root/parent node
+        util::cuda::lambdaKernel<<<numBlocks(mData->nodeCount[2]), mNumThreads, 0, stream>>>(mData->nodeCount[2], PropagateUpperBBoxFunctor<BuildT>(), mData);
+        cudaCheckError();
+
+        // update the world-bbox in the root node
+        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, UpdateRootWorldBBoxFunctor<BuildT>(), mData);
+        cudaCheckError();
+
+        cudaCheck(cudaEventDestroy(propagateLowerBBoxEvents[deviceId]));
+    }
+
+    // Explicitly synchronize so that move constructor in getHandle doesn't fail
+    for (const auto& [deviceId, stream] : mDeviceMesh) {
+        cudaCheck(cudaSetDevice(deviceId));
+        cudaStreamSynchronize(stream);
+    }
+
+    if constexpr(BuildTraits<BuildT>::is_onindex) {
+        cudaCheck(cudaFree(mValueIndexPrefix));
+        cudaCheck(cudaFree(mValueIndex));
+    }
+
+    cudaCheck(cudaFree(mPointsPerTile));
+    cudaCheck(cudaFree(mIndices));
+    cudaCheck(cudaFree(mKeys));
+
+    cudaCheck(cudaFree(mData->pointsPerLeafPrefix));
+    cudaCheck(cudaFree(mData->pointsPerLeaf));
+
+    cudaCheck(cudaFree(mData->pointsPerVoxelPrefix));
+    cudaCheck(cudaFree(mData->pointsPerVoxel));
+
+    cudaCheck(cudaFree(mData->d_indx));
+    cudaCheck(cudaFree(mData->d_leaf_keys));
+    cudaCheck(cudaFree(mData->d_lower_keys));
+    cudaCheck(cudaFree(mData->d_tile_keys));
+    cudaCheck(cudaFree(mData->d_keys));
+}// DistributedPointsToGrid<BuildT>::processBBox
+
+} // namespace tools::cuda
+
+} // namespace nanovdb
+
+#endif // NANOVDB_TOOLS_CUDA_DISTRIBUTEDPOINTSTOGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/GridChecksum.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/GridChecksum.cuh
@@ -72,7 +72,7 @@ inline void updateChecksum(GridData *d_gridData, cudaStream_t stream = 0)
 namespace util::cuda {
 
 /// @brief Cuda kernel that computes CRC32 checksums of blocks of data using a look-up-table
-/// @param d_data device pointer to raw data from wich to compute the CRC32 checksums
+/// @param d_data device pointer to raw data from which to compute the CRC32 checksums
 /// @param d_blockCRC device pointer to array of @c blockCount checksums for each block
 /// @param blockCount number of blocks and checksums
 /// @param blockSize size of each block in bytes
@@ -85,7 +85,7 @@ __global__ void crc32Kernel(const T *d_data, uint32_t* d_blockCRC, uint32_t bloc
 }
 
 /// @brief Cuda kernel that computes CRC32 checksums of blocks of data (without using a look-up-table)
-/// @param d_data device pointer to raw data from wich to compute the CRC32 checksums
+/// @param d_data device pointer to raw data from which to compute the CRC32 checksums
 /// @param d_blockCRC device pointer to array of @c blockCount checksums for each block
 /// @param blockCount number of blocks and checksums
 /// @param blockSize size of each block in bytes
@@ -374,7 +374,7 @@ inline Checksum getChecksum(const GridData *d_gridData, cudaStream_t stream)
 /// @param stream optional cuda stream (defaults to zero)
 /// @return The actual mode used for checksum computation. Eg. if @c d_gridData is NULL (or @c mode = CheckMode::Empty)
 ///         then CheckMode::Empty is always returned. Else if the grid has no nodes or blind data CheckMode::Partial
-///         is always returnd (even if @c mode = CheckMode::Full).
+///         is always returned (even if @c mode = CheckMode::Full).
 inline void updateChecksum(GridData *d_gridData, CheckMode mode, cudaStream_t stream)
 {
     NANOVDB_ASSERT(d_gridData);

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/GridStats.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/GridStats.cuh
@@ -32,7 +32,7 @@ void updateGridStats(NanoGrid<BuildT> *d_grid, StatsMode mode = StatsMode::Defau
 
 //================================================================================================
 
-/// @brief Allows for the construction of NanoVDB grids without any dependecy
+/// @brief Allows for the construction of NanoVDB grids without any dependency
 template<typename BuildT, typename StatsT = Stats<typename NanoGrid<BuildT>::ValueType>>
 class GridStats
 {
@@ -84,20 +84,19 @@ template<typename BuildT, typename StatsT, int LEVEL>
 __global__ void processInternal(NodeManager<BuildT> *d_nodeMgr, StatsT *d_stats)
 {
     using ChildT = typename NanoNode<BuildT,LEVEL-1>::type;
-    const uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= d_nodeMgr->nodeCount(LEVEL)) return;
-    auto &d_node = d_nodeMgr->template node<LEVEL>(tid);
+    uint32_t nodeID = blockIdx.x * blockDim.x + threadIdx.x;// thread id (reused below to avoid compiler warning)
+    if (nodeID >= d_nodeMgr->nodeCount(LEVEL)) return;
+    auto &d_node = d_nodeMgr->template node<LEVEL>(nodeID);
     auto &bbox   = d_node.mBBox;
     bbox         = CoordBBox();// empty bbox
     StatsT stats;
-    uint32_t childID = 0u;
 
     for (auto it = d_node.beginChild(); it; ++it) {
         auto &child = *it;
         bbox.expand( child.bbox() );
         if constexpr(StatsT::hasAverage()) {
-            childID = *reinterpret_cast<uint32_t*>(&child.mMinimum);
-            StatsT &s = d_stats[childID];
+            nodeID = *reinterpret_cast<uint32_t*>(&child.mMinimum);
+            StatsT &s = d_stats[nodeID];
             s.setStats(child);
             stats.add(s);
         } else if constexpr(StatsT::hasMinMax()) {
@@ -112,8 +111,8 @@ __global__ void processInternal(NodeManager<BuildT> *d_nodeMgr, StatsT *d_stats)
         if constexpr(StatsT::hasStats()) stats.add(*it, ChildT::NUM_VALUES);
     }
     if constexpr(StatsT::hasAverage()) {
-        d_stats[childID] = stats;
-        *reinterpret_cast<uint32_t*>(&d_node.mMinimum) = childID;
+        d_stats[nodeID] = stats;
+        *reinterpret_cast<uint32_t*>(&d_node.mMinimum) = nodeID;
     } else if constexpr(StatsT::hasMinMax()) {
         stats.setStats(d_node);
     }

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/IndexToGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/IndexToGrid.cuh
@@ -14,8 +14,8 @@
              to only include it in .cu files (or other .cuh files)
 */
 
-#ifndef NVIDIA_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED
-#define NVIDIA_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED
+#ifndef NANOVDB_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/cuda/DeviceBuffer.h>
@@ -31,7 +31,7 @@ namespace tools::cuda {// ======================================================
 /// @tparam DstBuildT Build time of the destination/output Grid
 /// @tparam SrcBuildT  Build type of the source/input IndexGrid
 /// @tparam BufferT Type of the buffer used for allocation of the destination Grid
-/// @param d_srcGrid Device pointer to source/input IndexGrid, i.e. SrcBuildT={ValueIndex,ValueOnIndex,ValueIndexMask,ValueOnIndexMask}
+/// @param d_srcGrid Device pointer to source/input IndexGrid, i.e. SrcBuildT={ValueIndex,ValueOnIndex}
 /// @param d_srcValues Device pointer to an array of values
 /// @param pool Memory pool used to create a buffer for the destination/output Grid
 /// @param stream optional CUDA stream (defaults to CUDA stream 0
@@ -176,16 +176,25 @@ template<typename SrcBuildT, typename DstBuildT>
 __global__ void processRootTilesKernel(typename IndexToGrid<SrcBuildT>::NodeAccessor *nodeAcc,
                                        const typename BuildToValueMap<DstBuildT>::type *srcValues)
 {
-    const auto tid = blockIdx.x;
+    const auto tileID = blockIdx.x, tileCount = nodeAcc->nodeCount[3];// note: tileID != childID!
+    NANOVDB_ASSERT(tileID < tileCount);
 
-    // Process children and tiles
-    const auto &srcTile = *nodeAcc->srcRoot().tile(tid);
-    auto &dstTile = *nodeAcc->template dstRoot<DstBuildT>().tile(tid);
+    // Process child nodes and tiles of the root node
+    const auto &srcTile = *nodeAcc->srcRoot().tile(tileID);
+    auto &dstTile = *nodeAcc->template dstRoot<DstBuildT>().tile(tileID);
     dstTile.key   = srcTile.key;
     if (srcTile.child) {
-        dstTile.child = sizeof(NanoRoot<DstBuildT>) + sizeof(NanoRoot<DstBuildT>::Tile)*((srcTile.child - sizeof(NanoRoot<SrcBuildT>))/sizeof(NanoRoot<SrcBuildT>::Tile));
-        dstTile.value = srcValues[0];// set to background
-        dstTile.state = false;
+        // |<--NanoRoot-->|<--Tile[0]...Tile[tileCount-1]-->|<--Child[0]...child[childID-1]-->|
+        // |<-------------------- offset -------------------|
+        // |<-------------------------------- Tile::child ------------------------------------|
+        //                                                  |<------ Tile::child-offset ----->|
+        //                                                  |<--- childID x sizeof(ChildT) -->|
+        uint64_t offset = sizeof(NanoRoot<SrcBuildT>) + tileCount*sizeof(NanoRoot<SrcBuildT>::Tile);//  source offset
+        const uint64_t childID = (srcTile.child - offset)/sizeof(NanoRoot<SrcBuildT>::ChildNodeType);// derived from source offset
+        offset          = sizeof(NanoRoot<DstBuildT>) + tileCount*sizeof(NanoRoot<DstBuildT>::Tile);//  destination offset
+        dstTile.child   = offset + childID*sizeof(NanoRoot<DstBuildT>::ChildNodeType);
+        dstTile.value   = srcValues[0];// set to background
+        dstTile.state   = false;
     } else {
         dstTile.child = 0;// i.e. no child node
         dstTile.value = srcValues[srcTile.value];
@@ -224,7 +233,6 @@ __global__ void processNodesKernel(typename IndexToGrid<SrcBuildT>::NodeAccessor
             if (srcGrid.hasStdDeviation()) dstNode.mStdDevi = srcValues[srcNode.mStdDevi];
         }
     }
-    const uint64_t nodeSkip = nodeAcc->nodeCount[LEVEL] - blockIdx.x, srcOff = sizeof(SrcNodeT)*nodeSkip, dstOff = sizeof(DstNodeT)*nodeSkip;// offset to first node of child type
     const int off = blockDim.x*blockDim.y*threadIdx.x + blockDim.x*threadIdx.y;
     for (int threadIdx_z=0; threadIdx_z<blockDim.x; ++threadIdx_z) {
         const int i = off + threadIdx_z;
@@ -232,6 +240,7 @@ __global__ void processNodesKernel(typename IndexToGrid<SrcBuildT>::NodeAccessor
             if constexpr(sizeof(SrcNodeT)==sizeof(DstNodeT) && sizeof(SrcChildT)==sizeof(DstChildT)) {
                 dstNode.mTable[i].child = srcNode.mTable[i].child;
             } else {
+                const uint64_t nodeSkip = nodeAcc->nodeCount[LEVEL] - blockIdx.x, srcOff = sizeof(SrcNodeT)*nodeSkip, dstOff = sizeof(DstNodeT)*nodeSkip;// offset to first node of child type
                 const uint64_t childID = (srcNode.mTable[i].child - srcOff)/sizeof(SrcChildT);
                 dstNode.mTable[i].child = dstOff + childID*sizeof(DstChildT);
             }
@@ -359,7 +368,9 @@ inline BufferT IndexToGrid<SrcBuildT>::getBuffer(const BufferT &pool)
     mNodeAcc.meta  = mNodeAcc.node[0]  + NanoLeaf<DstBuildT>::DataType::memUsage()*mNodeAcc.nodeCount[0];// leaf nodes end and blind meta data begins
     mNodeAcc.blind = mNodeAcc.meta  + 0*sizeof(GridBlindMetaData); // meta data ends and blind data begins
     mNodeAcc.size  = mNodeAcc.blind;// end of buffer
-    auto buffer = BufferT::create(mNodeAcc.size, &pool, false, mStream);
+    int device = 0;
+    cudaCheck(cudaGetDevice(&device));
+    auto buffer = BufferT::create(mNodeAcc.size, &pool, device, mStream);
     mNodeAcc.d_dstPtr = buffer.deviceData();
     if (mNodeAcc.d_dstPtr == nullptr) throw std::runtime_error("Failed memory allocation on the device");
 
@@ -404,4 +415,4 @@ cudaCreateNanoGrid(const NanoGrid<SrcBuildT> *d_srcGrid, const typename BuildToV
 
 }// nanovdb namespace ===================================================================
 
-#endif // NVIDIA_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED
+#endif // NANOVDB_TOOLS_CUDA_INDEXTOGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/MergeGrids.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/MergeGrids.cuh
@@ -1,0 +1,284 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/MergeGrids.cuh
+
+    \authors Efty Sifakis
+
+    \brief Morphological union of NanoVDB indexGrids on the device
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Morphology.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h>
+
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class MergeGrids
+{
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param d_srcGrid1 first source device grid to be merged
+    /// @param d_srcGrid2 second source device grid to be merged
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    MergeGrids(const GridT* d_srcGrid1, const GridT* d_srcGrid2, cudaStream_t stream = 0)
+        : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrid1(d_srcGrid1), mDeviceSrcGrid2(d_srcGrid2) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable){mBuilder.mChecksum = mode;}
+
+    /// @brief Creates a handle to the merged grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+private:
+    void mergeRoot();
+
+    void mergeInternalNodes();
+
+    void processGridTreeRoot();
+
+    void mergeLeafNodes();
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT> mBuilder;
+    cudaStream_t            mStream{0};
+    util::cuda::Timer       mTimer;
+    int                     mVerbose{0};
+    const GridT             *mDeviceSrcGrid1;
+    const GridT             *mDeviceSrcGrid2;
+    TreeData                mSrcTreeData1;
+    TreeData                mSrcTreeData2;
+};// tools::cuda::MergeGrids<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+MergeGrids<BuildT>::getHandle(const BufferT &pool)
+{
+    // Copy TreeData from GPU -> CPU
+    cudaStreamSynchronize(mStream);
+    mSrcTreeData1 = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid1);
+    mSrcTreeData2 = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid2);
+
+    // Ensure that the input grid contains no tile values
+    if (mSrcTreeData1.mTileCount[2] || mSrcTreeData1.mTileCount[1] || mSrcTreeData1.mTileCount[0] ||
+        mSrcTreeData2.mTileCount[2] || mSrcTreeData2.mTileCount[1] || mSrcTreeData2.mTileCount[0])
+        throw std::runtime_error("Topological operations not supported on grids with value tiles");
+
+    // Merge root nodes
+    if (mVerbose==1) mTimer.start("\nMerging root nodes");
+    mergeRoot();
+
+    // Allocate memory for merged upper/lower masks
+    if (mVerbose==1) mTimer.restart("Allocating internal node mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+
+    // Merge masks of upper/lower nodes
+    if (mVerbose==1) mTimer.restart("Merge internal nodes");
+    mergeInternalNodes();
+
+    // Enumerate tree nodes
+    if (mVerbose==1) mTimer.restart("Count merged tree nodes");
+    mBuilder.countNodes(mStream);
+
+    cudaStreamSynchronize(mStream);
+
+    // Allocate new device grid buffer for merged result
+    if (mVerbose==1) mTimer.restart("Allocating merged grid buffer");
+    auto buffer = mBuilder.getBuffer(pool, mStream);
+
+    // Process GridData/TreeData/RootData of merged result
+    if (mVerbose==1) mTimer.restart("Processing grid/tree/root");
+    processGridTreeRoot();
+
+    // Process upper nodes of merged result
+    if (mVerbose==1) mTimer.restart("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+
+    // Process lower nodes of merged result
+    if (mVerbose==1) mTimer.restart("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+
+    // Merge leaf node active masks into new topology
+    if (mVerbose==1) mTimer.restart("Merging leaf nodes");
+    mergeLeafNodes();
+
+    // Process bounding boxes
+    if (mVerbose==1) mTimer.restart("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+
+    // Post-process Grid/Tree data
+    if (mVerbose==1) mTimer.restart("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// MergeGrids<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MergeGrids<BuildT>::mergeRoot()
+{
+    // Creates a new merged tree root with the merged tiles of the two input root topologies
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    std::map<uint64_t, typename RootT::DataType::Tile> mergedTiles;
+
+    // This encoding scheme mirrors the one used in PointsToGrid; note that it is different from Tile::key
+    auto coordToKey = [](const Coord &ijk)->uint64_t{
+        // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+        static constexpr int64_t kOffset = 1 << 31;
+        return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+    };// coordToKey lambda functor
+
+    // Make a host copy of the source root topology RootNode for both inputs
+    // Then, merge tiles of two sources in a sorted container
+
+    if (mSrcTreeData1.mVoxelCount) { // If the first input is not a null grid
+        // Make a host copy of the Root topology
+        auto deviceSrcRoot1 = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid1, GridT::memUsage() + mSrcTreeData1.mNodeOffset[3]));
+        uint64_t rootSize1 = mSrcTreeData1.mNodeOffset[2] - mSrcTreeData1.mNodeOffset[3];
+        auto srcRootBuffer1 = nanovdb::HostBuffer::create(rootSize1);
+        cudaCheck(cudaMemcpyAsync(srcRootBuffer1.data(), deviceSrcRoot1, rootSize1, cudaMemcpyDeviceToHost, mStream));
+        auto srcRoot1 = static_cast<RootT*>(srcRootBuffer1.data());
+
+        // Add all root tiles, reordering if necessary
+        for (uint32_t t = 0; t < srcRoot1->tileCount(); t++) {
+            auto tile = srcRoot1->tile(t);
+            auto sortKey = coordToKey(tile->origin());
+            mergedTiles.emplace(sortKey, *tile);
+        }
+    }
+
+    if (mSrcTreeData2.mVoxelCount) { // If the first input is not a null grid
+        // Make a host copy of the Root topology
+        auto deviceSrcRoot2 = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid2, GridT::memUsage() + mSrcTreeData2.mNodeOffset[3]));
+        uint64_t rootSize2 = mSrcTreeData2.mNodeOffset[2] - mSrcTreeData2.mNodeOffset[3];
+        auto srcRootBuffer2 = nanovdb::HostBuffer::create(rootSize2);
+        cudaCheck(cudaMemcpyAsync(srcRootBuffer2.data(), deviceSrcRoot2, rootSize2, cudaMemcpyDeviceToHost, mStream));
+        auto srcRoot2 = static_cast<RootT*>(srcRootBuffer2.data());
+
+        // Add all root tiles, reordering if necessary
+        for (uint32_t t = 0; t < srcRoot2->tileCount(); t++) {
+            auto tile = srcRoot2->tile(t);
+            auto sortKey = coordToKey(tile->origin());
+            mergedTiles.emplace(sortKey, *tile);
+        }
+    }
+
+    // Package the new root topology into a RootNode plus Tile list; upload to the GPU
+    uint64_t rootSize = RootT::memUsage(mergedTiles.size());
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto mergedRootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    mergedRootPtr->mTableSize = mergedTiles.size();
+    uint32_t t = 0;
+    for (const auto& [key, tile] : mergedTiles)
+        *mergedRootPtr->tile(t++) = tile;
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+}// MergeGrids<BuildT>::mergeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MergeGrids<BuildT>::mergeInternalNodes()
+{
+    // Merges the masks of upper and lower nodes from both input topologies into the
+    // densified, pre-allocated mask arrays of the merged result
+    using Op = util::morphology::cuda::MergeInternalNodesFunctor<BuildT>;
+    if (mSrcTreeData1.mNodeCount[1]) { // Unless the first grid to merge is empty
+        util::cuda::operatorKernel<Op>
+            <<<mSrcTreeData1.mNodeCount[1], Op::MaxThreadsPerBlock, 0, mStream>>>
+            (mDeviceSrcGrid1, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks());
+    }
+    if (mSrcTreeData2.mNodeCount[1]) { // Unless the second grid to merge is empty
+        util::cuda::operatorKernel<Op>
+            <<<mSrcTreeData2.mNodeCount[1], Op::MaxThreadsPerBlock, 0, mStream>>>
+            (mDeviceSrcGrid2, mBuilder.deviceProcessedRoot(), mBuilder.deviceUpperMasks(), mBuilder.deviceLowerMasks());
+    }
+}// MergeGrids<BuildT>::mergeInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void MergeGrids<BuildT>::processGridTreeRoot()
+{
+    // Copy GridData from first source grid
+    // TODO: Check for instances where extra processing is needed
+    // TODO: check that the second grid input has consistent GridData, too
+    cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid1->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
+    cudaCheckError();
+}// MergeGrids<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void MergeGrids<BuildT>::mergeLeafNodes()
+{
+    using Op = util::morphology::cuda::MergeLeafNodesFunctor<BuildT>;
+    if (mSrcTreeData1.mNodeCount[1]) { // Unless first input grid is empty
+        util::cuda::operatorKernel<Op>
+            <<<dim3(mSrcTreeData1.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+            (mDeviceSrcGrid1, static_cast<GridT*>(mBuilder.data()->d_bufferPtr));
+    }
+    if (mSrcTreeData2.mNodeCount[1]) { // Unless second input grid is empty
+        util::cuda::operatorKernel<Op>
+            <<<dim3(mSrcTreeData2.mNodeCount[1],Op::SlicesPerLowerNode,1), Op::MaxThreadsPerBlock, 0, mStream>>>
+            (mDeviceSrcGrid2, static_cast<GridT*>(mBuilder.data()->d_bufferPtr));
+    }
+
+    // Update leaf offsets and prefix sums
+    mBuilder.processLeafOffsets(mStream);
+}// MergeGrids<BuildT>::mergeLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_MERGEGRIDS_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/PointsToGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/PointsToGrid.cuh
@@ -12,16 +12,18 @@
              to only include it in .cu files (or other .cuh files)
 */
 
-#ifndef NVIDIA_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED
-#define NVIDIA_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED
+#ifndef NANOVDB_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED
 
 #include <cub/cub.cuh>
-#include <cub/util_allocator.cuh>
+#include <thrust/iterator/transform_iterator.h>
 #include <vector>
 #include <tuple>
+#include <cinttypes>
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/cuda/TempPool.h>
 #include <nanovdb/GridHandle.h>
 #include <nanovdb/tools/cuda/GridChecksum.cuh>
 #include <nanovdb/util/cuda/Timer.h>
@@ -39,7 +41,7 @@ namespace tools::cuda {// ======================================================
 ///        mainly used as a means to build a BVH acceleration structure for points, e.g. for efficient rendering.
 /// @tparam PtrT Template type to a raw or fancy-pointer of point coordinates in world space. Dereferencing should return Vec3f or Vec3d.
 /// @tparam BufferT Template type of buffer used for memory allocation on the device
-/// @tparam AllocT  Template type of optional device allocator for internal temporary memory
+/// @tparam ResourceT Template type of optional resource used for internal temporary memory
 /// @param dWorldPoints Raw or fancy pointer to list of point coordinates in world space on the device
 /// @param pointCount number of point in the list @c d_world
 /// @param voxelSize Size of a voxel in world units used for the output grid
@@ -49,7 +51,7 @@ namespace tools::cuda {// ======================================================
 /// @param stream optional CUDA stream (defaults to CUDA stream 0)
 /// @return Returns a handle with a grid of type NanoGrid<Point> where point information, e.g. coordinates,
 ///         are represented as blind data defined by @c type.
-template<typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 GridHandle<BufferT>
 pointsToGrid(const PtrT dWorldPoints,
              int pointCount,
@@ -64,13 +66,13 @@ pointsToGrid(const PtrT dWorldPoints,
 ///        mainly used as a means to build a BVH acceleration structure for points, e.g. for efficient rendering.
 /// @tparam PtrT Template type to a raw or fancy-pointer of point coordinates in world space. Dereferencing should return Vec3f or Vec3d.
 /// @tparam BufferT Template type of buffer used for memory allocation on the device
-/// @tparam AllocT  Template type of optional device allocator for internal temporary memory
+/// @tparam ResourceT Template type of optional resource used for internal temporary memory
 /// @param dWorldPoints Raw or fancy pointer to list of point coordinates in world space on the device
 /// @param pointCount total number of point in the list @c d_world
 /// @param maxPointsPerVoxel Max density of points per voxel, i.e. maximum number of points in any voxel
 /// @param tolerance allow for point density to vary by the specified tolerance (defaults to 1). That is, the voxel size
 ///                  is selected such that the max density is +/- the tolerance.
-/// @param maxIterations Maximum number of iterations used to seach for a voxel size that produces a point density
+/// @param maxIterations Maximum number of iterations used to search for a voxel size that produces a point density
 ///                      with specified tolerance takes.
 /// @param type Defined the way point information is represented in the output grid (see PointType enum in NanoVDB.h)
 ///             Should not be PointType::Disable!
@@ -78,7 +80,7 @@ pointsToGrid(const PtrT dWorldPoints,
 /// @param stream optional CUDA stream (defaults to CUDA stream 0)
 /// @return Returns a handle with a grid of type NanoGrid<Point> where point information, e.g. coordinates,
 ///         are represented as blind data defined by @c type.
-template<typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 GridHandle<BufferT>
 pointsToGrid(const PtrT dWorldPoints,
              int pointCount,
@@ -91,7 +93,7 @@ pointsToGrid(const PtrT dWorldPoints,
 
 //-----------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 GridHandle<BufferT>
 pointsToGrid(std::vector<std::tuple<const PtrT,size_t,double,PointType>> pointSet,
             const BufferT &buffer = BufferT(),
@@ -105,13 +107,13 @@ pointsToGrid(std::vector<std::tuple<const PtrT,size_t,double,PointType>> pointSe
 /// @tparam BuildT Template type of the return grid
 /// @tparam PtrT Template type to a raw or fancy-pointer of point coordinates in world space. Dereferencing should return Vec3f or Vec3d.
 /// @tparam BufferT Template type of buffer used for memory allocation on the device
-/// @tparam AllocT  Template type of optional device allocator for internal temporary memory
+/// @tparam ResourceT Template type of optional resource used for internal temporary memory
 /// @param dGridVoxels Raw or fancy pointer to list of voxel coordinates in grid (or index) space on the device
 /// @param pointCount number of voxel in the list @c dGridVoxels
 /// @param voxelSize Size of a voxel in world units used for the output grid
 /// @param buffer Instance of the device buffer used for memory allocation
 /// @return Returns a handle with the grid of type NanoGrid<BuildT>
-template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 GridHandle<BufferT>
 voxelsToGrid(const PtrT dGridVoxels,
              size_t voxelCount,
@@ -121,7 +123,7 @@ voxelsToGrid(const PtrT dGridVoxels,
 
 //-------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = nanovdb::cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 GridHandle<BufferT>
 voxelsToGrid(std::vector<std::tuple<const PtrT, size_t, double>> pointSet,
              const BufferT &buffer = BufferT(),
@@ -131,23 +133,23 @@ voxelsToGrid(std::vector<std::tuple<const PtrT, size_t, double>> pointSet,
 
 /// @brief Example class of a fancy pointer that can optionally be used as a template for writing
 ///        a custom fancy pointer that allows for particle coordinates to be arrange non-linearly
-///        in memory. For instance with coordinates are interlaced with other dats, i.e. an array
+///        in memory. For instance, when coordinates are interlaced with other data, e.g. an array
 ///        of structs, a custom implementation of fancy_ptr::operator[](size_t i) can account for
 ///        strides that skip other interlaces data.
 /// @tparam T Template type that specifies the type use for the coordinates of the points
-template <typename T>
+template<typename T>
 class fancy_ptr
 {
     const T* mPtr;
 public:
     /// @brief Default constructor.
-    /// @note  This method is atcually not required by cuda::PointsToGrid
+    /// @note  This method is actually not required by cuda::PointsToGrid
     /// @param ptr Pointer to array of elements
     __hostdev__ explicit fancy_ptr(const T* ptr = nullptr) : mPtr(ptr) {}
     /// @brief Index acces into the array pointed to by the stored pointer.
     /// @note  This method is required by cuda::PointsToGrid!
     /// @param i Unsigned index of the element to be returned
-    /// @return Const refernce to the element at the i'th poisiton
+    /// @return Const reference to the element at the i'th position
     __hostdev__ inline const T& operator[](size_t i) const {return mPtr[i];}
     /// @brief Dummy implementation required by pointer_traits.
     /// @note  Note that only the return type matters!
@@ -161,22 +163,22 @@ public:
 /// @tparam T Template type that specifies the type use for the coordinates of the points
 /// @param ptr Raw pointer to data
 /// @return a new instance of a fancy_ptr
-template <typename T>
+template<typename T>
 fancy_ptr<T> make_fancy(const T* ptr = nullptr) {return fancy_ptr<T>(ptr);}
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 /// @brief Trait of points, like type of pointer and size of the pointer type
-template <typename>
+template<typename>
 struct pointer_traits;
 
-template <typename T>
+template<typename T>
 struct pointer_traits<T*> {
     using element_type = T;
     static constexpr size_t element_size = sizeof(T);
 };
 
-template <typename T>
+template<typename T>
 struct pointer_traits {
     using element_type = typename util::remove_reference<decltype(*util::declval<T>())>::type;// assumes T::operator*() exists!
     static constexpr size_t element_size = sizeof(element_type);
@@ -189,7 +191,7 @@ struct pointer_traits {
 /// @param voxel 8-bit output coordinates that are relative to a voxel
 /// @param world input world coordinates
 /// @param indexToWorld Transform from index to world space
-template <typename Vec3T>
+template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3u8 &voxel, const Vec3T &world, const Map &indexToWorld)
 {
     const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
@@ -204,7 +206,7 @@ __hostdev__ inline static void worldToVoxel(Vec3u8 &voxel, const Vec3T &world, c
 /// @param voxel 16-bit output coordinates that are relative to a voxel
 /// @param world input world coordinates
 /// @param indexToWorld Transform from index to world space
-template <typename Vec3T>
+template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3u16 &voxel, const Vec3T &world, const Map &indexToWorld)
 {
     const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
@@ -219,7 +221,7 @@ __hostdev__ inline static void worldToVoxel(Vec3u16 &voxel, const Vec3T &world, 
 /// @param voxel float output coordinates that are relative to a voxel
 /// @param world input world coordinates
 /// @param indexToWorld Transform from index to world space
-template <typename Vec3T>
+template<typename Vec3T>
 __hostdev__ inline static void worldToVoxel(Vec3f &voxel, const Vec3T &world, const Map &indexToWorld)
 {
     const Vec3d ijk = indexToWorld.applyInverseMap(world);// world -> index
@@ -230,7 +232,7 @@ __hostdev__ inline static void worldToVoxel(Vec3f &voxel, const Vec3T &world, co
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename Vec3T = Vec3d>
+template<typename Vec3T = Vec3d>
 __hostdev__ inline static Vec3T voxelToWorld(const Vec3u8 &voxel, const Coord &ijk, const Map &map)
 {
     static constexpr double decode = 1.0/double((1<<8) - 1);
@@ -241,7 +243,7 @@ __hostdev__ inline static Vec3T voxelToWorld(const Vec3u8 &voxel, const Coord &i
     }
 }
 
-template <typename Vec3T = Vec3d>
+template<typename Vec3T = Vec3d>
 __hostdev__ inline static Vec3T voxelToWorld(const Vec3u16 &voxel, const Coord &ijk, const Map &map)
 {
     static constexpr double decode = 1.0/double((1<<16) - 1);
@@ -252,7 +254,7 @@ __hostdev__ inline static Vec3T voxelToWorld(const Vec3u16 &voxel, const Coord &
     }
 }
 
-template <typename Vec3T = Vec3d>
+template<typename Vec3T = Vec3d>
 __hostdev__ inline static Vec3T voxelToWorld(const Vec3f &voxel, const Coord &ijk, const Map &map)
 {
     if constexpr(util::is_same<Vec3T,Vec3d>::value) {
@@ -266,41 +268,41 @@ __hostdev__ inline static Vec3T voxelToWorld(const Vec3f &voxel, const Coord &ij
 
 namespace tools::cuda {
 
-template <typename BuildT, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT>
+struct PointsToGridData {
+    Map map;
+    void     *d_bufferPtr;
+    uint64_t *d_keys, *d_tile_keys, *d_lower_keys, *d_leaf_keys;// device pointer to 64 bit keys
+    uint64_t  grid, tree, root, upper, lower, leaf, meta, blind, size;// byte offsets to nodes in buffer
+    uint32_t *d_indx;// device pointer to point indices (or IDs)
+    uint32_t  nodeCount[3], *pointsPerLeafPrefix, *pointsPerLeaf;// 0=leaf,1=lower, 2=upper
+    uint32_t  voxelCount,  *pointsPerVoxelPrefix, *pointsPerVoxel;
+    __hostdev__ NanoGrid<BuildT>&  getGrid() const {return *util::PtrAdd<NanoGrid<BuildT>>(d_bufferPtr, grid);}
+    __hostdev__ NanoTree<BuildT>&  getTree() const {return *util::PtrAdd<NanoTree<BuildT>>(d_bufferPtr, tree);}
+    __hostdev__ NanoRoot<BuildT>&  getRoot() const {return *util::PtrAdd<NanoRoot<BuildT>>(d_bufferPtr, root);}
+    __hostdev__ NanoUpper<BuildT>& getUpper(int i) const {return *(util::PtrAdd<NanoUpper<BuildT>>(d_bufferPtr, upper)+i);}
+    __hostdev__ NanoLower<BuildT>& getLower(int i) const {return *(util::PtrAdd<NanoLower<BuildT>>(d_bufferPtr, lower)+i);}
+    __hostdev__ NanoLeaf<BuildT>&  getLeaf(int i) const {return *(util::PtrAdd<NanoLeaf<BuildT>>(d_bufferPtr, leaf)+i);}
+    __hostdev__ GridBlindMetaData& getMeta() const { return *util::PtrAdd<GridBlindMetaData>(d_bufferPtr, meta);};
+     template<typename Vec3T>
+    __hostdev__ Vec3T& getPoint(int i) const {return *(util::PtrAdd<Vec3T>(d_bufferPtr, blind)+i);}
+};// PointsToGridData
+
+
+template<typename BuildT, typename ResourceT = nanovdb::cuda::DeviceResource>
 class PointsToGrid
 {
 public:
-
-    struct Data {
-        Map map;
-        void     *d_bufferPtr;
-        uint64_t *d_keys, *d_tile_keys, *d_lower_keys, *d_leaf_keys;// device pointer to 64 bit keys
-        uint64_t  grid, tree, root, upper, lower, leaf, meta, blind, size;// byte offsets to nodes in buffer
-        uint32_t *d_indx;// device pointer to point indices (or IDs)
-        uint32_t  nodeCount[3], *pointsPerLeafPrefix, *pointsPerLeaf;// 0=leaf,1=lower, 2=upper
-        uint32_t  voxelCount,  *pointsPerVoxelPrefix, *pointsPerVoxel;
-        BitFlags<16> flags;
-        __hostdev__ NanoGrid<BuildT>&  getGrid() const {return *util::PtrAdd<NanoGrid<BuildT>>(d_bufferPtr, grid);}
-        __hostdev__ NanoTree<BuildT>&  getTree() const {return *util::PtrAdd<NanoTree<BuildT>>(d_bufferPtr, tree);}
-        __hostdev__ NanoRoot<BuildT>&  getRoot() const {return *util::PtrAdd<NanoRoot<BuildT>>(d_bufferPtr, root);}
-        __hostdev__ NanoUpper<BuildT>& getUpper(int i) const {return *(util::PtrAdd<NanoUpper<BuildT>>(d_bufferPtr, upper)+i);}
-        __hostdev__ NanoLower<BuildT>& getLower(int i) const {return *(util::PtrAdd<NanoLower<BuildT>>(d_bufferPtr, lower)+i);}
-        __hostdev__ NanoLeaf<BuildT>&  getLeaf(int i) const {return *(util::PtrAdd<NanoLeaf<BuildT>>(d_bufferPtr, leaf)+i);}
-        __hostdev__ GridBlindMetaData& getMeta() const { return *util::PtrAdd<GridBlindMetaData>(d_bufferPtr, meta);};
-         template <typename Vec3T>
-        __hostdev__ Vec3T& getPoint(int i) const {return *(util::PtrAdd<Vec3T>(d_bufferPtr, blind)+i);}
-    };// Data
-
     /// @brief Map constructor, which other constructors might call
     /// @param map Map to be used for the output device grid
     /// @param stream optional CUDA stream (defaults to CUDA stream 0)
     PointsToGrid(const Map &map, cudaStream_t stream = 0)
         : mStream(stream)
+        , mTimer(stream)
         , mPointType(util::is_same<BuildT,Point>::value ? PointType::Default : PointType::Disable)
     {
         mData.map = map;
-        mData.flags.initMask({GridFlags::HasBBox, GridFlags::IsBreadthFirst});
-        mDeviceData = mMemPool.template alloc<Data>(mStream);
+        mDeviceData = static_cast<PointsToGridData<BuildT>*>(ResourceT::allocateAsync(sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream));
     }
 
     /// @brief Default constructor that calls the Map constructor defined above
@@ -321,6 +323,8 @@ public:
         mMaxIterations = maxIterations;
     }
 
+    ~PointsToGrid(){ ResourceT::deallocateAsync(mDeviceData, sizeof(PointsToGridData<BuildT>), ResourceT::DEFAULT_ALIGNMENT, mStream); }
+
     /// @brief Toggle on and off verbose mode
     /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
     void setVerbose(int level = 1) {mVerbose = level; mData.flags.setBit(7u, level); }
@@ -329,16 +333,12 @@ public:
     /// @param mode Mode of checksum computation
     void setChecksum(CheckMode mode = CheckMode::Disable){mChecksum = mode;}
 
-    /// @brief Toggle on and off the computation of a bounding-box
-    /// @param on If true bbox will be computed
-    void includeBBox(bool on = true) { mData.flags.setMask(GridFlags::HasBBox, on); }
-
     /// @brief Set the name of the output grid
     /// @param name name of the output grid
     void setGridName(const std::string &name) {mGridName = name;}
 
     // only available when BuildT == Point
-    template <typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value>::type
+    template<typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value>::type
     setPointType(PointType type) { mPointType = type; }
 
     /// @brief Creates a handle to a grid with the specified build type from a list of points in index or world space
@@ -354,108 +354,76 @@ public:
                                   size_t pointCount,
                                   const BufferT &buffer = BufferT());
 
-    template <typename PtrT>
+    template<typename PtrT>
     void countNodes(const PtrT points, size_t pointCount);
 
-    template <typename PtrT>
+    template<typename PtrT>
     void processGridTreeRoot(const PtrT points, size_t pointCount);
 
     void processUpperNodes();
 
     void processLowerNodes();
 
-    template <typename PtrT>
-    void processLeafNodes(const PtrT points);
+    void processLeafNodes(size_t pointCount);
 
-    template <typename PtrT>
+    template<typename PtrT>
     void processPoints(const PtrT points, size_t pointCount);
 
     void processBBox();
 
     // the following methods are only defined when BuildT == Point
-    template <typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value, uint32_t>::type
+    template<typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value, uint32_t>::type
     maxPointsPerVoxel() const {return mMaxPointsPerVoxel;}
-    template <typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value, uint32_t>::type
+    template<typename T = BuildT> typename util::enable_if<util::is_same<T, Point>::value, uint32_t>::type
     maxPointsPerLeaf()  const {return mMaxPointsPerLeaf;}
 
 private:
     static constexpr unsigned int mNumThreads = 128;// seems faster than the old value of 256!
     static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
 
-    cudaStream_t      mStream{0};
-    util::cuda::Timer mTimer;
-    PointType         mPointType;
-    std::string       mGridName;
-    int               mVerbose{0};
-    Data              mData, *mDeviceData;
-    uint32_t          mMaxPointsPerVoxel{0u}, mMaxPointsPerLeaf{0u};
-    int               mTolerance{1}, mMaxIterations{1};
-    CheckMode         mChecksum{CheckMode::Disable};
+    cudaStream_t             mStream{0};
+    util::cuda::Timer        mTimer;
+    PointType                mPointType;
+    std::string              mGridName;
+    int                      mVerbose{0};
+    PointsToGridData<BuildT> mData, *mDeviceData;
+    uint32_t                 mMaxPointsPerVoxel{0u}, mMaxPointsPerLeaf{0u};
+    int                      mTolerance{1}, mMaxIterations{1};
+    CheckMode                mChecksum{CheckMode::Disable};
 
-    // wrapper of AllocT, defaulting to cub::CachingDeviceAllocator, which offers a shared scratch space
-    struct Allocator {
-        AllocT mAllocator;
-        void* d_scratch;
-        size_t scratchSize, actualScratchSize;
-        Allocator() : d_scratch(nullptr), scratchSize(0), actualScratchSize(0) {}
-        ~Allocator() {
-            if (scratchSize > 0) this->free(d_scratch);// a bug in cub makes this necessary
-            mAllocator.FreeAllCached();
-        }
-        template <typename T>
-        T* alloc(size_t count, cudaStream_t stream) {
-            T* d_ptr = nullptr;
-            cudaCheck(mAllocator.DeviceAllocate((void**)&d_ptr, sizeof(T)*count, stream));
-            return d_ptr;
-        }
-        template <typename T>
-        T* alloc(cudaStream_t stream) {return this->template alloc<T>(1, stream);}
-        void free(void *d_ptr) {if (d_ptr) cudaCheck(mAllocator.DeviceFree(d_ptr));}
-        template<class... T>
-        void free(void *d_ptr, T... other) {
-            if (d_ptr) cudaCheck(mAllocator.DeviceFree(d_ptr));
-            this->free(other...);
-        }
-        void adjustScratch(cudaStream_t stream){
-            if (scratchSize > actualScratchSize) {
-                if (actualScratchSize>0) cudaCheck(mAllocator.DeviceFree(d_scratch));
-                cudaCheck(mAllocator.DeviceAllocate((void**)&d_scratch, scratchSize, stream));
-                actualScratchSize = scratchSize;
-            }
-        }
-    } mMemPool;
+    nanovdb::cuda::TempPool<ResourceT> mTempDevicePool;
 
     template<typename PtrT, typename BufferT>
     BufferT getBuffer(const PtrT points, size_t pointCount, const BufferT &buffer);
-};// tools::cuda::PointsToGrid<BuildT>
+};// tools::cuda::PointsToGrid<BuildT, ResourceT>
 
 namespace kernels {
-/// @details Used by cuda::PointsToGrid<BuildT>::processLeafNodes before the computation
+/// @details Used by cuda::PointsToGrid<BuildT, ResourceT>::processLeafNodes before the computation
 /// of prefix-sum for index grid.
 /// Moving this away from an implementation using the lambdaKernel wrapper
 /// to fix the following on Windows platform:
 /// error : For this host platform/dialect, an extended lambda cannot be defined inside the 'if'
 /// or 'else' block of a constexpr if statement.
 /// function in a lambda through lambdaKernel wrapper defined in CudaUtils.h.
-template <typename BuildT, typename AllocT = cub::CachingDeviceAllocator>
-__global__ void fillValueIndexKernel(const size_t numItems, uint64_t* devValueIndex, typename PointsToGrid<BuildT, AllocT>::Data* d_data) {
+template<typename BuildT>
+__global__ void fillValueIndexKernel(const size_t numItems, unsigned int offset, uint64_t* devValueIndex, PointsToGridData<BuildT>* d_data) {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= numItems) return;
-    devValueIndex[tid] = static_cast<uint64_t>(d_data->getLeaf(tid).mValueMask.countOn());
+    devValueIndex[tid + offset] = static_cast<uint64_t>(d_data->getLeaf(tid + offset).mValueMask.countOn());
 }
 
-/// @details Used by PointsToGrid<BuildT>::processLeafNodes for the computation
+/// @details Used by PointsToGrid<BuildT, ResourceT>::processLeafNodes for the computation
 /// of prefix-sum for index grid.
 /// Moving this away from an implementation using the lambdaKernel wrapper
 /// to fix the following on Windows platform:
 /// error : For this host platform/dialect, an extended lambda cannot be defined inside the 'if'
 /// or 'else' block of a constexpr if statement.
-template <typename BuildT, typename AllocT = cub::CachingDeviceAllocator>
-__global__ void leafPrefixSumKernel(const size_t numItems, uint64_t* devValueIndexPrefix, typename PointsToGrid<BuildT, AllocT>::Data* d_data) {
+template<typename BuildT>
+__global__ void leafPrefixSumKernel(const size_t numItems, unsigned int offset, uint64_t* devValueIndexPrefix, PointsToGridData<BuildT>* d_data) {
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= numItems) return;
 
-    auto &leaf = d_data->getLeaf(tid);
+    auto &leaf = d_data->getLeaf(tid + offset);
     leaf.mOffset = 1u;// will be re-set below
     const uint64_t *w = leaf.mValueMask.words();
     uint64_t &prefixSum = leaf.mPrefixSum, sum = util::countOn(*w++);
@@ -464,26 +432,14 @@ __global__ void leafPrefixSumKernel(const size_t numItems, uint64_t* devValueInd
         sum += util::countOn(*w++);
         prefixSum |= sum << n;// each pre-fixed sum is encoded in 9 bits
     }
-    if (tid==0) {
+    if ((tid + offset) == 0) {
         d_data->getGrid().mData1 = 1u + devValueIndexPrefix[d_data->nodeCount[0]-1];// set total count
         d_data->getTree().mVoxelCount = devValueIndexPrefix[d_data->nodeCount[0]-1];
     } else {
-        leaf.mOffset = 1u + devValueIndexPrefix[tid-1];// background is index 0
+        leaf.mOffset = 1u + devValueIndexPrefix[tid + offset -1];// background is index 0
     }
 }
 
-/// @details Used by PointsToGrid<BuildT>::processLeafNodes to make sure leaf.mMask - leaf.mValueMask.
-/// Moving this away from an implementation using the lambdaKernel wrapper
-/// to fix the following on Windows platform:
-/// error : For this host platform/dialect, an extended lambda cannot be defined inside the 'if'
-/// or 'else' block of a constexpr if statement.
-template <typename BuildT, typename AllocT = cub::CachingDeviceAllocator>
-__global__ void setMaskEqValMaskKernel(const size_t numItems, typename PointsToGrid<BuildT, AllocT>::Data* d_data) {
-    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid >= numItems) return;
-    auto &leaf = d_data->getLeaf(tid);
-    leaf.mMask = leaf.mValueMask;
-}
 } // namespace kernels
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -492,25 +448,25 @@ __global__ void setMaskEqValMaskKernel(const size_t numItems, typename PointsToG
 #ifndef CALL_CUBS
 #ifdef _WIN32
 #define CALL_CUBS(func, ...) \
-    cudaCheck(cub::func(nullptr, mMemPool.scratchSize, __VA_ARGS__, mStream)); \
-    mMemPool.adjustScratch(mStream); \
-    cudaCheck(cub::func(mMemPool.d_scratch, mMemPool.scratchSize, __VA_ARGS__, mStream));
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), __VA_ARGS__, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), __VA_ARGS__, mStream));
 #else// fdef _WIN32
 #define CALL_CUBS(func, args...) \
-    cudaCheck(cub::func(nullptr, mMemPool.scratchSize, args, mStream)); \
-    mMemPool.adjustScratch(mStream); \
-    cudaCheck(cub::func(mMemPool.d_scratch, mMemPool.scratchSize, args, mStream));
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), args, mStream)); \
+    mTempDevicePool.reallocate(mStream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), args, mStream));
 #endif// ifdef _WIN32
 #endif// ifndef CALL_CUBS
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename AllocT>
+template<typename BuildT, typename ResourceT>
 template<typename PtrT, typename BufferT>
 inline GridHandle<BufferT>
-PointsToGrid<BuildT, AllocT>::getHandle(const PtrT points,
-                                        size_t pointCount,
-                                        const BufferT &pool)
+PointsToGrid<BuildT, ResourceT>::getHandle(const PtrT points,
+                                size_t pointCount,
+                                const BufferT &pool)
 {
     if (mVerbose==1) mTimer.start("\nCounting nodes");
     this->countNodes(points, pointCount);
@@ -528,7 +484,7 @@ PointsToGrid<BuildT, AllocT>::getHandle(const PtrT points,
     this->processLowerNodes();
 
     if (mVerbose==1) mTimer.restart("Process leaf nodes");
-    this->processLeafNodes(points);
+    this->processLeafNodes(pointCount);
 
     if (mVerbose==1) mTimer.restart("Process points");
     this->processPoints(points, pointCount);
@@ -538,33 +494,75 @@ PointsToGrid<BuildT, AllocT>::getHandle(const PtrT points,
     if (mVerbose==1) mTimer.stop();
 
     if (mVerbose==1) mTimer.restart("Computation of checksum");
-    tools::cuda::updateChecksum((GridData*)buffer.deviceData(), mChecksum);
+    tools::cuda::updateChecksum((GridData*)buffer.deviceData(), mChecksum, mStream);
     if (mVerbose==1) mTimer.stop();
 
+    cudaStreamSynchronize(mStream);
+
     return GridHandle<BufferT>(std::move(buffer));
-}// PointsToGrid<BuildT>::getHandle
+}// PointsToGrid<BuildT, ResourceT>::getHandle
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 // --- CUB helpers ---
-template<uint8_t BitCount, typename InT, typename OutT>
+template<uint8_t BitCount, typename InT = uint64_t, typename OutT = uint64_t>
 struct ShiftRight
 {
     __hostdev__ inline OutT operator()(const InT& v) const {return static_cast<OutT>(v >> BitCount);}
 };
 
-template<uint8_t BitCount, typename InT = uint64_t, typename OutT = uint64_t>
-struct ShiftRightIterator : public cub::TransformInputIterator<OutT, ShiftRight<BitCount, InT, OutT>, InT*>
-{
-    using BASE = cub::TransformInputIterator<OutT, ShiftRight<BitCount, InT, OutT>, InT*>;
-    __hostdev__ inline ShiftRightIterator(uint64_t* input_itr) : BASE(input_itr, ShiftRight<BitCount, InT, OutT>()) {}
-};
-
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-template <typename PtrT>
-void PointsToGrid<BuildT, AllocT>::countNodes(const PtrT points, size_t pointCount)
+template<typename BuildT, typename PtrT>
+struct TileKeyFunctor {
+    using Vec3T = typename util::remove_const<typename pointer_traits<PtrT>::element_type>::type;
+
+    __device__
+    void operator()(size_t tid, const PointsToGridData<BuildT> *d_data, const PtrT points, uint64_t* d_keys, uint32_t* d_indx) {
+        auto coordToKey = [](const Coord &ijk)->uint64_t{
+            // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+            static constexpr int64_t kOffset = 1 << 31;
+            return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+                   (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+                   (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+        };// coordToKey lambda functor
+        d_indx[tid] = uint32_t(tid);
+        uint64_t &key = d_keys[tid];
+        if constexpr(util::is_same<BuildT, Point>::value) {// points are in world space
+            if constexpr(util::is_same<Vec3T, Vec3f>::value) {
+                key = coordToKey(d_data->map.applyInverseMapF(points[tid]).round());
+            } else {// points are Vec3d
+                key = coordToKey(d_data->map.applyInverseMap(points[tid]).round());
+            }
+        } else if constexpr(util::is_same<Vec3T, Coord>::value) {// points Coord are in index space
+            key = coordToKey(points[tid]);
+        } else {// points are Vec3f or Vec3d in index space
+            key = coordToKey(points[tid].round());
+        }
+    }
+};
+
+template<typename BuildT, typename PtrT>
+struct VoxelKeyFunctor {
+    using Vec3T = typename util::remove_const<typename pointer_traits<PtrT>::element_type>::type;
+
+    __device__
+    void operator()(size_t tid, const PointsToGridData<BuildT> *d_data, const PtrT points, uint64_t id, uint64_t *d_keys, const uint32_t *d_indx) {
+        auto voxelKey = [] __device__ (uint64_t tileID, const Coord &ijk){
+            return tileID << 36 |                                       // upper offset: 64-15-12-9=28, i.e. last 28 bits
+                uint64_t(NanoUpper<BuildT>::CoordToOffset(ijk)) << 21 | // lower offset: 32^3 = 2^15,   i.e. next 15 bits
+                uint64_t(NanoLower<BuildT>::CoordToOffset(ijk)) <<  9 | // leaf  offset: 16^3 = 2^12,   i.e. next 12 bits
+                uint64_t(NanoLeaf< BuildT>::CoordToOffset(ijk));        // voxel offset:  8^3 =  2^9,   i.e. first 9 bits
+        };// voxelKey lambda functor
+        Vec3T p = points[d_indx[tid]];
+        if constexpr(util::is_same<BuildT, Point>::value) p = util::is_same<Vec3T, Vec3f>::value ? d_data->map.applyInverseMapF(p) : d_data->map.applyInverseMap(p);
+        d_keys[tid] = voxelKey(id, p.round());
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+template<typename PtrT>
+void PointsToGrid<BuildT, ResourceT>::countNodes(const PtrT points, size_t pointCount)
 {
     using Vec3T = typename util::remove_const<typename pointer_traits<PtrT>::element_type>::type;
     if constexpr(util::is_same<BuildT, Point>::value) {
@@ -583,92 +581,68 @@ void PointsToGrid<BuildT, AllocT>::countNodes(const PtrT points, size_t pointCou
 
 jump:// this marks the beginning of the actual algorithm
 
-    mData.d_keys = mMemPool.template alloc<uint64_t>(pointCount, mStream);
-    mData.d_indx = mMemPool.template alloc<uint32_t>(pointCount, mStream);// uint32_t can index 4.29 billion Coords, corresponding to 48 GB
-    cudaCheck(cudaMemcpyAsync(mDeviceData, &mData, sizeof(Data), cudaMemcpyHostToDevice, mStream));// copy mData from CPU -> GPU
+    mData.d_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    mData.d_indx = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));// uint32_t can index 4.29 billion Coords, corresponding to 48 GB
+    cudaCheck(cudaMemcpyAsync(mDeviceData, &mData, sizeof(PointsToGridData<BuildT>), cudaMemcpyHostToDevice, mStream));// copy mData from CPU -> GPU
 
     if (mVerbose==2) mTimer.start("\nAllocating arrays for keys and indices");
-    auto *d_keys = mMemPool.template alloc<uint64_t>(pointCount, mStream);
-    auto *d_indx = mMemPool.template alloc<uint32_t>(pointCount, mStream);
+    auto *d_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    auto *d_indx = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
 
     if (mVerbose==2) mTimer.restart("Generate tile keys");
-    util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, const Data *d_data, const PtrT points) {
-        auto coordToKey = [](const Coord &ijk)->uint64_t{
-            // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
-            static constexpr int64_t offset = 1 << 31;
-            return (uint64_t(uint32_t(int64_t(ijk[2]) + offset) >> 12)      ) | // z is the lower 21 bits
-                   (uint64_t(uint32_t(int64_t(ijk[1]) + offset) >> 12) << 21) | // y is the middle 21 bits
-                   (uint64_t(uint32_t(int64_t(ijk[0]) + offset) >> 12) << 42); //  x is the upper 21 bits
-        };// coordToKey lambda functor
-        d_indx[tid] = uint32_t(tid);
-        uint64_t &key = d_keys[tid];
-        if constexpr(util::is_same<BuildT, Point>::value) {// points are in world space
-            if constexpr(util::is_same<Vec3T, Vec3f>::value) {
-                key = coordToKey(d_data->map.applyInverseMapF(points[tid]).round());
-            } else {// points are Vec3d
-                key = coordToKey(d_data->map.applyInverseMap(points[tid]).round());
-            }
-        } else if constexpr(util::is_same<Vec3T, Coord>::value) {// points Coord are in index space
-            key = coordToKey(points[tid]);
-        } else {// points are Vec3f or Vec3d in index space
-            key = coordToKey(points[tid].round());
-        }
-    }, mDeviceData, points);
+    util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, TileKeyFunctor<BuildT, PtrT>(), mDeviceData, points, d_keys, d_indx);
     cudaCheckError();
     if (mVerbose==2) mTimer.restart("DeviceRadixSort of "+std::to_string(pointCount)+" tile keys");
-    CALL_CUBS(DeviceRadixSort::SortPairs, d_keys, mData.d_keys, d_indx, mData.d_indx, pointCount, 0, 62);// 21 bits per coord
+    CALL_CUBS(DeviceRadixSort::SortPairs, d_keys, mData.d_keys, d_indx, mData.d_indx, pointCount, 0, 63);// 21 bits per coord
     std::swap(d_indx, mData.d_indx);// sorted indices are now in d_indx
 
     if (mVerbose==2) mTimer.restart("Allocate runs");
-    auto *d_points_per_tile = mMemPool.template alloc<uint32_t>(pointCount, mStream);
-    uint32_t *d_node_count  = mMemPool.template alloc<uint32_t>(3, mStream);
+    auto *d_points_per_tile = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    uint32_t *d_node_count  = static_cast<uint32_t*>(ResourceT::allocateAsync(3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
 
     if (mVerbose==2) mTimer.restart("DeviceRunLengthEncode tile keys");
     CALL_CUBS(DeviceRunLengthEncode::Encode, mData.d_keys, d_keys, d_points_per_tile, d_node_count+2, pointCount);
     cudaCheck(cudaMemcpyAsync(mData.nodeCount+2, d_node_count+2, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-    mData.d_tile_keys = mMemPool.template alloc<uint64_t>(mData.nodeCount[2], mStream);
+    cudaCheck(cudaStreamSynchronize(mStream));
+    mData.d_tile_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_tile_keys, d_keys, mData.nodeCount[2]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
-    if (mVerbose) mTimer.restart("DeviceRadixSort of " + std::to_string(pointCount) + " voxel keys in " + std::to_string(mData.nodeCount[2]) + " tiles");
+    if (mVerbose==2) mTimer.restart("DeviceRadixSort of " + std::to_string(pointCount) + " voxel keys in " + std::to_string(mData.nodeCount[2]) + " tiles");
     uint32_t *points_per_tile = new uint32_t[mData.nodeCount[2]];
     cudaCheck(cudaMemcpyAsync(points_per_tile, d_points_per_tile, mData.nodeCount[2]*sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-    mMemPool.free(d_points_per_tile);
+    ResourceT::deallocateAsync(d_points_per_tile, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     for (uint32_t id = 0, offset = 0; id < mData.nodeCount[2]; ++id) {
         const uint32_t count = points_per_tile[id];
-        util::cuda::lambdaKernel<<<numBlocks(count), mNumThreads, 0, mStream>>>(count, [=] __device__(size_t tid, const Data *d_data) {
-            auto voxelKey = [] __device__ (uint64_t tileID, const Coord &ijk){
-                return tileID << 36 |                                       // upper offset: 64-15-12-9=28, i.e. last 28 bits
-                    uint64_t(NanoUpper<BuildT>::CoordToOffset(ijk)) << 21 | // lower offset: 32^3 = 2^15,   i.e. next 15 bits
-                    uint64_t(NanoLower<BuildT>::CoordToOffset(ijk)) <<  9 | // leaf  offset: 16^3 = 2^12,   i.e. next 12 bits
-                    uint64_t(NanoLeaf< BuildT>::CoordToOffset(ijk));        // voxel offset:  8^3 =  2^9,   i.e. first 9 bits
-            };// voxelKey lambda functor
-            tid += offset;
-            Vec3T p = points[d_indx[tid]];
-            if constexpr(util::is_same<BuildT, Point>::value) p = util::is_same<Vec3T, Vec3f>::value ? d_data->map.applyInverseMapF(p) : d_data->map.applyInverseMap(p);
-            d_keys[tid] = voxelKey(id, p.round());
-        }, mDeviceData); cudaCheckError();
+        util::cuda::offsetLambdaKernel<<<numBlocks(count), mNumThreads, 0, mStream>>>(count, offset, VoxelKeyFunctor<BuildT, PtrT>(), mDeviceData, points, id, d_keys, d_indx);
+        cudaCheckError();
         CALL_CUBS(DeviceRadixSort::SortPairs, d_keys + offset, mData.d_keys + offset, d_indx + offset, mData.d_indx + offset, count, 0, 36);// 9+12+15=36
         offset += count;
     }
-    mMemPool.free(d_indx);
+    ResourceT::deallocateAsync(d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     delete [] points_per_tile;
 
     if (mVerbose==2) mTimer.restart("Count points per voxel");
 
-    mData.pointsPerVoxel    = mMemPool.template alloc<uint32_t>(pointCount, mStream);
-    uint32_t *d_voxel_count = mMemPool.template alloc<uint32_t>(mStream);
+    cudaEvent_t copyEvent;
+    cudaCheck(cudaEventCreate(&copyEvent));
+    mData.pointsPerVoxel    = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    uint32_t *d_voxel_count = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceRunLengthEncode::Encode, mData.d_keys, d_keys, mData.pointsPerVoxel, d_voxel_count, pointCount);
     cudaCheck(cudaMemcpyAsync(&mData.voxelCount, d_voxel_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-    mMemPool.free(d_voxel_count);
+    cudaCheck(cudaEventRecord(copyEvent, mStream));
+    ResourceT::deallocateAsync(d_voxel_count, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     if (util::is_same<BuildT, Point>::value) {
         if (mVerbose==2) mTimer.restart("Count max points per voxel");
-        uint32_t *d_maxPointsPerVoxel = mMemPool.template alloc<uint32_t>(mStream), maxPointsPerVoxel;
+        uint32_t *d_maxPointsPerVoxel = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream)), maxPointsPerVoxel;
+        cudaCheck(cudaEventSynchronize(copyEvent));
         CALL_CUBS(DeviceReduce::Max, mData.pointsPerVoxel, d_maxPointsPerVoxel, mData.voxelCount);
         cudaCheck(cudaMemcpyAsync(&maxPointsPerVoxel, d_maxPointsPerVoxel, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-        mMemPool.free(d_maxPointsPerVoxel);
+        cudaCheck(cudaEventRecord(copyEvent, mStream));
+        ResourceT::deallocateAsync(d_maxPointsPerVoxel, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
         double dx = mData.map.getVoxelSize()[0];
+        cudaCheck(cudaEventSynchronize(copyEvent));
         if (++iterCounter >= mMaxIterations || pointCount == 1u || math::Abs((int)maxPointsPerVoxel - (int)mMaxPointsPerVoxel) <= mTolerance) {
             mMaxPointsPerVoxel = maxPointsPerVoxel;
         } else {
@@ -685,55 +659,68 @@ jump:// this marks the beginning of the actual algorithm
             } else {// maxPointsPerVoxel = 1 so increase dx significantly
                 dx *= 10.0;
             }
-            if (mVerbose==2) printf("\ntarget density = %u, current density = %u current dx = %f, next dx = %f\n", mMaxPointsPerVoxel, maxPointsPerVoxel, tmp.dx, dx);
+            if (mVerbose==2) printf("\ntarget density = %" PRIu32 ", current density = %" PRIu32 ", current dx = %f, next dx = %f\n", mMaxPointsPerVoxel, maxPointsPerVoxel, tmp.dx, dx);
             mData.map = Map(dx);
-            mMemPool.free(mData.d_keys, mData.d_indx, d_keys, mData.d_tile_keys, d_node_count, mData.pointsPerVoxel);
+            ResourceT::deallocateAsync(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            ResourceT::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            ResourceT::deallocateAsync(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            ResourceT::deallocateAsync(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            ResourceT::deallocateAsync(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+            ResourceT::deallocateAsync(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
             goto jump;
         }
     }
     if (iterCounter>1 && mVerbose) std::cerr << "Used " << iterCounter << " attempts to determine dx that produces a target dpoint denisty\n\n";
 
     if (mVerbose==2) mTimer.restart("Compute prefix sum of points per voxel");
-    mData.pointsPerVoxelPrefix = mMemPool.template alloc<uint32_t>(mData.voxelCount, mStream);
+    cudaCheck(cudaEventSynchronize(copyEvent));
+    mData.pointsPerVoxelPrefix = static_cast<uint32_t*>(ResourceT::allocateAsync(mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceScan::ExclusiveSum, mData.pointsPerVoxel, mData.pointsPerVoxelPrefix, mData.voxelCount);
 
-    mData.pointsPerLeaf = mMemPool.template alloc<uint32_t>(pointCount, mStream);
-    CALL_CUBS(DeviceRunLengthEncode::Encode, ShiftRightIterator<9>(mData.d_keys), d_keys, mData.pointsPerLeaf, d_node_count, pointCount);
+    mData.pointsPerLeaf = static_cast<uint32_t*>(ResourceT::allocateAsync(pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+    CALL_CUBS(DeviceRunLengthEncode::Encode, thrust::make_transform_iterator(mData.d_keys, ShiftRight<9>()), d_keys, mData.pointsPerLeaf, d_node_count, pointCount);
     cudaCheck(cudaMemcpyAsync(mData.nodeCount, d_node_count, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
+    cudaCheck(cudaEventRecord(copyEvent, mStream));
 
     if constexpr(util::is_same<BuildT, Point>::value) {
-        uint32_t *d_maxPointsPerLeaf = mMemPool.template alloc<uint32_t>(mStream);
+        uint32_t *d_maxPointsPerLeaf = static_cast<uint32_t*>(ResourceT::allocateAsync(sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        cudaCheck(cudaEventSynchronize(copyEvent));
         CALL_CUBS(DeviceReduce::Max, mData.pointsPerLeaf, d_maxPointsPerLeaf, mData.nodeCount[0]);
         cudaCheck(cudaMemcpyAsync(&mMaxPointsPerLeaf, d_maxPointsPerLeaf, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
         //printf("\n Leaf count = %u, max points per leaf = %u\n", mData.nodeCount[0], mMaxPointsPerLeaf);
         if (mMaxPointsPerLeaf > std::numeric_limits<uint16_t>::max()) {
             throw std::runtime_error("Too many points per leaf: "+std::to_string(mMaxPointsPerLeaf));
         }
-        mMemPool.free(d_maxPointsPerLeaf);
+        ResourceT::deallocateAsync(d_maxPointsPerLeaf, sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     }
 
-    mData.pointsPerLeafPrefix = mMemPool.template alloc<uint32_t>(mData.nodeCount[0], mStream);
+    cudaCheck(cudaEventSynchronize(copyEvent));
+    mData.pointsPerLeafPrefix = static_cast<uint32_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     CALL_CUBS(DeviceScan::ExclusiveSum, mData.pointsPerLeaf, mData.pointsPerLeafPrefix, mData.nodeCount[0]);
 
-    mData.d_leaf_keys = mMemPool.template alloc<uint64_t>(mData.nodeCount[0], mStream);
+    cudaCheck(cudaStreamSynchronize(mStream));
+    mData.d_leaf_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_leaf_keys, d_keys, mData.nodeCount[0]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
-    CALL_CUBS(DeviceSelect::Unique, ShiftRightIterator<12>(mData.d_leaf_keys), d_keys, d_node_count+1, mData.nodeCount[0]);// count lower nodes
+    CALL_CUBS(DeviceSelect::Unique, thrust::make_transform_iterator(mData.d_leaf_keys, ShiftRight<12>()), d_keys, d_node_count+1, mData.nodeCount[0]);// count lower nodes
     cudaCheck(cudaMemcpyAsync(mData.nodeCount+1, d_node_count+1, sizeof(uint32_t), cudaMemcpyDeviceToHost, mStream));
-    mData.d_lower_keys = mMemPool.template alloc<uint64_t>(mData.nodeCount[1], mStream);
+    cudaCheck(cudaStreamSynchronize(mStream));
+    mData.d_lower_keys = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
     cudaCheck(cudaMemcpyAsync(mData.d_lower_keys, d_keys, mData.nodeCount[1]*sizeof(uint64_t), cudaMemcpyDeviceToDevice, mStream));
 
-    mMemPool.free(d_keys, d_node_count);
+    ResourceT::deallocateAsync(d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    ResourceT::deallocateAsync(d_node_count, 3*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     if (mVerbose==2) mTimer.stop();
+    cudaCheck(cudaEventDestroy(copyEvent));
 
     //printf("Leaf count = %u, lower count = %u, upper count = %u\n", mData.nodeCount[0], mData.nodeCount[1], mData.nodeCount[2]);
-}// PointsToGrid<BuildT>::countNodes
+}// PointsToGrid<BuildT, ResourceT>::countNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-template <typename PtrT, typename BufferT>
-inline BufferT PointsToGrid<BuildT, AllocT>::getBuffer(const PtrT, size_t pointCount, const BufferT &pool)
+template<typename BuildT, typename ResourceT>
+template<typename PtrT, typename BufferT>
+inline BufferT PointsToGrid<BuildT, ResourceT>::getBuffer(const PtrT, size_t pointCount, const BufferT &pool)
 {
     auto sizeofPoint = [&]()->size_t{
         switch (mPointType){
@@ -760,28 +747,32 @@ inline BufferT PointsToGrid<BuildT, AllocT>::getBuffer(const PtrT, size_t pointC
     mData.blind = mData.meta  + sizeof(GridBlindMetaData)*int( mPointType!=PointType::Disable ); // meta data ends and blind data begins
     mData.size  = mData.blind + pointCount*sizeofPoint();// end of buffer
 
-    auto buffer = BufferT::create(mData.size, &pool, false);// only allocate buffer on the device
+    int device = 0;
+    cudaGetDevice(&device);
+    auto buffer = BufferT::create(mData.size, &pool, device, mStream);// only allocate buffer on the device
+
     mData.d_bufferPtr = buffer.deviceData();
     if (mData.d_bufferPtr == nullptr) throw std::runtime_error("Failed to allocate grid buffer on the device");
-    cudaCheck(cudaMemcpyAsync(mDeviceData, &mData, sizeof(Data), cudaMemcpyHostToDevice, mStream));// copy Data CPU -> GPU
+    cudaCheck(cudaMemcpyAsync(mDeviceData, &mData, sizeof(PointsToGridData<BuildT>), cudaMemcpyHostToDevice, mStream));// copy Data CPU -> GPU
     return buffer;
-}// PointsToGrid<BuildT>::getBuffer
+}// PointsToGrid<BuildT, ResourceT>::getBuffer
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-template <typename PtrT>
-inline void PointsToGrid<BuildT, AllocT>::processGridTreeRoot(const PtrT points, size_t pointCount)
+template<typename BuildT, typename PtrT>
+struct BuildGridTreeRootFunctor
 {
     using Vec3T = typename util::remove_const<typename pointer_traits<PtrT>::element_type>::type;
-    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, [=] __device__(size_t, Data *d_data, PointType pointType) {
+
+    __device__
+    void operator()(size_t, PointsToGridData<BuildT> *d_data, PointType pointType, size_t pointCount) {
        // process Root
         auto &root = d_data->getRoot();
         root.mBBox = CoordBBox(); // init to empty
         root.mTableSize = d_data->nodeCount[2];
-        root.mBackground = NanoRoot<BuildT>::ValueType(0);// background_value
-        root.mMinimum = root.mMaximum = NanoRoot<BuildT>::ValueType(0);
-        root.mAverage = root.mStdDevi = NanoRoot<BuildT>::FloatType(0);
+        root.mBackground = typename NanoRoot<BuildT>::ValueType(0);// background_value
+        root.mMinimum = root.mMaximum = typename NanoRoot<BuildT>::ValueType(0);
+        root.mAverage = root.mStdDevi = typename NanoRoot<BuildT>::FloatType(0);
 
         // process Tree
         auto &tree = d_data->getTree();
@@ -789,9 +780,12 @@ inline void PointsToGrid<BuildT, AllocT>::processGridTreeRoot(const PtrT points,
         tree.setFirstNode(&d_data->getUpper(0));
         tree.setFirstNode(&d_data->getLower(0));
         tree.setFirstNode(&d_data->getLeaf(0));
-        tree.mNodeCount[2] = tree.mTileCount[2] = d_data->nodeCount[2];
-        tree.mNodeCount[1] = tree.mTileCount[1] = d_data->nodeCount[1];
-        tree.mNodeCount[0] = tree.mTileCount[0] = d_data->nodeCount[0];
+        tree.mNodeCount[2] = d_data->nodeCount[2];
+        tree.mNodeCount[1] = d_data->nodeCount[1];
+        tree.mNodeCount[0] = d_data->nodeCount[0];
+        tree.mTileCount[2] = 0;
+        tree.mTileCount[1] = 0;
+        tree.mTileCount[0] = 0;
         tree.mVoxelCount = d_data->voxelCount;
 
         // process Grid
@@ -883,17 +877,26 @@ inline void PointsToGrid<BuildT, AllocT>::processGridTreeRoot(const PtrT points,
                 } else if constexpr(util::is_same<Vec3T, Vec3d>::value){
                     util::strcpy(meta.mName, "World64: Vec3<double> point coordinates in world space");
                 } else {
-                    printf("Error in PointsToGrid<BuildT>::processGridTreeRoot: expected Vec3T = Vec3f or Vec3d\n");
+                    printf("Error in PointsToGrid<BuildT, ResourceT>::processGridTreeRoot: expected Vec3T = Vec3f or Vec3d\n");
                 }
                 break;
             default:
-                printf("Error in PointsToGrid<BuildT>::processGridTreeRoot: invalid pointType\n");
+                printf("Error in PointsToGrid<BuildT, ResourceT>::processGridTreeRoot: invalid pointType\n");
             }
+        } else if constexpr(BuildTraits<BuildT>::is_onindex) {
+            grid.mGridClass = GridClass::IndexGrid;
         } else if constexpr(BuildTraits<BuildT>::is_offindex) {
             grid.mData1 = 1u + 512u*d_data->nodeCount[0];
             grid.mGridClass = GridClass::IndexGrid;
         }
-    }, mDeviceData, mPointType);// lambdaKernel
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+template<typename PtrT>
+inline void PointsToGrid<BuildT, ResourceT>::processGridTreeRoot(const PtrT points, size_t pointCount)
+{
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, BuildGridTreeRootFunctor<BuildT, PtrT>(), mDeviceData, mPointType, pointCount);// lambdaKernel
     cudaCheckError();
 
     char *dst = mData.getGrid().mGridName;
@@ -902,14 +905,15 @@ inline void PointsToGrid<BuildT, AllocT>::processGridTreeRoot(const PtrT points,
     } else {
         cudaCheck(cudaMemsetAsync(dst, 0, GridData::MaxNameSize, mStream));
     }
-}// PointsToGrid<BuildT>::processGridTreeRoot
+}// PointsToGrid<BuildT, ResourceT>::processGridTreeRoot
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-inline void PointsToGrid<BuildT, AllocT>::processUpperNodes()
+template<typename BuildT>
+struct BuildUpperNodesFunctor
 {
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], [=] __device__(size_t tid, Data *d_data) {
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         auto &root  = d_data->getRoot();
         auto &upper = d_data->getUpper(tid);
 #if 1
@@ -922,34 +926,48 @@ inline void PointsToGrid<BuildT, AllocT>::processUpperNodes()
         };
         const Coord ijk = keyToCoord(d_data->d_tile_keys[tid]);
 #else
-        const Coord ijk = NanoRoot<uint32_t>::KeyToCoord(d_data->d_tile_keys[tid]);
+        const Coord ijk = typename NanoRoot<uint32_t>::KeyToCoord(d_data->d_tile_keys[tid]);
 #endif
         root.tile(tid)->setChild(ijk, &upper, &root);
         upper.mBBox[0] = ijk;
-        upper.mFlags = 0;
+        upper.mFlags = (uint64_t) GridFlags::HasBBox;
         upper.mValueMask.setOff();
         upper.mChildMask.setOff();
-        upper.mMinimum = upper.mMaximum = NanoLower<BuildT>::ValueType(0);
-        upper.mAverage = upper.mStdDevi = NanoLower<BuildT>::FloatType(0);
-    }, mDeviceData);
+        upper.mMinimum = upper.mMaximum = typename NanoLower<BuildT>::ValueType(0);
+        upper.mAverage = upper.mStdDevi = typename NanoLower<BuildT>::FloatType(0);
+    }
+};
+
+template<typename BuildT>
+struct SetUpperBackgroundValuesFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
+        auto &upper = d_data->getUpper(tid >> 15);
+        upper.mTable[tid & 32767u].value = typename NanoUpper<BuildT>::ValueType(0);// background
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+inline void PointsToGrid<BuildT, ResourceT>::processUpperNodes()
+{
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], BuildUpperNodesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
 
-    mMemPool.free(mData.d_tile_keys);
+    ResourceT::deallocateAsync(mData.d_tile_keys, mData.nodeCount[2]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 
     const uint64_t valueCount = mData.nodeCount[2] << 15;
-    util::cuda::lambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, mStream>>>(valueCount, [=] __device__(size_t tid, Data *d_data) {
-        auto &upper = d_data->getUpper(tid >> 15);
-        upper.mTable[tid & 32767u].value = NanoUpper<BuildT>::ValueType(0);// background
-    }, mDeviceData);
+    util::cuda::lambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, mStream>>>(valueCount, SetUpperBackgroundValuesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
-}// PointsToGrid<BuildT>::processUpperNodes
+}// PointsToGrid<BuildT, ResourceT>::processUpperNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-inline void PointsToGrid<BuildT, AllocT>::processLowerNodes()
+template<typename BuildT>
+struct BuildLowerNodesFunctor
 {
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], [=] __device__(size_t tid, Data *d_data) {
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         auto &root  = d_data->getRoot();
         const uint64_t lowerKey = d_data->d_lower_keys[tid];
         auto &upper = d_data->getUpper(lowerKey >> 15);
@@ -958,33 +976,42 @@ inline void PointsToGrid<BuildT, AllocT>::processLowerNodes()
         auto &lower = d_data->getLower(tid);
         upper.setChild(upperOffset, &lower);
         lower.mBBox[0] = upper.offsetToGlobalCoord(upperOffset);
-        lower.mFlags = 0;
+        lower.mFlags = (uint64_t) GridFlags::HasBBox;
         lower.mValueMask.setOff();
         lower.mChildMask.setOff();
-        lower.mMinimum = lower.mMaximum = NanoLower<BuildT>::ValueType(0);// background;
-        lower.mAverage = lower.mStdDevi = NanoLower<BuildT>::FloatType(0);
-    }, mDeviceData);
+        lower.mMinimum = lower.mMaximum = typename NanoLower<BuildT>::ValueType(0);// background;
+        lower.mAverage = lower.mStdDevi = typename NanoLower<BuildT>::FloatType(0);
+    }
+};
+
+template<typename BuildT>
+struct SetLowerBackgroundValuesFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
+        auto &lower = d_data->getLower(tid >> 12);
+        lower.mTable[tid & 4095u].value = typename NanoLower<BuildT>::ValueType(0);// background
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+inline void PointsToGrid<BuildT, ResourceT>::processLowerNodes()
+{
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], BuildLowerNodesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
 
     const uint64_t valueCount = mData.nodeCount[1] << 12;
-    util::cuda::lambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, mStream>>>(valueCount, [=] __device__(size_t tid, Data *d_data) {
-        auto &lower = d_data->getLower(tid >> 12);
-        lower.mTable[tid & 4095u].value = NanoLower<BuildT>::ValueType(0);// background
-    }, mDeviceData);
+    util::cuda::lambdaKernel<<<numBlocks(valueCount), mNumThreads, 0, mStream>>>(valueCount, SetLowerBackgroundValuesFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
-}// PointsToGrid<BuildT>::processLowerNodes
+}// PointsToGrid<BuildT, ResourceT>::processLowerNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-template <typename PtrT>
-inline void PointsToGrid<BuildT, AllocT>::processLeafNodes(const PtrT points)
+template<typename BuildT>
+struct ProcessLeafMetaDataFunctor
 {
-    const uint8_t flags = static_cast<uint8_t>(mData.flags.data());// mIncludeStats ? 16u : 0u;// 4th bit indicates stats
-
-    if (mVerbose==2) mTimer.start("process leaf meta data");
-    // loop over leaf nodes and add it to its parent node
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], [=] __device__(size_t tid, Data *d_data) {
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data, uint8_t flags) {
         const uint64_t leafKey = d_data->d_leaf_keys[tid], tile_id = leafKey >> 27;
         auto &upper = d_data->getUpper(tile_id);
         const uint32_t lowerOffset = leafKey & 4095u, upperOffset = (leafKey >> 12) & 32767u;
@@ -1004,14 +1031,17 @@ inline void PointsToGrid<BuildT, AllocT>::processLeafNodes(const PtrT points)
             leaf.mOffset = tid*512u + 1u;// background is index 0
             leaf.mPrefixSum = 0u;
         } else if constexpr(!BuildTraits<BuildT>::is_special) {
-            leaf.mAverage = leaf.mStdDevi = NanoLeaf<BuildT>::FloatType(0);
-            leaf.mMinimum = leaf.mMaximum = NanoLeaf<BuildT>::ValueType(0);
+            leaf.mAverage = leaf.mStdDevi = typename NanoLeaf<BuildT>::FloatType(0);
+            leaf.mMinimum = leaf.mMaximum = typename NanoLeaf<BuildT>::ValueType(0);
         }
-    }, mDeviceData); cudaCheckError();
+    }
+};
 
-    if (mVerbose==2) mTimer.restart("set active voxel state and values");
-    // loop over all active voxels and set LeafNode::mValueMask and LeafNode::mValues
-    util::cuda::lambdaKernel<<<numBlocks(mData.voxelCount), mNumThreads, 0, mStream>>>(mData.voxelCount, [=] __device__(size_t tid, Data *d_data) {
+template<typename BuildT>
+struct SetLeafActiveVoxelStateAndValuesFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         const uint32_t pointID  = d_data->pointsPerVoxelPrefix[tid];
         const uint64_t voxelKey = d_data->d_keys[pointID];
         auto &upper = d_data->getUpper(voxelKey >> 36);
@@ -1022,15 +1052,16 @@ inline void PointsToGrid<BuildT, AllocT>::processLeafNodes(const PtrT points)
         if constexpr(util::is_same<Point, BuildT>::value) {
             leaf.mValues[n] = uint16_t(pointID + d_data->pointsPerVoxel[tid] - leaf.offset());
         } else if constexpr(!BuildTraits<BuildT>::is_special) {
-            leaf.mValues[n] = NanoLeaf<BuildT>::ValueType(1);// set value of active voxels that are not points (or index)
+            leaf.mValues[n] = typename NanoLeaf<BuildT>::ValueType(1);// set value of active voxels that are not points (or index)
         }
-    }, mDeviceData); cudaCheckError();
+    }
+};
 
-    mMemPool.free(mData.d_keys, mData.pointsPerVoxel, mData.pointsPerVoxelPrefix, mData.pointsPerLeafPrefix, mData.pointsPerLeaf);
-
-    if (mVerbose==2) mTimer.restart("set inactive voxel values");
-    const uint64_t denseVoxelCount = mData.nodeCount[0] << 9;
-    util::cuda::lambdaKernel<<<numBlocks(denseVoxelCount), mNumThreads, 0, mStream>>>(denseVoxelCount, [=] __device__(size_t tid, Data *d_data) {
+template<typename BuildT>
+struct SetLeafInactiveVoxelValuesFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         auto &leaf = d_data->getLeaf(tid >> 9u);
         const uint32_t n = tid & 511u;
         if (leaf.mValueMask.isOn(n)) return;
@@ -1038,198 +1069,267 @@ inline void PointsToGrid<BuildT, AllocT>::processLeafNodes(const PtrT points)
             const uint32_t m = leaf.mValueMask.findPrev<true>(n - 1);
             leaf.mValues[n] = m < 512u ? leaf.mValues[m] : 0u;
         } else if constexpr(!BuildTraits<BuildT>::is_special) {
-            leaf.mValues[n] = NanoLeaf<BuildT>::ValueType(0);// value of inactive voxels
+            leaf.mValues[n] = typename NanoLeaf<BuildT>::ValueType(0);// value of inactive voxels
         }
-    }, mDeviceData); cudaCheckError();
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+inline void PointsToGrid<BuildT, ResourceT>::processLeafNodes(size_t pointCount)
+{
+    const uint8_t flags = (uint8_t) GridFlags::HasBBox;
+
+    if (mVerbose==2) mTimer.start("process leaf meta data");
+    // loop over leaf nodes and add it to its parent node
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], ProcessLeafMetaDataFunctor<BuildT>(), mDeviceData, flags);
+    cudaCheckError();
+
+    if (mVerbose==2) mTimer.restart("set active voxel state and values");
+    // loop over all active voxels and set LeafNode::mValueMask and LeafNode::mValues
+    util::cuda::lambdaKernel<<<numBlocks(mData.voxelCount), mNumThreads, 0, mStream>>>(mData.voxelCount, SetLeafActiveVoxelStateAndValuesFunctor<BuildT>(), mDeviceData);
+    cudaCheckError();
+
+    ResourceT::deallocateAsync(mData.d_keys, pointCount*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    ResourceT::deallocateAsync(mData.pointsPerVoxel, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    ResourceT::deallocateAsync(mData.pointsPerVoxelPrefix, mData.voxelCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    ResourceT::deallocateAsync(mData.pointsPerLeafPrefix, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    ResourceT::deallocateAsync(mData.pointsPerLeaf,mData.nodeCount[0]*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+
+    if (mVerbose==2) mTimer.restart("set inactive voxel values");
+    const uint64_t denseVoxelCount = mData.nodeCount[0] << 9;
+    util::cuda::lambdaKernel<<<numBlocks(denseVoxelCount), mNumThreads, 0, mStream>>>(denseVoxelCount, SetLeafInactiveVoxelValuesFunctor<BuildT>(), mDeviceData);
+    cudaCheckError();
 
     if constexpr(BuildTraits<BuildT>::is_onindex) {
         if (mVerbose==2) mTimer.restart("prefix-sum for index grid");
-        uint64_t *devValueIndex = mMemPool.template alloc<uint64_t>(mData.nodeCount[0], mStream);
-        auto devValueIndexPrefix = mMemPool.template alloc<uint64_t>(mData.nodeCount[0], mStream);
-        kernels::fillValueIndexKernel<BuildT, AllocT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], devValueIndex, mDeviceData);
+        auto devValueIndex = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        auto devValueIndexPrefix = static_cast<uint64_t*>(ResourceT::allocateAsync(mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream));
+        kernels::fillValueIndexKernel<BuildT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], 0, devValueIndex, mDeviceData);
         cudaCheckError();
         CALL_CUBS(DeviceScan::InclusiveSum, devValueIndex, devValueIndexPrefix, mData.nodeCount[0]);
-        mMemPool.free(devValueIndex);
-        kernels::leafPrefixSumKernel<BuildT, AllocT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], devValueIndexPrefix, mDeviceData);
+        ResourceT::deallocateAsync(devValueIndex, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+        kernels::leafPrefixSumKernel<BuildT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], 0, devValueIndexPrefix, mDeviceData);
         cudaCheckError();
-        mMemPool.free(devValueIndexPrefix);
+        ResourceT::deallocateAsync(devValueIndexPrefix, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     }
 
-    if constexpr(BuildTraits<BuildT>::is_indexmask) {
-        if (mVerbose==2) mTimer.restart("leaf.mMask = leaf.mValueMask");
-        kernels::setMaskEqValMaskKernel<BuildT, AllocT><<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], mDeviceData);
-        cudaCheckError();
-    }
     if (mVerbose==2) mTimer.stop();
-}// PointsToGrid<BuildT>::processLeafNodes
+}// PointsToGrid<BuildT, ResourceT>::processLeafNodes
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-template <typename PtrT>
-inline void PointsToGrid<BuildT, AllocT>::processPoints(const PtrT, size_t)
+// Undefine utility macro for cub functions
+#ifdef CALL_CUBS
+#undef CALL_CUBS
+#endif
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT, typename ResourceT>
+template<typename PtrT>
+inline void PointsToGrid<BuildT, ResourceT>::processPoints(const PtrT, size_t pointCount)
 {
-    mMemPool.free(mData.d_indx);
+    ResourceT::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 // Template specialization with BuildT = Point
-template <>
-template <typename PtrT>
+template<>
+template<typename PtrT>
 inline void PointsToGrid<Point>::processPoints(const PtrT points, size_t pointCount)
 {
     switch (mPointType){
     case PointType::Disable:
         throw std::runtime_error("PointsToGrid<Point>::processPoints: mPointType == PointType::Disable\n");
     case PointType::PointID:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<uint32_t>(tid) = d_data->d_indx[tid];
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::World64:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<Vec3d>(tid) = points[d_data->d_indx[tid]];
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::World32:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<Vec3f>(tid) = points[d_data->d_indx[tid]];
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Grid64:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<Vec3d>(tid) = d_data->map.applyInverseMap(points[d_data->d_indx[tid]]);
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Grid32:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<Vec3f>(tid) = d_data->map.applyInverseMapF(points[d_data->d_indx[tid]]);
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Voxel32:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             worldToVoxel(d_data->template getPoint<Vec3f>(tid), points[d_data->d_indx[tid]], d_data->map);
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Voxel16:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             worldToVoxel(d_data->template getPoint<Vec3u16>(tid), points[d_data->d_indx[tid]], d_data->map);
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Voxel8:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             worldToVoxel(d_data->template getPoint<Vec3u8>(tid), points[d_data->d_indx[tid]], d_data->map);
         }, mDeviceData); cudaCheckError();
         break;
     case PointType::Default:
-        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, Data *d_data) {
+        util::cuda::lambdaKernel<<<numBlocks(pointCount), mNumThreads, 0, mStream>>>(pointCount, [=] __device__(size_t tid, PointsToGridData<Point> *d_data) {
             d_data->template getPoint<typename pointer_traits<PtrT>::element_type>(tid) = points[d_data->d_indx[tid]];
         }, mDeviceData); cudaCheckError();
         break;
     default:
         printf("Internal error in PointsToGrid<Point>::processPoints\n");
     }
-    mMemPool.free(mData.d_indx);
+    nanovdb::cuda::DeviceResource::deallocateAsync(mData.d_indx, pointCount*sizeof(uint32_t), nanovdb::cuda::DeviceResource::DEFAULT_ALIGNMENT, mStream);
 }// PointsToGrid<Point>::processPoints
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename BuildT, typename AllocT>
-inline void PointsToGrid<BuildT, AllocT>::processBBox()
+template<typename BuildT>
+struct ResetLowerNodeBBoxFunctor
 {
-    if (mData.flags.isMaskOff(GridFlags::HasBBox)) {
-        mMemPool.free(mData.d_leaf_keys, mData.d_lower_keys);
-        return;
-    }
-
-    // reset bbox in lower nodes
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], [=] __device__(size_t tid, Data *d_data) {
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         d_data->getLower(tid).mBBox = CoordBBox();
-    }, mDeviceData);
-    cudaCheckError();
+    }
+};
 
-    // update and propagate bbox from leaf -> lower/parent nodes
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], [=] __device__(size_t tid, Data *d_data) {
+template<typename BuildT>
+struct UpdateAndPropagateLeafBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         const uint64_t leafKey = d_data->d_leaf_keys[tid];
         auto &upper = d_data->getUpper(leafKey >> 27);
         auto &lower = *upper.getChild((leafKey >> 12) & 32767u);
         auto &leaf = d_data->getLeaf(tid);
         leaf.updateBBox();
         lower.mBBox.expandAtomic(leaf.bbox());
-    }, mDeviceData);
-    mMemPool.free(mData.d_leaf_keys);
-    cudaCheckError();
+    }
+};
 
-    // reset bbox in upper nodes
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], [=] __device__(size_t tid, Data *d_data) {
+template<typename BuildT>
+struct ResetUpperNodeBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         d_data->getUpper(tid).mBBox = CoordBBox();
-    }, mDeviceData);
-    cudaCheckError();
+    }
+};
 
-    // propagate bbox from lower -> upper/parent node
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], [=] __device__(size_t tid, Data *d_data) {
+template<typename BuildT>
+struct PropagateLowerBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
         const uint64_t lowerKey = d_data->d_lower_keys[tid];
         auto &upper = d_data->getUpper(lowerKey >> 15);
         auto &lower = d_data->getLower(tid);
         upper.mBBox.expandAtomic(lower.bbox());
-    }, mDeviceData);
-    mMemPool.free(mData.d_lower_keys);
+    }
+};
+
+template<typename BuildT>
+struct PropagateUpperBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
+        d_data->getRoot().mBBox.expandAtomic(d_data->getUpper(tid).bbox());
+    }
+};
+
+template<typename BuildT>
+struct UpdateRootWorldBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, PointsToGridData<BuildT> *d_data) {
+        auto BBox = d_data->getRoot().mBBox;
+        BBox.max() += 1;
+        d_data->getGrid().mFlags.setMaskOn(GridFlags::HasBBox);
+        d_data->getGrid().mWorldBBox = BBox.transform(d_data->map);
+    }
+};
+
+template<typename BuildT, typename ResourceT>
+inline void PointsToGrid<BuildT, ResourceT>::processBBox()
+{
+    // reset bbox in lower nodes
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], ResetLowerNodeBBoxFunctor<BuildT>(), mDeviceData);
+    cudaCheckError();
+
+    // update and propagate bbox from leaf -> lower/parent nodes
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[0]), mNumThreads, 0, mStream>>>(mData.nodeCount[0], UpdateAndPropagateLeafBBoxFunctor<BuildT>(), mDeviceData);
+    ResourceT::deallocateAsync(mData.d_leaf_keys, mData.nodeCount[0]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
+    cudaCheckError();
+
+    // reset bbox in upper nodes
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], ResetUpperNodeBBoxFunctor<BuildT>(), mDeviceData);
+    cudaCheckError();
+
+    // propagate bbox from lower -> upper/parent node
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[1]), mNumThreads, 0, mStream>>>(mData.nodeCount[1], PropagateLowerBBoxFunctor<BuildT>(), mDeviceData);
+    ResourceT::deallocateAsync(mData.d_lower_keys, mData.nodeCount[1]*sizeof(uint64_t), ResourceT::DEFAULT_ALIGNMENT, mStream);
     cudaCheckError()
 
     // propagate bbox from upper -> root/parent node
-    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], [=] __device__(size_t tid, Data *d_data) {
-        d_data->getRoot().mBBox.expandAtomic(d_data->getUpper(tid).bbox());
-    }, mDeviceData);
+    util::cuda::lambdaKernel<<<numBlocks(mData.nodeCount[2]), mNumThreads, 0, mStream>>>(mData.nodeCount[2], PropagateUpperBBoxFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
 
     // update the world-bbox in the root node
-    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, [=] __device__(size_t, Data *d_data) {
-        d_data->getGrid().mWorldBBox = d_data->getRoot().mBBox.transform(d_data->map);
-    }, mDeviceData);
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, UpdateRootWorldBBoxFunctor<BuildT>(), mDeviceData);
     cudaCheckError();
-}// PointsToGrid<BuildT>::processBBox
+}// PointsToGrid<BuildT, ResourceT>::processBBox
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT, typename AllocT>
+template<typename BuildT, typename PtrT, typename BufferT, typename ResourceT>
 GridHandle<BufferT>// Grid<BuildT>
 voxelsToGrid(const PtrT d_ijk, size_t voxelCount, double voxelSize, const BufferT &buffer, cudaStream_t stream)
 {
-    PointsToGrid<BuildT, AllocT> converter(voxelSize, Vec3d(0.0), stream);
+    PointsToGrid<BuildT, ResourceT> converter(voxelSize, Vec3d(0.0), stream);
     return converter.getHandle(d_ijk, voxelCount, buffer);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename PtrT, typename BufferT, typename AllocT>
+template<typename PtrT, typename BufferT, typename ResourceT>
 GridHandle<BufferT>// Grid<Point> with PointType coordinates as blind data
 pointsToGrid(const PtrT d_xyz, int pointCount, int maxPointsPerVoxel, int tolerance, int maxIterations, PointType type, const BufferT &buffer, cudaStream_t stream)
 {
-    PointsToGrid<Point, AllocT> converter(maxPointsPerVoxel, tolerance, maxIterations, Vec3d(0.0), stream);
+    PointsToGrid<Point, ResourceT> converter(maxPointsPerVoxel, tolerance, maxIterations, stream);
     converter.setPointType(type);
     return converter.getHandle(d_xyz, pointCount, buffer);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT, typename AllocT>
+template<typename BuildT, typename PtrT, typename BufferT, typename ResourceT>
 GridHandle<BufferT>
 pointsToGrid(std::vector<std::tuple<const PtrT,size_t,double,PointType>> vec, const BufferT &buffer, cudaStream_t stream)
 {
     std::vector<GridHandle<BufferT>> handles;
-    for (auto &p : vec) handles.push_back(pointsToGrid<BuildT, AllocT>(std::get<0>(p), std::get<1>(p), std::get<2>(p), std::get<3>(p), buffer, stream));
+    for (auto &p : vec) handles.push_back(pointsToGrid<BuildT, PtrT, BufferT, ResourceT>(std::get<0>(p), std::get<1>(p), std::get<2>(p), std::get<3>(p), buffer, stream));
     return mergeDeviceGrids(handles, stream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT, typename AllocT>
+template<typename BuildT, typename PtrT, typename BufferT, typename ResourceT>
 GridHandle<BufferT>
 voxelsToGrid(std::vector<std::tuple<const PtrT,size_t,double>> vec, const BufferT &buffer, cudaStream_t stream)
 {
     std::vector<GridHandle<BufferT>> handles;
-    for (auto &p : vec) handles.push_back(voxelsToGrid<BuildT, PtrT, BufferT, AllocT>(std::get<0>(p), std::get<1>(p), std::get<2>(p), buffer, stream));
+    for (auto &p : vec) handles.push_back(voxelsToGrid<BuildT, PtrT, BufferT, ResourceT>(std::get<0>(p), std::get<1>(p), std::get<2>(p), buffer, stream));
     return mergeDeviceGrids(handles, stream);
 }
 
@@ -1237,7 +1337,7 @@ voxelsToGrid(std::vector<std::tuple<const PtrT,size_t,double>> vec, const Buffer
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename PtrT, typename BufferT = cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename PtrT, typename BufferT = cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 [[deprecated("Use cuda::pointsToGrid instead")]]
 GridHandle<BufferT>
 cudaPointsToGrid(const PtrT dWorldPoints,
@@ -1247,24 +1347,24 @@ cudaPointsToGrid(const PtrT dWorldPoints,
                  const BufferT &buffer = BufferT(),
                  cudaStream_t stream = 0)
 {
-    return tools::cuda::pointsToGrid<PtrT, BufferT, AllocT>(dWorldPoints, pointCount, voxelSize, type, buffer, stream);
+    return tools::cuda::pointsToGrid<PtrT, BufferT, ResourceT>(dWorldPoints, pointCount, voxelSize, type, buffer, stream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 [[deprecated("Use cuda::pointsToGrid instead")]]
 GridHandle<BufferT>
 cudaPointsToGrid(std::vector<std::tuple<const PtrT,size_t,double,PointType>> pointSet,
                  const BufferT &buffer = BufferT(),
                  cudaStream_t stream = 0)
 {
-    return tools::cuda::pointsToGrid<BuildT, PtrT, BufferT,AllocT>(pointSet, buffer, stream);
+    return tools::cuda::pointsToGrid<BuildT, PtrT, BufferT, ResourceT>(pointSet, buffer, stream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 [[deprecated("Use cuda::voxelsToGrid instead")]]
 GridHandle<BufferT>
 cudaVoxelsToGrid(const PtrT dGridVoxels,
@@ -1273,21 +1373,21 @@ cudaVoxelsToGrid(const PtrT dGridVoxels,
                  const BufferT &buffer = BufferT(),
                  cudaStream_t stream = 0)
 {
-    return tools::cuda::voxelsToGrid<BuildT, PtrT, BufferT, AllocT>(dGridVoxels, voxelCount, voxelSize, buffer, stream);
+    return tools::cuda::voxelsToGrid<BuildT, PtrT, BufferT, ResourceT>(dGridVoxels, voxelCount, voxelSize, buffer, stream);
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename AllocT = cub::CachingDeviceAllocator>
+template<typename BuildT, typename PtrT, typename BufferT = cuda::DeviceBuffer, typename ResourceT = nanovdb::cuda::DeviceResource>
 [[deprecated("Use cuda::voxelsToGrid instead")]]
 GridHandle<BufferT>
 cudaVoxelsToGrid(std::vector<std::tuple<const PtrT, size_t, double>> pointSet,
                  const BufferT &buffer = BufferT(),
                  cudaStream_t stream = 0)
 {
-    return tools::cuda::voxelsToGrid<BuildT, PtrT, BufferT, AllocT>(pointSet, buffer, stream);
+    return tools::cuda::voxelsToGrid<BuildT, PtrT, BufferT, ResourceT>(pointSet, buffer, stream);
 }
 
 }// namespace nanovdb
 
-#endif // NVIDIA_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED
+#endif // NANOVDB_TOOLS_CUDA_POINTSTOGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/PruneGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/PruneGrid.cuh
@@ -1,0 +1,255 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/PruneGrid.cuh
+
+    \authors Efty Sifakis
+
+    \brief Morphological pruning of NanoVDB indexGrids using leaf-indexed mask
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_PRUNEGRID_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_PRUNEGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Morphology.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h>
+
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class PruneGrid
+{
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param d_srcGrid source device grid to be pruned
+    /// @param d_srcLeafMask sidecar array of leaf masks for voxels to retain
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    PruneGrid(const GridT* d_srcGrid, const Mask<3>* d_srcLeafMask, cudaStream_t stream = 0)
+        : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrid(d_srcGrid), mDeviceSrcLeafMask(d_srcLeafMask) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable){mBuilder.mChecksum = mode;}
+
+    /// @brief Creates a handle to the pruned grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+private:
+    void pruneRoot();
+
+    void pruneInternalNodes();
+
+    void processGridTreeRoot();
+
+    void pruneLeafNodes();
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT> mBuilder;
+    cudaStream_t            mStream{0};
+    util::cuda::Timer       mTimer;
+    int                     mVerbose{0};
+    const GridT             *mDeviceSrcGrid;
+    const Mask<3>           *mDeviceSrcLeafMask;
+    TreeData                mSrcTreeData;
+};// tools::cuda::PruneGrid<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+PruneGrid<BuildT>::getHandle(const BufferT &pool)
+{
+    // Copy TreeData from GPU -> CPU
+    cudaStreamSynchronize(mStream);
+    mSrcTreeData = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid);
+
+    // Ensure that the input grid contains no tile values
+    if (mSrcTreeData.mTileCount[2] || mSrcTreeData.mTileCount[1] || mSrcTreeData.mTileCount[0])
+        throw std::runtime_error("Topological operations not supported on grids with value tiles");
+
+
+    // Speculatively prune root node
+    if (mVerbose==1) mTimer.start("\nPrune root node");
+    pruneRoot();
+
+    // Allocate memory for pruned upper/lower masks
+    if (mVerbose==1) mTimer.restart("Allocating internal node mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+
+    // Prune masks of upper/lower nodes
+    if (mVerbose==1) mTimer.restart("Prune internal nodes");
+    pruneInternalNodes();
+
+    // Enumerate tree nodes
+    if (mVerbose==1) mTimer.restart("Count pruned tree nodes");
+    mBuilder.countNodes(mStream);
+
+    cudaStreamSynchronize(mStream);
+
+    // Allocate new device grid buffer for pruned result
+    if (mVerbose==1) mTimer.restart("Allocating pruned grid buffer");
+    auto buffer = mBuilder.getBuffer(pool, mStream);
+
+    // Process GridData/TreeData/RootData of pruned result
+    if (mVerbose==1) mTimer.restart("Processing grid/tree/root");
+    processGridTreeRoot();
+
+    // Process upper nodes of pruned result
+    if (mVerbose==1) mTimer.restart("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+
+    // Process lower nodes of pruned result
+    if (mVerbose==1) mTimer.restart("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+
+    // Prune active masks of leaf nodes and rebuild offsets
+    if (mVerbose==1) mTimer.restart("Pruning leaf nodes");
+    pruneLeafNodes();
+
+    // Process bounding boxes
+    if (mVerbose==1) mTimer.restart("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+
+    // Post-process Grid/Tree data
+    if (mVerbose==1) mTimer.restart("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// PruneGrid<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void PruneGrid<BuildT>::pruneRoot()
+{
+    // This method conservatively (and trivially) prunes the root tile table.
+    // For this simple approximation, it is assumed that all root tiles currently present will presist,
+    // and they will be pruned at a later stage if deemed empty.
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    std::map<uint64_t, typename RootT::DataType::Tile> prunedTiles;
+
+    // This encoding scheme mirrors the one used in PointsToGrid; note that it is different from Tile::key
+    auto coordToKey = [](const Coord &ijk)->uint64_t{
+        // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+        static constexpr int64_t kOffset = 1 << 31;
+        return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+    };// coordToKey lambda functor
+
+    if (mSrcTreeData.mVoxelCount) { // If the input grid is not empty
+        // Make a host copy of the source topology RootNode
+        auto deviceSrcRoot = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid, GridT::memUsage() + mSrcTreeData.mNodeOffset[3]));
+        uint64_t rootSize = mSrcTreeData.mNodeOffset[2] - mSrcTreeData.mNodeOffset[3];
+        auto srcRootBuffer = nanovdb::HostBuffer::create(rootSize);
+        cudaCheck(cudaMemcpyAsync(srcRootBuffer.data(), deviceSrcRoot, rootSize, cudaMemcpyDeviceToHost, mStream));
+        auto srcRoot = static_cast<RootT*>(srcRootBuffer.data());
+
+        // Add all root tiles, reordering if necessary
+        for (uint32_t t = 0; t < srcRoot->tileCount(); t++) {
+            auto tile = srcRoot->tile(t);
+            auto sortKey = coordToKey(tile->origin());
+            prunedTiles.emplace(sortKey, *tile);
+        }
+    }
+
+    // Package the duplicated root topology into a RootNode plus Tile list; upload to the GPU
+    uint64_t rootSize = RootT::memUsage(prunedTiles.size());
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto prunedRootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    prunedRootPtr->mTableSize = prunedTiles.size();
+    uint32_t t = 0;
+    for (const auto& [key, tile] : prunedTiles)
+        *prunedRootPtr->tile(t++) = tile;
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+}// PruneGrid<BuildT>::pruneRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void PruneGrid<BuildT>::pruneInternalNodes()
+{
+    // Computes the masks of upper and (densified) lower internal nodes, as a result of the pruning operation
+    // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
+    // as if every upper node had a full set of 32^3 lower children
+    if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::PruneInternalNodesFunctor<BuildT>(),
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mDeviceSrcLeafMask, mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+    }
+}// PruneGrid<BuildT>::pruneInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void PruneGrid<BuildT>::processGridTreeRoot()
+{
+    // Copy GridData from source grid
+    // By convention: this will duplicate grid name and map. Others will be reset later
+    cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
+    cudaCheckError();
+}// PruneGrid<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void PruneGrid<BuildT>::pruneLeafNodes()
+{
+    // Prunes the active masks of the source grid to the intersection with the leaf-mask sidecar
+    // followed by rebuilding the leaf offsets
+    auto srcLeafCount = mSrcTreeData.mNodeCount[0];
+    if (srcLeafCount) { // Unless grid is empty
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::PruneLeafMasksFunctor<BuildT>(), mDeviceSrcGrid, &mBuilder.data()->getGrid(), mDeviceSrcLeafMask);
+    }
+
+    // Update leaf offsets and prefix sums
+    mBuilder.processLeafOffsets(mStream);
+}// PruneGrid<BuildT>::pruneLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_PRUNEGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/RefineGrid.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/RefineGrid.cuh
@@ -1,0 +1,267 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/RefineGrid.cuh
+
+    \authors Efty Sifakis
+
+    \brief 2x Topological refinement of NanoVDB indexGrids on the device
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_REFINEGRID_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_REFINEGRID_CUH_HAS_BEEN_INCLUDED
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/GridHandle.h>
+#include <nanovdb/tools/cuda/TopologyBuilder.cuh>
+#include <nanovdb/util/cuda/DeviceGridTraits.cuh>
+#include <nanovdb/util/cuda/Morphology.cuh>
+#include <nanovdb/util/cuda/Timer.h>
+#include <nanovdb/util/cuda/Util.h>
+
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class RefineGrid
+{
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+
+public:
+
+    /// @brief Constructor
+    /// @param deviceGrid source device grid to be refined
+    /// @param stream optional CUDA stream (defaults to CUDA stream 0)
+    RefineGrid(const GridT* d_srcGrid, cudaStream_t stream = 0)
+        : mBuilder(stream), mStream(stream), mTimer(stream), mDeviceSrcGrid(d_srcGrid) {}
+
+    /// @brief Toggle on and off verbose mode
+    /// @param level Verbose level: 0=quiet, 1=timing, 2=benchmarking
+    void setVerbose(int level = 1) { mVerbose = level; }
+
+    /// @brief Set the mode for checksum computation, which is disabled by default
+    /// @param mode Mode of checksum computation
+    void setChecksum(CheckMode mode = CheckMode::Disable){mBuilder.mChecksum = mode;}
+
+    /// @brief Creates a handle to the refined grid
+    /// @tparam BufferT Buffer type used for allocation of the grid handle
+    /// @param buffer optional buffer (currently ignored)
+    /// @return returns a handle with a grid of type NanoGrid<BuildT>
+    template<typename BufferT = nanovdb::cuda::DeviceBuffer>
+    GridHandle<BufferT>
+    getHandle(const BufferT &buffer = BufferT());
+
+private:
+    void refineRoot();
+
+    void refineInternalNodes();
+
+    void processGridTreeRoot();
+
+    void refineLeafNodes();
+
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    TopologyBuilder<BuildT> mBuilder;
+    cudaStream_t            mStream{0};
+    util::cuda::Timer       mTimer;
+    int                     mVerbose{0};
+    const GridT             *mDeviceSrcGrid;
+    TreeData                mSrcTreeData;
+};// tools::cuda::RefineGrid<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+template<typename BufferT>
+GridHandle<BufferT>
+RefineGrid<BuildT>::getHandle(const BufferT &pool)
+{
+    // Copy TreeData from GPU -> CPU
+    cudaStreamSynchronize(mStream);
+    mSrcTreeData = util::cuda::DeviceGridTraits<BuildT>::getTreeData(mDeviceSrcGrid);
+
+    // Ensure that the input grid contains no tile values
+    if (mSrcTreeData.mTileCount[2] || mSrcTreeData.mTileCount[1] || mSrcTreeData.mTileCount[0])
+        throw std::runtime_error("Topological operations not supported on grids with value tiles");
+
+    // Speculatively refine root node
+    if (mVerbose==1) mTimer.start("\nRefining root node");
+    refineRoot();
+
+    // Allocate memory for refined upper/lower masks
+    if (mVerbose==1) mTimer.restart("Allocating internal node mask buffers");
+    mBuilder.allocateInternalMaskBuffers(mStream);
+
+    // Refine masks of upper/lower nodes
+    if (mVerbose==1) mTimer.restart("Refining internal nodes");
+    refineInternalNodes();
+
+    // Enumerate tree nodes
+    if (mVerbose==1) mTimer.restart("Count refined tree nodes");
+    mBuilder.countNodes(mStream);
+
+    cudaStreamSynchronize(mStream);
+
+    // Allocate new device grid buffer for refined result
+    if (mVerbose==1) mTimer.restart("Allocating refined grid buffer");
+    auto buffer = mBuilder.getBuffer(pool, mStream);
+
+    // Process GridData/TreeData/RootData of refined result
+    if (mVerbose==1) mTimer.restart("Processing grid/tree/root");
+    processGridTreeRoot();
+
+    // Process upper nodes of refined result
+    if (mVerbose==1) mTimer.restart("Processing upper nodes");
+    mBuilder.processUpperNodes(mStream);
+
+    // Process lower nodes of refined result
+    if (mVerbose==1) mTimer.restart("Processing lower nodes");
+    mBuilder.processLowerNodes(mStream);
+
+    // Refine leaf node active masks into new topology
+    if (mVerbose==1) mTimer.restart("Refining leaf nodes");
+    refineLeafNodes();
+
+    // Process bounding boxes
+    if (mVerbose==1) mTimer.restart("Processing bounding boxes");
+    mBuilder.processBBox(mStream);
+
+    // Post-process Grid/Tree data
+    if (mVerbose==1) mTimer.restart("Post-processing grid/tree data");
+    mBuilder.postProcessGridTree(mStream);
+    if (mVerbose==1) mTimer.stop();
+
+    cudaStreamSynchronize(mStream);
+
+    return GridHandle<BufferT>(std::move(buffer));
+}// RefineGrid<BuildT>::getHandle
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void RefineGrid<BuildT>::refineRoot()
+{
+    // This method conservatively and speculatively refines the root tiles, to accommodate
+    // any new root nodes that might be introduced by the upsampling operation.
+    // The index-space bounding box of each tile is examined, and if it overlaps any of the 2048^3-sized octants
+    // of the tile, a corresponding new tile is preemptively introduced into the root topology.
+    // Root tiles that were preemptively introduced, but end up having no active contents will
+    // be pruned in later stages of processing.
+
+    int device = 0;
+    cudaGetDevice(&device);
+
+    std::map<uint64_t, typename RootT::DataType::Tile> refinedTiles;
+
+    // This encoding scheme mirrors the one used in PointsToGrid; note that it is different from Tile::key
+    auto coordToKey = [](const Coord &ijk)->uint64_t{
+        // Note: int32_t has a range of -2^31 to 2^31 - 1 whereas uint32_t has a range of 0 to 2^32 - 1
+        static constexpr int64_t kOffset = 1 << 31;
+        return (uint64_t(uint32_t(int64_t(ijk[2]) + kOffset) >> 12)      ) | // z is the lower 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[1]) + kOffset) >> 12) << 21) | // y is the middle 21 bits
+            (uint64_t(uint32_t(int64_t(ijk[0]) + kOffset) >> 12) << 42); //  x is the upper 21 bits
+    };// coordToKey lambda functor
+
+    if (mSrcTreeData.mVoxelCount) { // If the input grid is not empty
+        // Make a host copy of the source topology RootNode *and* the Upper Nodes (needed for BBox'es)
+        // TODO: Consider avoiding to copy the entire set of upper nodes
+        auto deviceSrcRoot = static_cast<const RootT*>(util::PtrAdd(mDeviceSrcGrid, GridT::memUsage() + mSrcTreeData.mNodeOffset[3]));
+        uint64_t rootAndUpperSize = mSrcTreeData.mNodeOffset[1] - mSrcTreeData.mNodeOffset[3];
+        auto srcRootAndUpperBuffer = nanovdb::HostBuffer::create(rootAndUpperSize);
+        cudaCheck(cudaMemcpyAsync(srcRootAndUpperBuffer.data(), deviceSrcRoot, rootAndUpperSize, cudaMemcpyDeviceToHost, mStream));
+        auto srcRootAndUpper = static_cast<RootT*>(srcRootAndUpperBuffer.data());
+
+        // For each original root tile, consider adding those tiles in its 26-connected neighborhood
+        for (uint32_t t = 0; t < srcRootAndUpper->tileCount(); t++) {
+            auto srcUpper = srcRootAndUpper->getChild(srcRootAndUpper->tile(t));
+            const auto tileBBox = srcUpper->bbox();
+            for (int di = 0; di <= 2048; di += 2048)
+            for (int dj = 0; dj <= 2048; dj += 2048)
+            for (int dk = 0; dk <= 2048; dk += 2048) {
+                const auto octantBBox = nanovdb::CoordBBox::createCube(srcUpper->origin().offsetBy(di,dj,dk), 2048);
+                if (tileBBox.hasOverlap(octantBBox)) {
+                    auto refinedOrigin = octantBBox.min()+octantBBox.min();
+                    auto sortKey = coordToKey(refinedOrigin); // key used in the radix sort, in accordance with PointsToGrid
+                    auto tileKey = RootT::CoordToKey(refinedOrigin); // encoding used in the NanoVDB tile
+                    typename RootT::Tile refinedTile{tileKey}; // Only the key value is needed; child pointer & value will be unused
+                    refinedTiles.emplace(sortKey, refinedTile);
+               }
+            }
+        }
+    }
+
+    // Package the new root topology into a RootNode plus Tile list; upload to the GPU
+    uint64_t rootSize = RootT::memUsage(refinedTiles.size());
+    mBuilder.mProcessedRoot = nanovdb::cuda::DeviceBuffer::create(rootSize);
+    auto refinedRootPtr = static_cast<RootT*>(mBuilder.mProcessedRoot.data());
+    refinedRootPtr->mTableSize = refinedTiles.size();
+    uint32_t t = 0;
+    for (const auto& [key, tile] : refinedTiles)
+        *refinedRootPtr->tile(t++) = tile;
+    mBuilder.mProcessedRoot.deviceUpload(device, mStream, false);
+}// RefineGrid<BuildT>::refineRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void RefineGrid<BuildT>::refineInternalNodes()
+{
+    // Computes the masks of upper and (densified) lower internal nodes, as a result of the refinement operation
+    // Masks of lower internal nodes are densified in the sense that a serialized array of them is allocated,
+    // as if every upper node had a full set of 32^3 lower children
+    if (auto srcLeafCount = mSrcTreeData.mNodeCount[0]) { // Unless it's an empty grid
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::RefineInternalNodesFunctor<BuildT>(),
+            mDeviceSrcGrid, mBuilder.deviceProcessedRoot(), mBuilder.mUpperMasks.deviceData(), mBuilder.mLowerMasks.deviceData() );
+    }
+}// RefineGrid<BuildT>::refineInternalNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+void RefineGrid<BuildT>::processGridTreeRoot()
+{
+    // Copy GridData from source grid
+    // By convention: this will duplicate grid name and map. Others will be reset later
+    cudaCheck(cudaMemcpyAsync(&mBuilder.data()->getGrid(), mDeviceSrcGrid->data(), GridT::memUsage(), cudaMemcpyDeviceToDevice, mStream));
+    util::cuda::lambdaKernel<<<1, 1, 0, mStream>>>(1, topology::detail::BuildGridTreeRootFunctor<BuildT>(), mBuilder.deviceData());
+    cudaCheckError();
+}// RefineGrid<BuildT>::processGridTreeRoot
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void RefineGrid<BuildT>::refineLeafNodes()
+{
+    // Refines the active masks of the source grid (as indicated at the leaf level), into a new grid that
+    // has been already topologically refined to include all necessary leaf nodes.
+    auto srcLeafCount = mSrcTreeData.mNodeCount[0];
+    if (srcLeafCount) { // Unless grid is empty
+        util::cuda::lambdaKernel<<<numBlocks(srcLeafCount), mNumThreads, 0, mStream>>>(
+            srcLeafCount, util::morphology::cuda::RefineLeafMasksFunctor<BuildT>(), mDeviceSrcGrid, &mBuilder.data()->getGrid());
+    }
+
+    // Update leaf offsets and prefix sums
+    mBuilder.processLeafOffsets(mStream);
+}// RefineGrid<BuildT>::refineLeafNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_REFINEGRID_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/SignedFloodFill.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/SignedFloodFill.cuh
@@ -10,7 +10,7 @@
 
     \brief Performs signed flood-fill operation on the hierarchical tree structure on the device
 
-    \todo This tools needs to handle the (extremely) rare case when root node
+    \todo This tools needs to handle the (extremely) rare case when the root node
           needs to be modified during the signed flood fill operation. This happens
           when the root-table needs to be expanded with tile values (of size 4096^3)
           that are completely inside the implicit surface.
@@ -24,9 +24,11 @@
 
 #include <nanovdb/NanoVDB.h>
 #include <nanovdb/GridHandle.h>
+#include <nanovdb/cuda/UnifiedBuffer.h>
 #include <nanovdb/util/cuda/Timer.h>
 #include <nanovdb/util/cuda/Util.h>
 #include <nanovdb/tools/cuda/GridChecksum.cuh>
+#include <nanovdb/io/IO.h>// debugging needs io of Coord
 
 namespace nanovdb {
 
@@ -40,8 +42,6 @@ namespace tools::cuda {
 template<typename BuildT>
 typename util::enable_if<BuildTraits<BuildT>::is_float, void>::type
 signedFloodFill(NanoGrid<BuildT> *d_grid, bool verbose = false, cudaStream_t stream = 0);
-
-namespace {// anonymous namespace
 
 template<typename BuildT>
 class SignedFloodFill
@@ -65,47 +65,77 @@ private:
 
 //================================================================================================
 
+namespace kernels {// kernels namespace
+
+template <typename ValueT>
+struct RootChild {
+    Coord    ijk;// origin of the child node
+    uint32_t idx;// linear offset for the child node
+    ValueT   val[2];// first and last values as defined by child->getFirstValue/getLastValue
+    RootChild(Coord i=Coord(), uint32_t j=0) : ijk(i), idx(j) {};// c-tor
+    bool operator()(const RootChild &a, const RootChild &b) const { return a.ijk < b.ijk; }// for sorting
+};
+
+// CPU kernel!
 template<typename BuildT>
-__global__ void processRootKernel(NanoTree<BuildT> *tree)
-{
-    // auto &root = tree->root();
-    /*
-    using ChildT = typename RootT::ChildNodeType;
-    // Insert the child nodes into a map sorted according to their origin
-    std::map<Coord, ChildT*> nodeKeys;
-    typename RootT::ChildOnIter it = root.beginChildOn();
-    for (; it; ++it) nodeKeys.insert(std::pair<Coord, ChildT*>(it.getCoord(), &(*it)));
-    static const Index DIM = RootT::ChildNodeType::DIM;
+void processRoot(NanoTree<BuildT> *d_tree)
+{// the root needs special care since unlike other nodes it's sparse and not dense!
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using TileT  = typename RootT::Tile;
+    using ValueT = typename RootT::ValueType;
+    using ChildT = RootChild<ValueT>;
+    static const int dim = int(RootT::ChildNodeType::DIM);
+
+    // First copy the tree and root and then its tiles, which is of unknown size
+    nanovdb::cuda::UnifiedBuffer uBuffer(sizeof(TreeT) + sizeof(RootT), sizeof(TreeT) + sizeof(RootT) + 64*sizeof(TileT));
+    cudaCheck(cudaMemcpy(uBuffer.data(), d_tree, uBuffer.size(), cudaMemcpyDeviceToHost));// copy Tree and Root (minus tiles)
+    if (!uBuffer.data<TreeT>()->isRootNext()) throw std::runtime_error("ERROR: expected no padding between tree and root!");
+    if ( uBuffer.data<TreeT>()->root().tileCount() == 0) return;// empty root node so nothing to do
+    uBuffer.resize(sizeof(TreeT) + uBuffer.data<TreeT>()->root().memUsage());// likely does nothing since we reserved 64 tiles
+    RootT *root = &uBuffer.data<TreeT>()->root();
+    cudaCheck(cudaMemcpy(root + 1, (char*)(d_tree + 1) + sizeof(RootT), root->tileCount()*sizeof(TileT), cudaMemcpyDeviceToHost));// copy tiles
+
+    // Sort the child nodes of the root in lexicographic order
+    nanovdb::cuda::UnifiedBuffer nodeBuffer(root->tileCount()*sizeof(ChildT));// potential over-allocation
+    auto *first = nodeBuffer.data<ChildT>(), *last = first;
+    for (auto it=root->beginChild(); it; ++it) *last++ = ChildT(it.getCoord(), it.pos());
+    if (last - first < 2) return;// zero or one child node so nothing to do!
+    std::sort(first, last, ChildT());// lexicographic ordering
 
     // We employ a simple z-scanline algorithm that inserts inactive tiles with
     // the inside value if they are sandwiched between inside child nodes only!
-    typename std::map<Coord, ChildT*>::const_iterator b = nodeKeys.begin(), e = nodeKeys.end();
-    if ( b == e ) return;
-    for (typename std::map<Coord, ChildT*>::const_iterator a = b++; b != e; ++a, ++b) {
-        Coord d = b->first - a->first; // delta of neighboring coordinates
-        if (d[0]!=0 || d[1]!=0 || d[2]==Int32(DIM)) continue;// not same z-scanline or neighbors
-        const ValueT fill[] = { a->second->getLastValue(), b->second->getFirstValue() };
-        if (!(fill[0] < 0) || !(fill[1] < 0)) continue; // scanline isn't inside
-        Coord c = a->first + Coord(0u, 0u, DIM);
-        for (; c[2] != b->first[2]; c[2] += DIM) root.addTile(c, mInside, false);
+    for (ChildT *a = first, *b = a+1; b!=last; ++a, ++b) {// loop over pairs of adjacent child nodes
+        const Coord d = b->ijk - a->ijk;// coord delta of adjacent child nodes
+        if (d[0]!=0 || d[1]!=0 || d[2]==dim) continue;// not same z-scanline or they are neighbors
+        util::cuda::lambdaKernel<<<1, 1>>>(1, [=] __device__(size_t) {
+            a->val[1] = root->getChild(root->tile(a->idx))->getLastValue();
+            b->val[0] = root->getChild(root->tile(b->idx))->getFirstValue();
+        });
+        cudaCheck(cudaDeviceSynchronize());// required for host access to RootChild::val[2]
+        if (a->val[1] > 0 || b->val[0] > 0) continue; // scanline is not inside a surface
+        for (Coord c = a->ijk.offsetBy(0,0,dim); c[2] != b->ijk[2]; c[2] += dim) {
+            TileT *tile = root->probeTile(c);
+            if (!tile) throw std::runtime_error("ERROR: missing internal tile! Please add them and try again!");
+            tile->setValue(c, false, -root->background());
+        }
     }
-    */
-    //root.setBackground(mOutside, /*updateChildNodes=*/false);
-}// processRootKernel
+    cudaCheck(cudaMemcpy(d_tree + 1, root, root->memUsage(), cudaMemcpyHostToDevice));// copy tiles back to device
+}// processRoot
 
 //================================================================================================
 
 template<typename BuildT, int LEVEL>
-__global__ void processNodeKernel(NanoTree<BuildT> *tree, size_t count)
+__global__ void processNode(NanoTree<BuildT> *d_tree, size_t count)
 {
     using NodeT = typename NanoNode<BuildT, LEVEL>::type;
     const int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= count) return;
     const uint32_t nValue = tid & (NodeT::SIZE - 1u);
-    auto &node = *(tree->template getFirstNode<LEVEL>() + (tid >> (3*NodeT::LOG2DIM)));
+    auto &node = *(d_tree->template getFirstNode<LEVEL>() + (tid >> (3*NodeT::LOG2DIM)));
     const auto &mask = node.childMask();
     if (mask.isOn(nValue)) return;// ignore if child
-    auto value = tree->background();// initiate to outside value
+    auto value = d_tree->background();// initiate to outside value
     auto n = mask.template findNext<true>(nValue);
     if (n < NodeT::SIZE) {
         if (node.getChild(n)->getFirstValue() < 0) value = -value;
@@ -115,25 +145,25 @@ __global__ void processNodeKernel(NanoTree<BuildT> *tree, size_t count)
         value = -value;
     }
     node.setValue(nValue, value);
-}// processNodeKernel
+}// processNode
 
 //================================================================================================
 
 template<typename BuildT>
-__global__ void processLeafKernel(NanoTree<BuildT> *tree, size_t count)
+__global__ void processLeaf(NanoTree<BuildT> *d_tree, size_t count)
 {
     using LeafT = NanoLeaf<BuildT>;
     const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= count) return;
     const uint32_t nVoxel = tid & (LeafT::SIZE - 1u);
-    auto *leaf = tree->getFirstLeaf() + (tid >> (3*LeafT::LOG2DIM));
+    auto *leaf = d_tree->getFirstLeaf() + (tid >> (3*LeafT::LOG2DIM));
     const auto &mask = leaf->valueMask();
     if (mask.isOn(nVoxel)) return;
     auto *buffer = leaf->mValues;
     auto n = mask.template findNext<true>(nVoxel);
     if (n == LeafT::SIZE && (n = mask.template findPrev<true>(nVoxel)) == LeafT::SIZE) n = 0u;
-    buffer[nVoxel] = buffer[n]<0 ? -tree->background() : tree->background();
-}// processLeafKernel
+    buffer[nVoxel] = buffer[n]<0 ? -d_tree->background() : d_tree->background();
+}// processLeaf
 
 //================================================================================================
 
@@ -145,7 +175,7 @@ __global__ void cpyNodeCountKernel(NanoGrid<BuildT> *d_grid, uint64_t *d_count)
     *d_count = d_grid->tree().root().tileCount();
 }
 
-}// anonymous namespace
+}// kernels namespace
 
 //================================================================================================
 
@@ -156,29 +186,29 @@ void SignedFloodFill<BuildT>::operator()(NanoGrid<BuildT> *d_grid)
     NANOVDB_ASSERT(d_grid);
     uint64_t count[4], *d_count = nullptr;
     cudaCheck(util::cuda::mallocAsync((void**)&d_count, 4*sizeof(uint64_t), mStream));
-    cpyNodeCountKernel<BuildT><<<1, 1, 0, mStream>>>(d_grid, d_count);
+    kernels::cpyNodeCountKernel<BuildT><<<1, 1, 0, mStream>>>(d_grid, d_count);
     cudaCheckError();
     cudaCheck(cudaMemcpyAsync(&count, d_count, 4*sizeof(uint64_t), cudaMemcpyDeviceToHost, mStream));
     cudaCheck(util::cuda::freeAsync(d_count, mStream));
 
     static const int threadsPerBlock = 128;
     auto blocksPerGrid = [&](size_t count)->uint32_t{return (count + (threadsPerBlock - 1)) / threadsPerBlock;};
-    auto *tree = reinterpret_cast<NanoTree<BuildT>*>(d_grid + 1);
+    auto *d_tree = reinterpret_cast<NanoTree<BuildT>*>(d_grid + 1);
 
     if (mVerbose) mTimer.start("\nProcess leaf nodes");
-    processLeafKernel<BuildT><<<blocksPerGrid(count[0]<<9), threadsPerBlock, 0, mStream>>>(tree, count[0]<<9);
+    kernels::processLeaf<BuildT><<<blocksPerGrid(count[0]<<9), threadsPerBlock, 0, mStream>>>(d_tree, count[0]<<9);
     cudaCheckError();
 
     if (mVerbose) mTimer.restart("Process lower internal nodes");
-    processNodeKernel<BuildT,1><<<blocksPerGrid(count[1]<<12), threadsPerBlock, 0, mStream>>>(tree, count[1]<<12);
+    kernels::processNode<BuildT,1><<<blocksPerGrid(count[1]<<12), threadsPerBlock, 0, mStream>>>(d_tree, count[1]<<12);
     cudaCheckError();
 
     if (mVerbose) mTimer.restart("Process upper internal nodes");
-    processNodeKernel<BuildT,2><<<blocksPerGrid(count[2]<<15), threadsPerBlock, 0, mStream>>>(tree, count[2]<<15);
+    kernels::processNode<BuildT,2><<<blocksPerGrid(count[2]<<15), threadsPerBlock, 0, mStream>>>(d_tree, count[2]<<15);
     cudaCheckError();
 
-    //if (mVerbose) mTimer.restart("Process root node");
-    //processRootKernel<BuildT><<<1, 1, 0, mStream>>>(tree);
+    if (mVerbose) mTimer.restart("Process root node");
+    kernels::processRoot<BuildT>(d_tree);
     if (mVerbose) mTimer.stop();
     cudaCheckError();
 }// SignedFloodFill::operator()
@@ -196,6 +226,7 @@ signedFloodFill(NanoGrid<BuildT> *d_grid, bool verbose, cudaStream_t stream)
     if (cs.isFull()) {// CheckMode::Partial checksum is unaffected
         updateChecksum(d_gridData, CheckMode::Full, stream);
     }
+    cudaCheck(cudaStreamSynchronize(stream));
 }
 
 }// namespace tools::cuda

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/TopologyBuilder.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/TopologyBuilder.cuh
@@ -1,0 +1,563 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/cuda/TopologyBuilder.cuh
+
+    \authors Efty Sifakis
+
+    \brief Shared functionality of (mostly morphology) operators that alter the voxel content of grids
+
+    \warning The header file contains cuda device code so be sure
+             to only include it in .cu files (or other .cuh files)
+*/
+
+#ifndef NVIDIA_TOOLS_CUDA_TOPOLOGYBUILDER_CUH_HAS_BEEN_INCLUDED
+#define NVIDIA_TOOLS_CUDA_TOPOLOGYBUILDER_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/cuda/TempPool.h>
+#include <nanovdb/cuda/DeviceBuffer.h>
+#include <nanovdb/util/cuda/Morphology.cuh>
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+template <typename BuildT>
+class TopologyBuilder
+{
+    static_assert(nanovdb::BuildTraits<BuildT>::is_onindex);// For now, only OnIndexGrids supported
+
+    using GridT  = NanoGrid<BuildT>;
+    using TreeT  = NanoTree<BuildT>;
+    using RootT  = NanoRoot<BuildT>;
+    using UpperT = NanoUpper<BuildT>;
+    using LowerT = NanoLower<BuildT>;
+    using LeafT  = NanoLeaf<BuildT>;
+
+public:
+
+    TopologyBuilder(cudaStream_t stream)
+    {
+        mData = nanovdb::cuda::DeviceBuffer::create(sizeof(Data));
+    }
+
+    struct Data {
+        void     *d_bufferPtr;
+        uint64_t grid, tree, root, upper, lower, leaf, size;// byte offsets to nodes in buffer
+        uint32_t nodeCount[3];// 0=leaf,1=lower, 2=upper
+        uint32_t *d_upperOffsets;
+        __hostdev__ GridT&  getGrid() const {return *util::PtrAdd<GridT>(d_bufferPtr, grid);}
+        __hostdev__ TreeT&  getTree() const {return *util::PtrAdd<TreeT>(d_bufferPtr, tree);}
+        __hostdev__ RootT&  getRoot() const {return *util::PtrAdd<RootT>(d_bufferPtr, root);}
+        __hostdev__ UpperT& getUpper(int i) const {return *(util::PtrAdd<UpperT>(d_bufferPtr, upper)+i);}
+        __hostdev__ LowerT& getLower(int i) const {return *(util::PtrAdd<LowerT>(d_bufferPtr, lower)+i);}
+        __hostdev__ LeafT&  getLeaf(int i) const {return *(util::PtrAdd<LeafT>(d_bufferPtr, leaf)+i);}
+    };// Data
+
+    void allocateInternalMaskBuffers(cudaStream_t stream);
+
+    void countNodes(cudaStream_t stream);
+
+    template<typename BufferT>
+    BufferT getBuffer(const BufferT &buffer, cudaStream_t stream);
+
+    void processUpperNodes(cudaStream_t stream);
+
+    void processLowerNodes(cudaStream_t stream);
+
+    void processLeafOffsets(cudaStream_t stream);
+
+    void processBBox(cudaStream_t stream);
+
+    void postProcessGridTree(cudaStream_t stream);
+
+    nanovdb::cuda::DeviceBuffer  mProcessedRoot;
+    nanovdb::cuda::DeviceBuffer  mUpperMasks;
+    nanovdb::cuda::DeviceBuffer  mLowerMasks;
+    nanovdb::cuda::DeviceBuffer  mUpperOffsets;
+    nanovdb::cuda::DeviceBuffer  mLowerOffsets;
+    nanovdb::cuda::DeviceBuffer  mLeafOffsets;
+    nanovdb::cuda::DeviceBuffer  mVoxelOffsets;
+    nanovdb::cuda::DeviceBuffer  mLowerParents;
+    nanovdb::cuda::DeviceBuffer  mLeafParents;
+    nanovdb::cuda::DeviceBuffer  mData;
+    CheckMode                    mChecksum{CheckMode::Disable};
+
+    auto deviceProcessedRoot() { return static_cast<RootT*>(mProcessedRoot.deviceData()); }
+    auto hostProcessedRoot()   { return static_cast<RootT*>(mProcessedRoot.data()); }
+    void* deviceUpperMasks() { return mUpperMasks.deviceData(); }
+    void* deviceLowerMasks() { return mLowerMasks.deviceData(); }
+    Data* data()             { return static_cast<Data*>(mData.data()); }
+    Data* deviceData()       { return static_cast<Data*>(mData.deviceData()); }
+
+private:
+    static constexpr unsigned int mNumThreads = 128;// for kernels spawned via lambdaKernel (others may specialize)
+    static unsigned int numBlocks(unsigned int n) {return (n + mNumThreads - 1) / mNumThreads;}
+
+    nanovdb::cuda::TempDevicePool mTempDevicePool;
+};// tools::cuda::TopologyBuilder<BuildT>
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Define utility macro used to call cub functions that use dynamic temporary storage
+#ifndef CALL_CUBS
+#ifdef _WIN32
+#define CALL_CUBS(func, ...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), __VA_ARGS__, stream)); \
+    mTempDevicePool.reallocate(stream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), __VA_ARGS__, stream));
+#else// ndef _WIN32
+#define CALL_CUBS(func, args...) \
+    cudaCheck(cub::func(nullptr, mTempDevicePool.requestedSize(), args, stream)); \
+    mTempDevicePool.reallocate(stream); \
+    cudaCheck(cub::func(mTempDevicePool.data(), mTempDevicePool.size(), args, stream));
+#endif// ifdef _WIN32
+#endif// ifndef CALL_CUBS
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void TopologyBuilder<BuildT>::allocateInternalMaskBuffers(cudaStream_t stream)
+{
+    if (hostProcessedRoot()->tileCount() == 0) return; // Processing empty grid(s); nothing to allocate
+
+    // Allocate (and zero-fill) buffers large enough to hold:
+    // (a) The serialized masks of all upper nodes, for all tiles in the updated root node, and
+    // (b) The serialized masks of all densified lower nodes, as if every upper node had a full set of 32^3 lower children
+    int device = 0;
+    cudaGetDevice(&device);
+    uint64_t upperSize = hostProcessedRoot()->tileCount() * sizeof(Mask<5>);
+    uint64_t lowerSize = hostProcessedRoot()->tileCount() * Mask<5>::SIZE * sizeof(Mask<4>);
+    mUpperMasks = nanovdb::cuda::DeviceBuffer::create(upperSize, nullptr, device, stream);
+    if (mUpperMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate upper mask buffer on device");
+    cudaCheck(cudaMemsetAsync(mUpperMasks.deviceData(), 0, upperSize, stream));
+    mLowerMasks = nanovdb::cuda::DeviceBuffer::create( lowerSize, nullptr, device, stream );
+    if (mLowerMasks.deviceData() == nullptr) throw std::runtime_error("Failed to allocate lower mask buffer on device");
+    cudaCheck(cudaMemsetAsync(mLowerMasks.deviceData(), 0, lowerSize, stream));
+}// TopologyBuilder<BuildT>::allocateInternalMaskBuffers
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template<typename BuildT>
+void TopologyBuilder<BuildT>::countNodes(cudaStream_t stream)
+{
+    auto processedTileCount = hostProcessedRoot()->tileCount();
+    if (processedTileCount == 0) { // Processing empty grid(s); zero nodes at all levels
+        data()->nodeCount[0] = data()->nodeCount[1] = data()->nodeCount[2] = 0;
+        return;
+    }
+
+    // Computes prefix sums of (a) non-empty lower nodes, (b) counts of their leaf children,
+    // and (c) count of the speculatively updated root tiles that have actually been used.
+    // These are used to reconstruct child offsets for the internal nodes of the updated tree,
+    // as well as the tile table at the root.
+    std::size_t size = processedTileCount*Mask<5>::SIZE;
+
+    int device = 0;
+    cudaGetDevice(&device);
+    nanovdb::cuda::DeviceBuffer upperCountsBuffer = nanovdb::cuda::DeviceBuffer::create(processedTileCount*sizeof(uint32_t), nullptr, device, stream);
+    nanovdb::cuda::DeviceBuffer lowerCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
+    nanovdb::cuda::DeviceBuffer leafCountsBuffer = nanovdb::cuda::DeviceBuffer::create(size*sizeof(uint32_t), nullptr, device, stream);
+
+    using CountType = uint32_t (*)[Mask<5>::SIZE];
+    auto lowerCounts = reinterpret_cast<CountType>( lowerCountsBuffer.deviceData() );
+    auto leafCounts = reinterpret_cast<CountType>( leafCountsBuffer.deviceData() );
+
+    using Op = util::morphology::cuda::EnumerateNodesFunctor;
+    util::cuda::operatorKernel<Op>
+        <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>
+        (deviceUpperMasks(), deviceLowerMasks(), lowerCounts, leafCounts);
+
+    mUpperOffsets = nanovdb::cuda::DeviceBuffer::create((processedTileCount+1)*sizeof(uint32_t), nullptr, device, stream);
+    mLowerOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
+    mLeafOffsets = nanovdb::cuda::DeviceBuffer::create((size+1)*sizeof(uint32_t), nullptr, device, stream);
+
+    cudaCheck(cudaMemsetAsync(mLowerOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    CALL_CUBS(DeviceScan::InclusiveSum,
+        static_cast<uint32_t*>(lowerCountsBuffer.deviceData()),
+        static_cast<uint32_t*>(mLowerOffsets.deviceData())+1,
+        size);
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[1], static_cast<uint32_t*>(mLowerOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+
+    cudaCheck(cudaMemsetAsync(mLeafOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    CALL_CUBS(DeviceScan::InclusiveSum,
+        static_cast<uint32_t*>(leafCountsBuffer.deviceData()),
+        static_cast<uint32_t*>(mLeafOffsets.deviceData())+1,
+        size);
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[0], static_cast<uint32_t*>(mLeafOffsets.deviceData())+size, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+
+    util::cuda::lambdaKernel<<<numBlocks(processedTileCount), mNumThreads, 0, stream>>>(
+        processedTileCount,
+        [] __device__(size_t tileID, CountType lowerOffsets, uint32_t* upperCounts)
+            { upperCounts[tileID] = (lowerOffsets[tileID+1][0] > lowerOffsets[tileID][0]) ? 1 : 0; },
+        static_cast<CountType>(mLowerOffsets.deviceData()),
+        static_cast<uint32_t*>(upperCountsBuffer.deviceData()));
+
+    cudaCheck(cudaMemsetAsync( mUpperOffsets.deviceData(), 0, sizeof(uint32_t), stream));
+    CALL_CUBS(DeviceScan::InclusiveSum,
+        static_cast<uint32_t*>(upperCountsBuffer.deviceData()),
+        static_cast<uint32_t*>(mUpperOffsets.deviceData())+1,
+        processedTileCount);
+    cudaCheck(cudaMemcpyAsync(&data()->nodeCount[2], static_cast<uint32_t*>(mUpperOffsets.deviceData())+processedTileCount, sizeof(uint32_t), cudaMemcpyDeviceToHost, stream));
+}// TopologyBuilder<BuildT>::countNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+template <typename BufferT>
+BufferT TopologyBuilder<BuildT>::getBuffer(const BufferT &pool, cudaStream_t stream)
+{
+    // Allocates a device buffer for the destination grid, once the topology/size of the tree is known
+    data()->grid  = 0;// grid is always stored at the start of the buffer!
+    data()->tree  = GridT::memUsage();// grid ends and tree begins
+    data()->root  = data()->tree  + TreeT::memUsage(); // tree ends and root node begins
+    data()->upper = data()->root  + RootT::memUsage(data()->nodeCount[2]);// root node ends and upper internal nodes begin
+    data()->lower = data()->upper + UpperT::memUsage()*data()->nodeCount[2];// upper internal nodes ends and lower internal nodes begin
+    data()->leaf  = data()->lower + LowerT::memUsage()*data()->nodeCount[1];// lower internal nodes ends and leaf nodes begin
+    data()->size  = data()->leaf  + LeafT::DataType::memUsage()*data()->nodeCount[0];// leaf nodes end and blind meta data begins
+
+    int device = 0;
+    cudaGetDevice(&device);
+    auto buffer = BufferT::create(data()->size, &pool, device, stream);// only allocate buffer on the device
+    cudaCheck(cudaMemsetAsync(buffer.deviceData(), 0, data()->size, stream));
+
+    data()->d_bufferPtr = buffer.deviceData();
+    if (data()->d_bufferPtr == nullptr) throw std::runtime_error("Failed to allocate grid buffer on the device");
+    if (data()->nodeCount[2] != 0) // Unless the result is an empty grid
+        data()->d_upperOffsets = static_cast<uint32_t*>(mUpperOffsets.deviceData());
+    mData.deviceUpload(device, stream, false);
+
+    return buffer;
+}// TopologyBuilder<BuildT>::getBuffer
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct BuildGridTreeRootFunctor
+{
+    __device__
+    void operator()(size_t, typename TopologyBuilder<BuildT>::Data *d_data) {
+
+        // process Root
+        auto &root = d_data->getRoot();
+        root.mTableSize = d_data->nodeCount[2];
+        root.mBackground = NanoRoot<BuildT>::ValueType(0);// background_value
+        root.mMinimum = root.mMaximum = NanoRoot<BuildT>::ValueType(0);
+        root.mAverage = root.mStdDevi = NanoRoot<BuildT>::FloatType(0);
+        root.mBBox = CoordBBox(); // To be further updated after the leaf-level voxel update
+
+        // process Tree
+        auto &tree = d_data->getTree();
+        tree.setRoot(&root);
+        if (d_data->nodeCount[2]) {
+            tree.setFirstNode(&d_data->getUpper(0));
+            tree.setFirstNode(&d_data->getLower(0));
+            tree.setFirstNode(&d_data->getLeaf(0));
+        }
+        else {
+            tree.template setFirstNode<NanoUpper<BuildT>>(nullptr);
+            tree.template setFirstNode<NanoLower<BuildT>>(nullptr);
+            tree.template setFirstNode<NanoLeaf<BuildT>>(nullptr);
+        }
+        tree.mNodeCount[2] = d_data->nodeCount[2];
+        tree.mNodeCount[1] = d_data->nodeCount[1];
+        tree.mNodeCount[0] = d_data->nodeCount[0];
+        tree.mVoxelCount = 0; // Actual voxel count (for non-empty grids) will only be known
+                              // once leaf masks have been processed
+        tree.mTileCount[2] = tree.mTileCount[1] =  tree.mTileCount[0] = 0;
+
+        // process Grid
+        // The GridData header has already been copied from the input;
+        // reset what is necessary, and assert that others are at the expected values
+        auto &grid = d_data->getGrid();
+
+#ifdef NANOVDB_USE_NEW_MAGIC_NUMBERS
+        NANOVDB_ASSERT(grid.mMagic == NANOVDB_MAGIC_GRID);
+#else
+        NANOVDB_ASSERT(grid.mMagic == NANOVDB_MAGIC_NUMB);
+#endif
+        grid.mChecksum.disable(); // all 64 bits ON means checksum is disabled
+        NANOVDB_ASSERT(grid.mVersion == Version());
+        NANOVDB_ASSERT(grid.mFlags.isMaskOn(GridFlags::IsBreadthFirst));
+        grid.mFlags.initMask({GridFlags::IsBreadthFirst}); // expected flags (HasBBox will be set later if grid is non-empty)
+        grid.mGridIndex = 0u; // Possibly overwriting input; returned grid has batch size 1
+        grid.mGridCount = 1u; // Possibly overwriting input; returned grid has batch size 1
+        grid.mGridSize = d_data->size;
+        // grid.mGridName expected to have been copied verbatim from input
+        // grid.mMap expected to have been copied verbatim from input
+        grid.mWorldBBox = Vec3dBBox();// invalid bbox
+        grid.mVoxelSize = grid.mMap.getVoxelSize();
+        NANOVDB_ASSERT(grid.mGridClass == GridClass::IndexGrid);
+        NANOVDB_ASSERT(grid.mGridType == toGridType<BuildT>());
+        grid.mBlindMetadataOffset = d_data->size; // i.e. no blind data, even if the input grid had any
+        grid.mBlindMetadataCount = 0u; // i.e. no blind data
+        NANOVDB_ASSERT(grid.mData0 == 0u); // zero padding
+        grid.mData1 = 1u; // This will be updated (unless this is an empty grid) after voxels have been processed
+#ifdef NANOVDB_USE_NEW_MAGIC_NUMBERS
+        NANOVDB_ASSERT(grid.mData2 == 0u);
+#else
+        NANOVDB_ASSERT(grid.mData2 == NANOVDB_MAGIC_GRID);
+#endif
+    }
+};
+
+}// namespace topology::detail
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct BuildUpperNodesFunctor
+{
+    __device__
+    void operator()(size_t processedTileID, typename TopologyBuilder<BuildT>::Data *d_data, NanoRoot<BuildT> *d_processedRoot) {
+        uint32_t tileID = d_data->d_upperOffsets[processedTileID];
+        if (tileID != d_data->d_upperOffsets[processedTileID+1]) // if the offsets are the same, this was a speculatively introduced tile which was not necessary
+        {
+            auto &root  = d_data->getRoot();
+            auto &dstUpper = d_data->getUpper(tileID);
+            auto &processedTile = *d_processedRoot->tile(processedTileID);
+            root.tile(tileID)->setChild( processedTile.origin(), &dstUpper, &root );
+            dstUpper.mBBox = CoordBBox(); // To be further updated after the operation has been applied at leaf-level
+            // TODO: Is this accurate? Any other flags that should be set?
+            dstUpper.mFlags = (uint64_t)GridFlags::HasBBox;
+        }
+    }
+};
+
+}// namespace topology::detail
+
+template <typename BuildT>
+inline void TopologyBuilder<BuildT>::processUpperNodes(cudaStream_t stream)
+{
+    // Connect all newly allocated upper nodes to their respective tiles
+    // Also fill in any necessary part of the preamble (in InternalData) of upper nodes
+    auto processedTileCount = hostProcessedRoot()->tileCount();
+
+    if (processedTileCount) { // Unless output grid is empty
+        util::cuda::lambdaKernel<<<numBlocks(processedTileCount), mNumThreads, 0, stream>>>(
+            processedTileCount, topology::detail::BuildUpperNodesFunctor<BuildT>(), deviceData(), deviceProcessedRoot());
+        cudaCheckError();
+    }
+}// TopologyBuilder<BuildT>::processUpperNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename BuildT>
+inline void TopologyBuilder<BuildT>::processLowerNodes(cudaStream_t stream)
+{
+    // Fill out the contents of all newly allocated lower nodes (using the densified upper/lower mask arrays)
+    // Also fill in the preamble (most of LeafData) for their leaf children
+    auto processedTileCount = hostProcessedRoot()->tileCount();
+    using CountType = uint32_t (*)[Mask<5>::SIZE];
+ 
+    if (processedTileCount) { // Unless output grid is empty
+        int device = 0;
+        cudaGetDevice(&device);
+        std::size_t lowerCount = data()->nodeCount[1];
+        mLowerParents = nanovdb::cuda::DeviceBuffer::create(lowerCount*sizeof(uint32_t), nullptr, device, stream);
+        std::size_t leafCount = data()->nodeCount[0];
+        mLeafParents = nanovdb::cuda::DeviceBuffer::create(leafCount*sizeof(uint32_t), nullptr, device, stream);
+
+        using Op = util::morphology::cuda::ProcessLowerNodesFunctor<BuildT>;
+        util::cuda::operatorKernel<Op>
+            <<<dim3(processedTileCount, Op::SlicesPerUpperNode, 1), Op::MaxThreadsPerBlock, 0, stream>>>(
+                deviceUpperMasks(),
+                deviceLowerMasks(),
+                static_cast<uint32_t*>(mUpperOffsets.deviceData()),
+                static_cast<CountType>(mLowerOffsets.deviceData()),
+                static_cast<CountType>(mLeafOffsets.deviceData()),
+                static_cast<GridT*>(data()->d_bufferPtr),
+                static_cast<uint32_t*>(mLowerParents.deviceData()),
+                static_cast<uint32_t*>(mLeafParents.deviceData())
+            );
+        cudaCheckError();
+    }
+
+    mProcessedRoot.clear(stream);
+    mUpperMasks.clear(stream);
+    mLowerMasks.clear(stream);
+    mLowerOffsets.clear(stream);
+    mLeafOffsets.clear(stream);
+}// TopologyBuilder<BuildT>::processLowerNodes
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct UpdateLeafVoxelCountsAndPrefixSumFunctor
+{
+    __device__
+    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelCounts) {
+        auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
+        const uint64_t *w = leaf.mValueMask.words();
+        uint64_t prefixSum = 0, sum = util::countOn(*w++);
+        prefixSum = sum;
+        for (int n = 9; n < 55; n += 9) {// n=i*9 where i=1,2,..6
+            sum += util::countOn(*w++);
+            prefixSum |= sum << n; }// each pre-fixed sum is encoded in 9 bits
+        sum += util::countOn(*w);
+        d_voxelCounts[leafID] = sum;
+        leaf.mPrefixSum = prefixSum; }
+};
+
+template <typename BuildT>
+struct UpdateLeafVoxelOffsetsFunctor
+{
+    __device__
+    void operator()(size_t leafID, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t *d_voxelOffsets) {
+        auto &leaf = d_data->getGrid().tree().template getFirstNode<0>()[leafID];
+        leaf.mOffset = d_voxelOffsets[leafID]+1; }
+};
+
+}// namespace topology::detail
+
+template<typename BuildT>
+inline void TopologyBuilder<BuildT>::processLeafOffsets(cudaStream_t stream)
+{
+    int device = 0;
+    cudaGetDevice(&device);
+    std::size_t leafCount = data()->nodeCount[0];
+    if (leafCount) { // Unless output grid is empty
+        mVoxelOffsets = nanovdb::cuda::DeviceBuffer::create((leafCount+1)*sizeof(uint64_t), nullptr, device, stream);
+        cudaCheck(cudaMemsetAsync(mVoxelOffsets.deviceData(), 0, sizeof(uint64_t), stream));
+        util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
+            leafCount, topology::detail::UpdateLeafVoxelCountsAndPrefixSumFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1);
+        CALL_CUBS(DeviceScan::InclusiveSum,
+            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
+            static_cast<uint64_t*>(mVoxelOffsets.deviceData())+1,
+            leafCount);
+        util::cuda::lambdaKernel<<<numBlocks(leafCount), mNumThreads, 0, stream>>>(
+            leafCount, topology::detail::UpdateLeafVoxelOffsetsFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+    }
+}// TopologyBuilder<BuildT>::processLeafOffsets
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Undefine utility macro for cub functions
+#ifdef CALL_CUBS
+#undef CALL_CUBS
+#endif
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct UpdateAndPropagateLeafBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* leafParents) {
+        auto &lower = d_data->getLower(leafParents[tid]);
+        auto &leaf = d_data->getLeaf(tid);
+        leaf.updateBBox();
+        lower.mBBox.expandAtomic(leaf.bbox());
+    }
+};
+
+template <typename BuildT>
+struct PropagateLowerBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, const uint32_t* lowerParents) {
+        auto &upper = d_data->getUpper(lowerParents[tid]);
+        auto &lower = d_data->getLower(tid);
+        upper.mBBox.expandAtomic(lower.bbox()); }
+};
+
+template <typename BuildT>
+struct PropagateUpperBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+        d_data->getRoot().mBBox.expandAtomic(d_data->getUpper(tid).bbox());
+    }
+};
+
+template <typename BuildT>
+struct UpdateRootWorldBBoxFunctor
+{
+    __device__
+    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data) {
+        // TODO: check that the correct semantics are followed in this transformation
+        auto BBox = d_data->getRoot().mBBox;
+        BBox.max() += 1;
+        d_data->getGrid().mFlags.setMaskOn(GridFlags::HasBBox);
+        d_data->getGrid().mWorldBBox = BBox.transform(d_data->getGrid().data()->mMap);
+    }
+};
+
+}// namespace topology::detail
+
+template <typename BuildT>
+inline void TopologyBuilder<BuildT>::processBBox(cudaStream_t stream)
+{
+    if (data()->nodeCount[0] == 0) return; // Output grid is empty; retain empty bounding box
+
+    // TODO: Do we need a special case when flags indicates no bounding box?
+
+    // update and propagate bbox from leaf -> lower/parent nodes
+    util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[0]), mNumThreads, 0, stream>>>(
+        data()->nodeCount[0], topology::detail::UpdateAndPropagateLeafBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLeafParents.deviceData()));
+    mLeafParents.clear(stream);
+    cudaCheckError();
+
+    // propagate bbox from lower -> upper/parent node
+    util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[1]), mNumThreads, 0, stream>>>(
+        data()->nodeCount[1], topology::detail::PropagateLowerBBoxFunctor<BuildT>(), deviceData(), static_cast<uint32_t*>(mLowerParents.deviceData()));
+    mLowerParents.clear(stream);
+    cudaCheckError();
+
+    // propagate bbox from upper -> root/parent node
+    util::cuda::lambdaKernel<<<numBlocks(data()->nodeCount[2]), mNumThreads, 0, stream>>>(data()->nodeCount[2], topology::detail::PropagateUpperBBoxFunctor<BuildT>(), deviceData());
+    cudaCheckError();
+
+    // update the world-bbox in the root node
+    util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::UpdateRootWorldBBoxFunctor<BuildT>(), deviceData());
+    cudaCheckError();
+}// TopologyBuilder<BuildT>::processBBox
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+namespace topology::detail {
+
+template <typename BuildT>
+struct PostProcessGridTreeFunctor
+{
+    __device__
+    void operator()(size_t tid, typename TopologyBuilder<BuildT>::Data *d_data, uint64_t* d_voxelOffsets) {
+        auto& grid = d_data->getGrid();
+        auto& tree = grid.tree();
+        auto leafCount = tree.mNodeCount[0];
+        tree.mVoxelCount = d_voxelOffsets[leafCount];
+        grid.mData1 = tree.mVoxelCount+1;
+    }
+};
+
+}// namespace topology::detail
+
+template <typename BuildT>
+inline void TopologyBuilder<BuildT>::postProcessGridTree(cudaStream_t stream)
+{
+    // Finish updates to GridData/TreeData and (optionally) update checksum
+    if (data()->nodeCount[0]) // if grid is empty, the default values are correct
+        util::cuda::lambdaKernel<<<1, 1, 0, stream>>>(1, topology::detail::PostProcessGridTreeFunctor<BuildT>(), deviceData(), static_cast<uint64_t*>(mVoxelOffsets.deviceData()));
+    cudaCheckError();
+    mVoxelOffsets.clear(stream);
+
+    tools::cuda::updateChecksum((GridData*)data()->d_bufferPtr, mChecksum, stream);
+}// TopologyBuilder<BuildT>::postProcessGridTree
+
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+}// namespace tools::cuda
+
+}// namespace nanovdb
+
+#endif // NVIDIA_TOOLS_CUDA_TOPOLOGYBUILDER_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/VoxelBlockManager.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/tools/cuda/VoxelBlockManager.cuh
@@ -1,0 +1,250 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file nanovdb/tools/VoxelBlockManager.cuh
+
+    \author Eftychios Sifakis
+
+    \date January 27, 2025
+
+    \brief Implements device functions to build and query the VoxelBlockManager.
+           The VoxelBlockManager is an acceleration structure for sequential access
+           and stencil operations over solely the active voxels of an OnIndexGrid
+           which enables SIMT parallelism independent of occupancy.
+*/
+
+#include <cuda/atomic>
+
+#include <nanovdb/NanoVDB.h>
+#include <nanovdb/util/cuda/Util.h>
+
+#ifndef NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED
+
+namespace nanovdb {
+
+namespace tools::cuda {
+
+/// @brief This class allows for sequential access to contiguous spans (i.e.
+/// blocks) of active voxels in an IndexGrid on the device, and efficient
+/// computation of linear offsets of stencils (e.g. 3-wide box stencil).
+/// @tparam BlockWidth Number of active voxels in a contiguous span
+template <int BlockWidth>
+struct VoxelBlockManager
+{
+    // The efficiency of the functions in this class are contingent on
+    // threadblock-level coordination, which manifests either as using shared
+    // memory for synchronization, or warp-level shift operations.
+
+    // The jumpMap is packed in uint64_t's, one per 64 consecutive bits. Hence
+    // JumpMapLength is the number of uint64_t that are needed to straddle the
+    // total BlockWidth bits of the jumpMap.
+    static constexpr int JumpMapLength = BlockWidth/64;
+
+    static constexpr uint32_t UnusedLeafIndex = 0xffffffff;
+    static constexpr uint16_t UnusedVoxelOffset = 0xffff;
+
+    /// @brief Given a grid and the associated jumpMap in global memory, compute
+    /// the leaf indices and voxel offsets in shared memory. This function
+    /// writes to shared memory and synchronizes threads and thus should not be
+    /// called from divergent threads within a thread block.
+    /// @tparam BuildT Build type of the grid
+    /// @param grid
+    /// @param firstLeafID
+    /// @param jumpMap
+    /// @param blockFirstOffset
+    /// @param smem_leafIndex Leaf indices stored in shared memory
+    /// @param smem_voxelOffset Voxel offsets stored in shared memory
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    decodeInverseMaps(
+        NanoGrid<BuildT> *grid,
+        const uint32_t firstLeafID,
+        const uint64_t *jumpMap,
+        const uint64_t blockFirstOffset,
+        uint32_t *smem_leafIndex,
+        uint16_t *smem_voxelOffset)
+    {
+        // Verify that the nodes can be accessed linearly
+        NANOVDB_ASSERT(grid->isSequential());
+
+        int tID = threadIdx.x;
+
+        // Count how many additional leaves (following the one indicated by firstLeafID)
+        // overlap with this voxel block
+        int nExtraLeaves = 0;
+        for (int i = 0; i < JumpMapLength; i++)
+            nExtraLeaves += util::countOn(jumpMap[i]);
+
+        // Initialize leafIndex & voxelOffset to sentinel values
+        // for blocks that extend beyond the last active voxel in the grid
+        if (tID < BlockWidth)
+#pragma cuda unroll
+            for (int i = 0; i < BlockWidth; i += blockDim.x) {
+                smem_leafIndex[i+tID] = UnusedLeafIndex;
+                smem_voxelOffset[i+tID] = UnusedVoxelOffset;
+            }
+        __syncthreads();
+
+        NANOVDB_ASSERT(blockDim.x <= 512);
+        const auto& tree = grid->tree();
+        // Loop through all leafNodes overlapping the voxel block
+        // with all threads in threadblock working collaboratively within each leafNode
+        for (int leafID = firstLeafID; leafID <= firstLeafID + nExtraLeaves; leafID++) {
+            const auto& leaf = tree.template getFirstNode<0>()[leafID];
+            const Coord origin = leaf.origin();
+            for (int threadOffset = 0; threadOffset < 512; threadOffset += blockDim.x) {
+                int localOffset = threadOffset + tID;
+                int index = leaf.data()->getValue(localOffset);
+                if ((index >= blockFirstOffset) && (index < blockFirstOffset + BlockWidth)) {
+                    int blockOffset = index - blockFirstOffset;
+                    // Write inverse map to shared memory; no collisions
+                    smem_leafIndex[blockOffset] = leafID;
+                    smem_voxelOffset[blockOffset] = localOffset;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    /// @brief Given a grid and its decoded voxel map, compute the stencil.
+    /// This function accesses shared memory but does not synchronize threads
+    /// so it may be called from divergent threads within a thread block.
+    /// offsets for a 3x3x3 box stencil.
+    /// @tparam BuildT Build type of the grid
+    /// @param grid
+    /// @param smem_leafIndex Leaf indices stored in shared memory
+    /// @param smem_voxelOffset Voxel offsets stored in shared memory
+    /// @param stencilIndices Pointer to output stencil indices. Must have
+    /// length of at least 27 (corresponding to the 3x3x3 stencil)
+    template <class BuildT>
+    __device__
+    static typename util::enable_if<BuildTraits<BuildT>::is_index, void>::type
+    computeBoxStencil(
+        const NanoGrid<BuildT> *grid,
+        const uint32_t *smem_leafIndex,
+        const uint16_t *smem_voxelOffset,
+        uint64_t *stencilIndices)
+    {
+        // Verify that the nodes can be accessed linearly
+        NANOVDB_ASSERT(grid->isSequential());
+
+        int tID = threadIdx.x;
+        const auto& tree = grid->tree();
+        if (smem_leafIndex[tID] != UnusedLeafIndex) {
+            // This presumes that leaf nodes are fixed-size and sequentially accessible in memory
+            const auto& leaf = tree.template getFirstNode<0>()[ smem_leafIndex[tID] ];
+            const Coord coord = leaf.offsetToGlobalCoord( smem_voxelOffset[tID] );
+            const auto index = leaf.getValue( smem_voxelOffset[tID] );
+            for (int di = -1; di <= 1; di++)
+            for (int dj = -1; dj <= 1; dj++)
+            for (int dk = -1; dk <= 1; dk++) {
+                int spokeID = ( di + 1 ) * 9 + ( dj + 1 ) * 3 + dk + 1;
+                const auto neighbor = coord.offsetBy( di, dj, dk );
+                stencilIndices[spokeID] = tree.getValue( neighbor );
+            }
+        }
+    }
+};
+
+/// @brief This functor calculates the firstLeafID and jumpMap for the
+/// VoxelBlockManager over the subset of the Tree nodes specified by
+/// firstOffset, lastOffset, and nBlocks.
+template<int BlockWidthLog2, int NumThreads>
+struct BuildVoxelBlockManagerFunctor
+{
+    static constexpr int BlockWidth = 1 << BlockWidthLog2;
+    static constexpr int JumpMapLength = BlockWidth/64;
+    static constexpr int SlicesPerLowerNode = 8;
+    static constexpr int LeafNodesPerSlice = 4096/SlicesPerLowerNode;
+
+    static constexpr int MaxThreadsPerBlock = NumThreads;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    void __device__
+    operator()(
+        uint64_t firstOffset,
+        uint64_t lastOffset,
+        int nBlocks,
+        const NanoGrid<ValueOnIndex> *grid,
+        uint32_t *firstLeafID,
+        uint64_t *jumpMap)
+    {
+        // Verify that the nodes can be accessed linearly
+        NANOVDB_ASSERT(grid->isSequential());
+
+        using JumpMapType = uint64_t (&)[][JumpMapLength];
+
+        int tID = threadIdx.x;
+        int blockID = blockIdx.x;
+        int sliceID = blockIdx.y;
+
+        const auto& tree = grid->tree();
+
+        const auto& lower = tree.getFirstNode<1>()[blockID];
+        for ( std::size_t jj = sliceID*LeafNodesPerSlice; jj < (sliceID+1)*LeafNodesPerSlice; jj += MaxThreadsPerBlock )
+            if ( lower.childMask().isOn(jj+tID) )
+            {
+                auto& leaf = *lower.getChild(jj+tID);
+                const auto leafFirstOffset = leaf.data()->firstOffset();
+                const auto leafValueCount = leaf.data()->valueCount();
+                const auto leafLastOffset = leafFirstOffset + leafValueCount - 1;
+
+                auto leafIndex = util::PtrDiff(&leaf,tree.getFirstNode<0>()) / sizeof(NanoLeaf<ValueOnIndex>);
+
+                if ( ( leafFirstOffset > lastOffset ) || (leafLastOffset < firstOffset) ) continue;
+
+                int lastBlock = (leafLastOffset - firstOffset) >> BlockWidthLog2;
+                lastBlock = min(lastBlock, nBlocks-1);
+                uint64_t firstBlock = (leafFirstOffset < firstOffset) ? 0 :
+                    (leafFirstOffset - firstOffset) >> BlockWidthLog2;
+
+                // For all but the first block touched, mark the firstLeaf as being this one
+                for ( uint64_t b = lastBlock; b > firstBlock; --b )
+                    firstLeafID[b] = leafIndex;
+                if (leafFirstOffset < firstOffset) { firstLeafID[0] = leafIndex; continue; }
+
+                const auto offsetInBlock = (leafFirstOffset - 1) & (BlockWidth - 1);
+                if ( !offsetInBlock ) {
+                    // If the first leaf starts exactly at the beginning of a
+                    // block, register it in mFirstLeaf too
+                    firstLeafID[firstBlock] = leafIndex;
+                } else {
+                    // Otherwise, mark it in the jumpMap
+                    // The specific uint64_t in the jumpMap to be marked is at element offset (offsetInBlock>>6), i.e. offsetBlock/64
+                    // and bit offset (offsetInBlock & 0x3f), i.e. offsetInBlock%64
+                    ::cuda::atomic_ref<uint64_t> ref(jumpMap[firstBlock * JumpMapLength + (offsetInBlock>>6)]);
+                    ref.fetch_or(0x1ul << (offsetInBlock & 0x3f));
+                }
+            }
+
+        return;
+    }
+
+};
+
+/// @brief Helper function to build a VoxelBlockManager on the device
+template<int BlockWidthLog2, int NumThreads = 128>
+void buildVoxelBlockManager(
+    uint64_t firstOffset,
+    uint64_t lastOffset,
+    int nBlocks,
+    int lowerCount,
+    const NanoGrid<ValueOnIndex> *grid,
+    uint32_t *firstLeafID,
+    uint64_t *jumpMap,
+    cudaStream_t stream = 0)
+{
+    using Op = BuildVoxelBlockManagerFunctor<BlockWidthLog2, NumThreads>;
+    util::cuda::operatorKernel<Op>
+        <<<dim3(lowerCount,Op::SlicesPerLowerNode,1), NumThreads, 0, stream>>>(
+            firstOffset, lastOffset, nBlocks, grid, firstLeafID, jumpMap);
+}
+
+} // namespace tools::cuda
+
+} // namespace nanovdb
+
+#endif // NANOVDB_VOXELBLOCKMANAGER_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/MorphologyHelpers.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/MorphologyHelpers.h
@@ -1,0 +1,127 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file MorphologyHelpers.h
+
+    \author Efty Sifakis
+
+    \date March 17, 2025
+
+    \brief This file implements helper methods used in morphology operations
+
+*/
+
+#ifndef NANOVDB_UTIL_MORPHOLOGYHELPERS_H_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_MORPHOLOGYHELPERS_H_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+
+namespace nanovdb::tools::morphology {
+
+enum NearestNeighbors { NN_FACE = 6, NN_FACE_EDGE = 18, NN_FACE_EDGE_VERTEX = 26 };
+
+} // namespace nanovdb::tools::morphology
+
+namespace nanovdb::util {
+
+namespace morphology {
+
+template<int di, int dj, int dk>
+struct NearestNeighborBitMask {
+    static_assert( (di>=-1) && (di<=1) && (dj>=-1) && (dj<=1) && (dk>=-1) && (dk<=1) );
+    static constexpr uint32_t value = 1u << (di+1)*9+(dj+1)*3+dk+1;
+};
+
+template<tools::morphology::NearestNeighbors nnType>
+__hostdev__
+uint32_t neighborMaskStencil(const nanovdb::Mask<3>& mask)
+{
+    using tools::morphology::NN_FACE;
+    using tools::morphology::NN_FACE_EDGE;
+    using tools::morphology::NN_FACE_EDGE_VERTEX;
+
+    uint32_t result = 0;
+    auto words = mask.words();
+    uint64_t allWordsOr = 0;
+    for (int i = 0; i < 8; i++)
+        allWordsOr |= words[i];
+    // Center
+    if ( allWordsOr )                            result |= NearestNeighborBitMask< 0, 0, 0>::value;
+    // Neighbors across faces
+    if constexpr (nnType == NN_FACE || nnType == NN_FACE_EDGE || nnType == NN_FACE_EDGE_VERTEX) {
+        if ( words[0] )                          result |= NearestNeighborBitMask<-1, 0, 0>::value;
+        if ( words[7] )                          result |= NearestNeighborBitMask< 1, 0, 0>::value;
+        if ( allWordsOr & 0x00000000000000ffUL ) result |= NearestNeighborBitMask< 0,-1, 0>::value;
+        if ( allWordsOr & 0xff00000000000000UL ) result |= NearestNeighborBitMask< 0, 1, 0>::value;
+        if ( allWordsOr & 0x0101010101010101UL ) result |= NearestNeighborBitMask< 0, 0,-1>::value;
+        if ( allWordsOr & 0x8080808080808080UL ) result |= NearestNeighborBitMask< 0, 0, 1>::value; }
+    // Neighbors across edges
+    if constexpr (nnType == NN_FACE_EDGE || nnType == NN_FACE_EDGE_VERTEX) {
+        if ( words[0]   & 0x00000000000000ffUL ) result |= NearestNeighborBitMask<-1,-1, 0>::value;
+        if ( words[0]   & 0xff00000000000000UL ) result |= NearestNeighborBitMask<-1, 1, 0>::value;
+        if ( words[0]   & 0x0101010101010101UL ) result |= NearestNeighborBitMask<-1, 0,-1>::value;
+        if ( words[0]   & 0x8080808080808080UL ) result |= NearestNeighborBitMask<-1, 0, 1>::value;
+        if ( allWordsOr & 0x0000000000000001UL ) result |= NearestNeighborBitMask< 0,-1,-1>::value;
+        if ( allWordsOr & 0x0000000000000080UL ) result |= NearestNeighborBitMask< 0,-1, 1>::value;
+        if ( allWordsOr & 0x0100000000000000UL ) result |= NearestNeighborBitMask< 0, 1,-1>::value;
+        if ( allWordsOr & 0x8000000000000000UL ) result |= NearestNeighborBitMask< 0, 1, 1>::value;
+        if ( words[7]   & 0x00000000000000ffUL ) result |= NearestNeighborBitMask< 1,-1, 0>::value;
+        if ( words[7]   & 0xff00000000000000UL ) result |= NearestNeighborBitMask< 1, 1, 0>::value;
+        if ( words[7]   & 0x0101010101010101UL ) result |= NearestNeighborBitMask< 1, 0,-1>::value;
+        if ( words[7]   & 0x8080808080808080UL ) result |= NearestNeighborBitMask< 1, 0, 1>::value; }
+        // Neighbors across vertices
+    if constexpr (nnType == NN_FACE_EDGE_VERTEX) {
+        if ( words[0]   & 0x0000000000000001UL ) result |= NearestNeighborBitMask<-1,-1,-1>::value;
+        if ( words[0]   & 0x0000000000000080UL ) result |= NearestNeighborBitMask<-1,-1, 1>::value;
+        if ( words[0]   & 0x0100000000000000UL ) result |= NearestNeighborBitMask<-1, 1,-1>::value;
+        if ( words[0]   & 0x8000000000000000UL ) result |= NearestNeighborBitMask<-1, 1, 1>::value;
+        if ( words[7]   & 0x0000000000000001UL ) result |= NearestNeighborBitMask< 1,-1,-1>::value;
+        if ( words[7]   & 0x0000000000000080UL ) result |= NearestNeighborBitMask< 1,-1, 1>::value;
+        if ( words[7]   & 0x0100000000000000UL ) result |= NearestNeighborBitMask< 1, 1,-1>::value;
+        if ( words[7]   & 0x8000000000000000UL ) result |= NearestNeighborBitMask< 1, 1, 1>::value; }
+    return result;
+}
+
+__hostdev__
+inline Coord::ValueType
+coarsenComponent(const Coord::ValueType n)
+{return (n>=0) ? (n>>1) : -((-n+1)>>1);} // Round down for negative integers
+
+__hostdev__
+inline Coord
+coarsenCoord(const Coord& coord)
+{
+    Coord result;
+    result[0] = coarsenComponent(coord[0]);
+    result[1] = coarsenComponent(coord[1]);
+    result[2] = coarsenComponent(coord[2]);
+    return result;
+}
+
+__hostdev__
+inline Coord::ValueType
+refineComponent(const Coord::ValueType n)
+{return (n>=0) ? (n<<1) : -((-n)<<1);}
+
+__hostdev__
+inline Coord
+refineCoord(const Coord& coord)
+{
+    Coord result;
+    result[0] = refineComponent(coord[0]);
+    result[1] = refineComponent(coord[1]);
+    result[2] = refineComponent(coord[2]);
+    return result;
+}
+
+} // namespace morphology
+
+} // namespace nanovdb::util
+
+#if defined(__CUDACC__)
+#include <nanovdb/util/cuda/MorphologyHelpers.cuh>
+#endif // defined(__CUDACC__)
+
+#endif // NANOVDB_UTIL_MORPHOLOGYHELPERS_H_HAS_BEEN_INCLUDED
+

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/Timer.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/Timer.h
@@ -19,7 +19,7 @@ namespace util {
 
 class Timer
 {
-    std::chrono::high_resolution_clock::time_point mStart;
+    std::chrono::high_resolution_clock::time_point mStart, mStop;
 public:
     /// @brief Default constructor
     Timer() {}
@@ -38,22 +38,34 @@ public:
         mStart = std::chrono::high_resolution_clock::now();
     }
 
-    /// @brief elapsed time (since start) in miliseconds
+    /// @brief Record the stop time so the elapsed time since start can be computed
+    void record()
+    {
+        mStop = std::chrono::high_resolution_clock::now();
+    }
+
+    /// @brief Returns the time in milliseconds since record was called
+    float milliseconds() const
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(mStop - mStart).count();
+    }
+
+    /// @brief call record and return the elapsed time (since start) in miliseconds
     template <typename AccuracyT = std::chrono::milliseconds>
     auto elapsed()
     {
-        auto end = std::chrono::high_resolution_clock::now();
-        return std::chrono::duration_cast<AccuracyT>(end - mStart).count();
+        this->record();
+        return std::chrono::duration_cast<AccuracyT>(mStop - mStart).count();
     }
 
-    /// @brief stop the timer
+    /// @brief stop the timer and print elapsed time to a stream
     /// @tparam AccuracyT Template parameter defining the accuracy of the reported times
     /// @param os output stream for the message above
     template <typename AccuracyT = std::chrono::milliseconds>
     void stop(std::ostream& os = std::cerr)
     {
-        auto end = std::chrono::high_resolution_clock::now();
-        auto diff = std::chrono::duration_cast<AccuracyT>(end - mStart).count();
+        mStop = std::chrono::high_resolution_clock::now();
+        auto diff = std::chrono::duration_cast<AccuracyT>(mStop - mStart).count();
         os << "completed in " << diff;
         if (std::is_same<AccuracyT, std::chrono::microseconds>::value) {// resolved at compile-time
             os << " microseconds" << std::endl;
@@ -66,7 +78,7 @@ public:
         }
     }
 
-    /// @brief stop and start the timer
+    /// @brief stop and start the timer again
     /// @tparam AccuracyT Template parameter defining the accuracy of the reported times
     /// @param msg string message to be printed when timer is started
     /// @param os output stream for the message above

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/Util.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/Util.h
@@ -154,7 +154,7 @@ __hostdev__ inline size_t strlen(const char *str)
 {
     NANOVDB_ASSERT(str != nullptr);
     const char *s = str;
-    while(*s) ++s;               ;
+    while(*s) ++s;
     return (s - str);
 }// util::strlen
 
@@ -322,11 +322,17 @@ struct is_same<T0, T1> {static constexpr bool value = false;};
 template<typename T>
 struct is_same<T, T> {static constexpr bool value = true;};
 
+template<typename T0, typename T1, typename ...T>
+static constexpr bool is_same_v = is_same<T0, T1, T...>::value;
+
 // --------------------------> util::is_floating_point <------------------------------------
 
 /// @brief C++11 implementation of std::is_floating_point
 template<typename T>
 struct is_floating_point {static constexpr bool value = is_same<T, float, double>::value;};
+
+template<typename T>
+static constexpr bool is_floating_point_v = is_floating_point<T>::value;
 
 // --------------------------> util::enable_if <------------------------------------
 
@@ -337,6 +343,9 @@ struct enable_if {};
 template <typename T>
 struct enable_if<true, T> {using type = T;};
 
+template<bool Test, typename T = void>
+using enable_if_t = typename enable_if<Test, T>::type;
+
 // --------------------------> util::disable_if <------------------------------------
 
 template<bool, typename T = void>
@@ -345,6 +354,9 @@ struct disable_if {using type = T;};
 template<typename T>
 struct disable_if<true, T> {};
 
+template<bool Test, typename T = void>
+using disable_if_t = typename disable_if<Test, T>::type;
+
 // --------------------------> util::is_const <------------------------------------
 
 template<typename T>
@@ -352,6 +364,9 @@ struct is_const {static constexpr bool value = false;};
 
 template<typename T>
 struct is_const<const T> {static constexpr bool value = true;};
+
+template<typename T>
+static constexpr bool is_const_v = is_const<T>::value;
 
 // --------------------------> util::is_pointer <------------------------------------
 
@@ -366,6 +381,9 @@ struct is_pointer {static constexpr bool value = false;};
 template<class T>
 struct is_pointer<T*> {static constexpr bool value = true;};
 
+template<typename T>
+static constexpr bool is_pointer_v = is_pointer<T>::value;
+
 // --------------------------> util::conditional <------------------------------------
 
 /// @brief C++11 implementation of std::conditional
@@ -377,6 +395,9 @@ struct conditional { using type = TrueT; };
 /// @tparam TrueT Type used when boolean is true
 template<class TrueT, class FalseT>
 struct conditional<false, TrueT, FalseT> { using type = FalseT; };
+
+template<bool Test, class TrueT, class FalseT>
+using conditional_t = typename conditional<Test, TrueT, FalseT>::type;
 
 // --------------------------> util::remove_const <------------------------------------
 
@@ -392,6 +413,9 @@ struct remove_const {using type = T;};
 template<typename T>
 struct remove_const<const T> {using type = T;};
 
+template<typename T>
+using remove_const_t = typename remove_const<T>::type;
+
 // --------------------------> util::remove_reference <------------------------------------
 
 /// @brief Trait use to remove reference, i.e. "&", qualifier from a type. Default implementation is just a pass-through
@@ -406,6 +430,9 @@ struct remove_reference {using type = T;};
 template <typename T>
 struct remove_reference<T&> {using type = T;};
 
+template <typename T>
+using remove_reference_t = typename remove_const<T>::type;
+
 // --------------------------> util::remove_pointer <------------------------------------
 
 /// @brief Trait use to remove pointer, i.e. "*", qualifier from a type. Default implementation is just a pass-through
@@ -419,6 +446,9 @@ struct remove_pointer {using type = T;};
 /// @details remove_pointer<float*>::type = float
 template <typename T>
 struct remove_pointer<T*> {using type = T;};
+
+template <typename T>
+using remove_pointer_t = typename remove_pointer<T>::type;
 
 // --------------------------> util::match_const <------------------------------------
 
@@ -438,6 +468,9 @@ struct match_const {using type = typename remove_const<T>::type;};
 template<typename T, typename ReferenceT>
 struct match_const<T, const ReferenceT> {using type = const typename remove_const<T>::type;};
 
+template<typename T, typename ReferenceT>
+using match_const_t = typename match_const<T, ReferenceT>::type;
+
 // --------------------------> util::is_specialization <------------------------------------
 
 /// @brief Metafunction used to determine if the first template
@@ -449,6 +482,7 @@ struct match_const<T, const ReferenceT> {using type = const typename remove_cons
 ///          is_specialization<std::vector<float>, std::vector>::value == true;
 template<typename AnyType, template<typename...> class TemplateType>
 struct is_specialization {static const bool value = false;};
+
 template<typename... Args, template<typename...> class TemplateType>
 struct is_specialization<TemplateType<Args...>, TemplateType>
 {

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/DeviceGridTraits.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/DeviceGridTraits.cuh
@@ -1,0 +1,89 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+    \file DeviceGridTraits.cuh
+
+    \author Efty Sifakis
+
+    \date Aug 8, 2025
+
+    \brief This file implements helpers probing grid traits of device-resident NanoVDB grids
+
+*/
+
+#ifndef NANOVDB_UTIL_CUDA_DEVICEGRIDTRAITS_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_CUDA_DEVICEGRIDTRAITS_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+
+namespace nanovdb::util {
+
+namespace cuda {
+
+/// @brief Utility class for directly probing a device-resident IndexGrid for fundamental traits
+///        of the tree topology
+/// @tparam BuildT Build type for the grid
+template <typename BuildT>
+struct DeviceGridTraits
+{
+    using GridT = typename nanovdb::NanoGrid<BuildT>;
+    using TreeT = typename nanovdb::NanoTree<BuildT>;
+    using RootT = typename nanovdb::NanoRoot<BuildT>;
+    using TreeDataT = typename TreeT::DataType;
+
+    static TreeDataT getTreeData(const GridT *d_grid)
+    {
+        TreeDataT treeData;
+        std::size_t offset = GridT::memUsage();
+        cudaCheck(cudaMemcpy(&treeData, util::PtrAdd(d_grid, offset), sizeof(TreeDataT), cudaMemcpyDeviceToHost));
+        return treeData;
+    }
+
+    static uint64_t getActiveVoxelCount(const GridT *d_grid)
+    {
+        uint64_t activeVoxelCount = 0;
+        std::size_t offset = GridT::memUsage() + offsetof(TreeT, mVoxelCount);
+        cudaCheck(cudaMemcpy(&activeVoxelCount, util::PtrAdd(d_grid, offset), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+        return activeVoxelCount;
+    }
+
+    static uint64_t getValueCount(const GridT *d_grid)
+    {
+        uint64_t valueCount = 0;
+        std::size_t offset = offsetof(GridT, mData1);
+        cudaCheck(cudaMemcpy(&valueCount, util::PtrAdd(d_grid, offset), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+        return valueCount;
+    }
+
+    static uint64_t getGridSize(const GridT *d_grid)
+    {
+        uint64_t gridSize = 0;
+        std::size_t offset = offsetof(GridT, mGridSize);
+        cudaCheck(cudaMemcpy(&gridSize, util::PtrAdd(d_grid, offset), sizeof(uint64_t), cudaMemcpyDeviceToHost));
+        return gridSize;
+    }
+
+    static CoordBBox getIndexBBox(const GridT *d_grid, const TreeDataT &h_treeData)
+    {
+        CoordBBox box;
+        std::size_t offset = GridT::memUsage() + h_treeData.mNodeOffset[3] + offsetof(RootT, mBBox);
+        cudaCheck(cudaMemcpy(&box, util::PtrAdd(d_grid, offset), sizeof(CoordBBox), cudaMemcpyDeviceToHost));
+        return box;
+    }
+
+    static uint32_t getRootTableSize(const GridT *d_grid, const TreeDataT &h_treeData)
+    {
+        uint32_t tableSize;
+        std::size_t offset = GridT::memUsage() + h_treeData.mNodeOffset[3] + offsetof(RootT, mTableSize);
+        cudaCheck(cudaMemcpy(&tableSize, util::PtrAdd(d_grid, offset), sizeof(uint32_t), cudaMemcpyDeviceToHost));
+        return tableSize;
+    }
+
+};
+
+} // namespace cuda
+
+} // namespace nanovdb::util
+
+#endif // NANOVDB_UTIL_CUDA_DEVICEGRIDTRAITS_H_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Injection.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Injection.cuh
@@ -1,0 +1,197 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+    \file Injection.cuh
+
+    \author Efty Sifakis
+
+    \date Jun 3, 2025
+
+    \brief This file implements data injection methods on sidecars corresponding to
+           distinct indexGrid topologies.
+
+*/
+
+#ifndef NANOVDB_UTIL_CUDA_INECTION_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_CUDA_INECTION_CUH_HAS_BEEN_INCLUDED
+
+#include <nanovdb/NanoVDB.h>
+
+namespace nanovdb::util {
+
+namespace cuda {
+
+template <typename BuildT, typename ValueType, int64_t offset = 0>
+struct InjectGridDataFunctor
+{
+    // Copies the sidecar data of a (source) grid into the sidecar of an overlapping (destination) grid
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    // blockDim.x is presumed to be the leaf count of the source tree
+    // Values of the destination sidecar that do not overlap with the source are left unchanged
+    // NOTE: If the source voxels are not a subset of the destination voxels, the injection will be from
+    // the intersection of the two active voxel sets into the destination
+    // This version presumes that the sidecar contents are of compile-time known length,
+    // and can be copied with the assignment operator.
+
+    static constexpr int MaxThreadsPerBlock = 256;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__
+    void operator()(
+        const typename nanovdb::NanoGrid<BuildT> *d_srcGrid,
+        const typename nanovdb::NanoGrid<BuildT> *d_dstGrid,
+        const ValueType *d_srcData,
+        ValueType *d_dstData)
+    {
+        int srcLeafID = blockIdx.x;
+        int warpID = threadIdx.x >> 5;
+        int threadInWarpID = threadIdx.x & 0x1f;
+
+        const auto& srcTree = d_srcGrid->tree();
+        const auto& dstTree = d_dstGrid->tree();
+        const auto& srcLeaf = srcTree.template getFirstNode<0>()[srcLeafID];
+        auto dstLeafPtr = dstTree.root().probeLeaf(srcLeaf.origin());
+        if (dstLeafPtr) {
+            auto srcWord = srcLeaf.valueMask().words()[warpID];
+            auto dstWord = dstLeafPtr->valueMask().words()[warpID];
+            auto srcOffset = srcLeaf.firstOffset();
+            if (warpID) srcOffset += (srcLeaf.mPrefixSum >> ((warpID-1) * 9)) & 0x1ff;
+            auto dstOffset = dstLeafPtr->firstOffset();
+            if (warpID) dstOffset += (dstLeafPtr->mPrefixSum >> ((warpID-1) * 9)) & 0x1ff;
+
+            uint64_t loMask = 1UL << threadInWarpID;
+            uint64_t hiMask = 0x100000000UL << threadInWarpID;
+            uint64_t loSrcCnt = nanovdb::util::countOn( srcWord & (loMask-1UL) );
+            uint64_t hiSrcCnt = nanovdb::util::countOn( srcWord & (hiMask-1UL) );
+            uint64_t loDstCnt = nanovdb::util::countOn( dstWord & (loMask-1UL) );
+            uint64_t hiDstCnt = nanovdb::util::countOn( dstWord & (hiMask-1UL) );
+
+            if ( loMask & srcWord & dstWord )
+                d_dstData[int64_t(dstOffset+loDstCnt)+offset] = d_srcData[int64_t(srcOffset+loSrcCnt)+offset];
+            if ( hiMask & srcWord & dstWord )
+                d_dstData[int64_t(dstOffset+hiDstCnt)+offset] = d_srcData[int64_t(srcOffset+hiSrcCnt)+offset];
+        }
+    }
+};
+
+template <typename BuildT, typename ValueType, int64_t offset = 0>
+struct InjectGridFeatureFunctor
+{
+    // Copies the sidecar data of a (source) grid into the sidecar of an overlapping (destination) grid
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    // blockDim.x is presumed to be the leaf count of the source tree
+    // Values of the destination sidecar that do not overlap with the source are left unchanged
+    // NOTE: If the source voxels are not a subset of the destination voxels, the injection will be from
+    // the intersection of the two active voxel sets into the destination
+    // This version presumes a runtime dimension parameter for input features
+    static constexpr int MaxThreadsPerBlock = 256;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__
+    void operator()(
+        const typename nanovdb::NanoGrid<BuildT> *d_srcGrid,
+        const typename nanovdb::NanoGrid<BuildT> *d_dstGrid,
+        const ValueType *d_srcData,
+        ValueType *d_dstData,
+        const std::size_t dim)
+    {
+        int srcLeafID = blockIdx.x;
+        int warpID = threadIdx.x >> 5;
+        int threadInWarpID = threadIdx.x & 0x1f;
+
+        const auto& srcTree = d_srcGrid->tree();
+        const auto& dstTree = d_dstGrid->tree();
+        const auto& srcLeaf = srcTree.template getFirstNode<0>()[srcLeafID];
+        auto dstLeafPtr = dstTree.root().probeLeaf(srcLeaf.origin());
+        if (dstLeafPtr) {
+            auto srcWord = srcLeaf.valueMask().words()[warpID];
+            auto dstWord = dstLeafPtr->valueMask().words()[warpID];
+            auto srcOffset = srcLeaf.firstOffset();
+            if (warpID) srcOffset += (srcLeaf.mPrefixSum >> ((warpID-1) * 9)) & 0x1ff;
+            auto dstOffset = dstLeafPtr->firstOffset();
+            if (warpID) dstOffset += (dstLeafPtr->mPrefixSum >> ((warpID-1) * 9)) & 0x1ff;
+
+            uint64_t loMask = 1UL << threadInWarpID;
+            uint64_t hiMask = 0x100000000UL << threadInWarpID;
+            uint64_t loSrcCnt = nanovdb::util::countOn( srcWord & (loMask-1UL) );
+            uint64_t hiSrcCnt = nanovdb::util::countOn( srcWord & (hiMask-1UL) );
+            uint64_t loDstCnt = nanovdb::util::countOn( dstWord & (loMask-1UL) );
+            uint64_t hiDstCnt = nanovdb::util::countOn( dstWord & (hiMask-1UL) );
+
+            if ( loMask & srcWord & dstWord )
+                for (int64_t w = 0; w < dim; w++)
+                    d_dstData[int64_t(dim)*(offset+int64_t(dstOffset+loDstCnt))+w] = d_srcData[int64_t(dim)*(offset+int64_t(srcOffset+loSrcCnt))+w];
+            if ( hiMask & srcWord & dstWord )
+                for (int64_t w = 0; w < dim; w++)
+                    d_dstData[int64_t(dim)*(offset+int64_t(dstOffset+hiDstCnt))+w] = d_srcData[int64_t(dim)*(offset+int64_t(srcOffset+hiSrcCnt))+w];
+        }
+    }
+};
+
+template <typename BuildT>
+struct InjectGridMaskFunctor
+{
+    // Populates a sidecar of leaf-enumerated bitmasks (associated with a destination grid)
+    // with those voxels that are also present in a source grid
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    // Note: if the source topology is not a subset of the destination topology, the result
+    // will be equivalent to the source being taken as the intersection of the two grids
+
+    __device__
+    void operator()(
+        const std::size_t dstLeafID,
+        const typename nanovdb::NanoGrid<BuildT> *d_srcGrid,
+        const typename nanovdb::NanoGrid<BuildT> *d_dstGrid,
+        typename nanovdb::Mask<3> *d_dstLeafMasks)
+    {
+        const auto& srcTree = d_srcGrid->tree();
+        const auto& dstTree = d_dstGrid->tree();
+        const auto& dstLeaf = dstTree.template getFirstNode<0>()[dstLeafID];
+        auto& resultMask = d_dstLeafMasks[dstLeafID];
+        auto srcLeafPtr = srcTree.root().probeLeaf(dstLeaf.origin());
+        if (srcLeafPtr) {
+            resultMask = srcLeafPtr->valueMask();
+            resultMask &= dstLeaf.valueMask();
+        }
+        else
+            resultMask.setOff();
+    }
+};
+
+template <typename BuildT, int64_t offset = 0>
+struct InjectPredicateToMaskFunctor
+{
+    // Populates a sidecar of leaf-enumerated bitmasks (associated with a destination grid)
+    // with those voxels that are also set to true in a boolean sidecar of values
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+
+    static constexpr int MaxThreadsPerBlock = 512;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    __device__
+    void operator()(
+        const typename nanovdb::NanoGrid<BuildT> *d_grid,
+        const bool *d_predicate,
+        typename nanovdb::Mask<3> *d_dstLeafMasks)
+    {
+        int leafID = blockIdx.x;
+        int threadID = threadIdx.x;
+
+        const auto &tree = d_grid->tree();
+        const auto &leaf = tree.template getFirstNode<0>()[leafID];
+        auto &resultMask = d_dstLeafMasks[leafID];
+        if (threadID < nanovdb::Mask<3>::WORD_COUNT)
+            resultMask.words()[threadID] = 0UL;
+        __syncthreads();
+        if (auto n = leaf.data()->getValue(threadID))
+            if (d_predicate[int64_t(n)+offset])
+                resultMask.setOnAtomic(threadID);
+    }
+};
+
+} // namespace cuda
+
+} // namespace nanovdb::util
+
+#endif // NANOVDB_UTIL_CUDA_INECTION_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Morphology.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Morphology.cuh
@@ -1,0 +1,935 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file Morphology.cuh
+
+    \author Efty Sifakis
+
+    \date March 17, 2025
+
+    \brief Implements various stages of morphology dilation operators
+*/
+
+#include <cub/cub.cuh>
+
+#include <nanovdb/util/MorphologyHelpers.h>
+
+#ifndef NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGY_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGY_CUH_HAS_BEEN_INCLUDED
+
+namespace nanovdb::util {
+
+namespace morphology {
+
+namespace cuda {
+
+template<class BuildT, tools::morphology::NearestNeighbors nnType>
+struct DilateInternalNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int WarpsPerBlock = MaxThreadsPerBlock >> 5;
+    static constexpr int SlicesPerLowerNode = 8;
+    static constexpr int LeafNodesPerSlice = 4096 / SlicesPerLowerNode;
+
+    void __device__
+    operator()(
+        const NanoGrid<BuildT> *srcGrid,
+        const NanoRoot<BuildT> *dilatedRoot,
+        void *upperMasks_,
+        void *lowerMasks_)
+    {
+        int tID = threadIdx.x;
+        int lowerID = blockIdx.x;
+        int sliceID = blockIdx.y;
+        int threadInWarpID = threadIdx.x & 0x1f;
+        int warpID = threadIdx.x >> 5;
+
+        using UpperMaskArrayT = Mask<5>*;
+        using LowerMaskArrayT = Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        using LowerMaskT = Mask<4>;
+        using LowerMaskStencilT = LowerMaskT (&)[3][3][3];
+        __shared__ uint64_t sOffsetMasksRaw[LowerMaskT::WORD_COUNT*27];
+        __shared__ uint64_t sNeighborMasksRaw[LowerMaskT::WORD_COUNT*27];
+        auto sOffsetMasks = reinterpret_cast<LowerMaskStencilT>(sOffsetMasksRaw[0]);
+        auto sNeighborMasks = reinterpret_cast<LowerMaskStencilT>(sNeighborMasksRaw[0]);
+
+        using WarpReduce = cub::WarpReduce<uint32_t>;
+        __shared__ typename WarpReduce::TempStorage temp_storage[WarpsPerBlock];
+
+        // TODO: Use all available threads
+        if (tID < LowerMaskT::WORD_COUNT)
+            for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+            for (int k = 0; k < 3; k++) {
+                const_cast<uint64_t*>(sOffsetMasks[i][j][k].words())[tID] = 0;
+                const_cast<uint64_t*>(sNeighborMasks[i][j][k].words())[tID] = 0; }
+        __syncthreads();
+
+        const auto& srcTree = srcGrid->tree();
+        const auto& lower = srcTree.template getFirstNode<1>()[lowerID];
+        auto& valueMask = const_cast<LowerMaskT&>(lower.valueMask());
+
+        for ( std::size_t jj = sliceID*LeafNodesPerSlice; jj < (sliceID+1)*LeafNodesPerSlice; jj += MaxThreadsPerBlock ) {
+
+            // Compute the mask of affected lower nodes in packed uint32_t format
+            uint32_t neighborMask = 0;
+            if ( lower.childMask().isOn(jj+tID) ) {
+                auto& leaf = *lower.data()->getChild(jj+tID);
+                neighborMask = neighborMaskStencil<nnType>(leaf.valueMask()); }
+
+            // Combine information from LeafNodes processed into an offset mask
+            for (int bit = 0; bit < 27; bit++) {
+                uint32_t mask = (neighborMask & (1u << bit)) ? (1u << threadInWarpID) : 0;
+                mask = WarpReduce(temp_storage[warpID]).Sum( mask ); // Really a bitwise or, but since the inputs
+                                                                     // have disjoint bits set, a sum is equivalent
+                auto warpMaskPtr = reinterpret_cast<uint32_t*>(sOffsetMasks[0][0][bit].words()) + (jj >> 5);
+                // Do we need to guard this ??
+                if (threadInWarpID == 0)
+                    warpMaskPtr[warpID] = mask;
+                __syncthreads(); }
+        }
+
+        // Compute neighbor masks from offset masks
+        // This version is optimized for 128 threads (and requires at least that many)
+        if (warpID == 0) {
+            // Contribution to mask of own lower node
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,1,1)
+            MaskShift<  1,  1,  1>( sOffsetMasks[0][0][0], sNeighborMasks[1][1][1] );
+            MaskShift<  1,  1,  0>( sOffsetMasks[0][0][1], sNeighborMasks[1][1][1] );
+            MaskShift<  1,  1, -1>( sOffsetMasks[0][0][2], sNeighborMasks[1][1][1] );
+            MaskShift<  1,  0,  1>( sOffsetMasks[0][1][0], sNeighborMasks[1][1][1] );
+            MaskShift<  1,  0,  0>( sOffsetMasks[0][1][1], sNeighborMasks[1][1][1] );
+            MaskShift<  1,  0, -1>( sOffsetMasks[0][1][2], sNeighborMasks[1][1][1] );
+            MaskShift<  1, -1,  1>( sOffsetMasks[0][2][0], sNeighborMasks[1][1][1] );
+            MaskShift<  1, -1,  0>( sOffsetMasks[0][2][1], sNeighborMasks[1][1][1] );
+            MaskShift<  1, -1, -1>( sOffsetMasks[0][2][2], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  1,  1>( sOffsetMasks[1][0][0], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  1,  0>( sOffsetMasks[1][0][1], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  1, -1>( sOffsetMasks[1][0][2], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  0,  1>( sOffsetMasks[1][1][0], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  0,  0>( sOffsetMasks[1][1][1], sNeighborMasks[1][1][1] );
+            MaskShift<  0,  0, -1>( sOffsetMasks[1][1][2], sNeighborMasks[1][1][1] );
+            MaskShift<  0, -1,  1>( sOffsetMasks[1][2][0], sNeighborMasks[1][1][1] );
+            MaskShift<  0, -1,  0>( sOffsetMasks[1][2][1], sNeighborMasks[1][1][1] );
+            MaskShift<  0, -1, -1>( sOffsetMasks[1][2][2], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  1,  1>( sOffsetMasks[2][0][0], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  1,  0>( sOffsetMasks[2][0][1], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  1, -1>( sOffsetMasks[2][0][2], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  0,  1>( sOffsetMasks[2][1][0], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  0,  0>( sOffsetMasks[2][1][1], sNeighborMasks[1][1][1] );
+            MaskShift< -1,  0, -1>( sOffsetMasks[2][1][2], sNeighborMasks[1][1][1] );
+            MaskShift< -1, -1,  1>( sOffsetMasks[2][2][0], sNeighborMasks[1][1][1] );
+            MaskShift< -1, -1,  0>( sOffsetMasks[2][2][1], sNeighborMasks[1][1][1] );
+            MaskShift< -1, -1, -1>( sOffsetMasks[2][2][2], sNeighborMasks[1][1][1] );
+            // Contribution to mask of lower node at offset (-1,-1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,-15,-15)
+            MaskShift<-15,-15,-15>( sOffsetMasks[0][0][0], sNeighborMasks[0][0][0] );
+            // Contribution to mask of lower node at offset (-1,-1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,-15,17)
+            MaskShift<-15,-15, 15>( sOffsetMasks[0][0][2], sNeighborMasks[0][0][2] );
+            // Contribution to mask of lower node at offset (-1,1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,17,-15)
+            MaskShift<-15, 15,-15>( sOffsetMasks[0][2][0], sNeighborMasks[0][2][0] );
+            // Contribution to mask of lower node at offset (-1,1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,17,17)
+            MaskShift<-15, 15, 15>( sOffsetMasks[0][2][2], sNeighborMasks[0][2][2] );
+            // Contribution to mask of lower node at offset (1,-1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,-15,-15)
+            MaskShift< 15,-15,-15>( sOffsetMasks[2][0][0], sNeighborMasks[2][0][0] );
+        }
+
+        if (warpID == 1) {
+            // Contribution to mask of lower node at offset (0,0,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,1,-15)
+            MaskShift<  1,  1,-15>( sOffsetMasks[0][0][0], sNeighborMasks[1][1][0] );
+            MaskShift<  1,  0,-15>( sOffsetMasks[0][1][0], sNeighborMasks[1][1][0] );
+            MaskShift<  1, -1,-15>( sOffsetMasks[0][2][0], sNeighborMasks[1][1][0] );
+            MaskShift<  0,  1,-15>( sOffsetMasks[1][0][0], sNeighborMasks[1][1][0] );
+            MaskShift<  0,  0,-15>( sOffsetMasks[1][1][0], sNeighborMasks[1][1][0] );
+            MaskShift<  0, -1,-15>( sOffsetMasks[1][2][0], sNeighborMasks[1][1][0] );
+            MaskShift< -1,  1,-15>( sOffsetMasks[2][0][0], sNeighborMasks[1][1][0] );
+            MaskShift< -1,  0,-15>( sOffsetMasks[2][1][0], sNeighborMasks[1][1][0] );
+            MaskShift< -1, -1,-15>( sOffsetMasks[2][2][0], sNeighborMasks[1][1][0] );
+            // Contribution to mask of lower node at offset (0,0,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,1,17)
+            MaskShift<  1,  1, 15>( sOffsetMasks[0][0][2], sNeighborMasks[1][1][2] );
+            MaskShift<  1,  0, 15>( sOffsetMasks[0][1][2], sNeighborMasks[1][1][2] );
+            MaskShift<  1, -1, 15>( sOffsetMasks[0][2][2], sNeighborMasks[1][1][2] );
+            MaskShift<  0,  1, 15>( sOffsetMasks[1][0][2], sNeighborMasks[1][1][2] );
+            MaskShift<  0,  0, 15>( sOffsetMasks[1][1][2], sNeighborMasks[1][1][2] );
+            MaskShift<  0, -1, 15>( sOffsetMasks[1][2][2], sNeighborMasks[1][1][2] );
+            MaskShift< -1,  1, 15>( sOffsetMasks[2][0][2], sNeighborMasks[1][1][2] );
+            MaskShift< -1,  0, 15>( sOffsetMasks[2][1][2], sNeighborMasks[1][1][2] );
+            MaskShift< -1, -1, 15>( sOffsetMasks[2][2][2], sNeighborMasks[1][1][2] );
+            // Contribution to mask of lower node at offset (-1,-1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,-15,1)
+            MaskShift<-15,-15,  1>( sOffsetMasks[0][0][0], sNeighborMasks[0][0][1] );
+            MaskShift<-15,-15,  0>( sOffsetMasks[0][0][1], sNeighborMasks[0][0][1] );
+            MaskShift<-15,-15, -1>( sOffsetMasks[0][0][2], sNeighborMasks[0][0][1] );
+            // Contribution to mask of lower node at offset (-1,1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,17,1)
+            MaskShift<-15, 15,  1>( sOffsetMasks[0][2][0], sNeighborMasks[0][2][1] );
+            MaskShift<-15, 15,  0>( sOffsetMasks[0][2][1], sNeighborMasks[0][2][1] );
+            MaskShift<-15, 15, -1>( sOffsetMasks[0][2][2], sNeighborMasks[0][2][1] );
+            // Contribution to mask of lower node at offset (1,-1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,-15,1)
+            MaskShift< 15,-15,  1>( sOffsetMasks[2][0][0], sNeighborMasks[2][0][1] );
+            MaskShift< 15,-15,  0>( sOffsetMasks[2][0][1], sNeighborMasks[2][0][1] );
+            MaskShift< 15,-15, -1>( sOffsetMasks[2][0][2], sNeighborMasks[2][0][1] );
+            // Contribution to mask of lower node at offset (1,1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,17,1)
+            MaskShift< 15, 15,  1>( sOffsetMasks[2][2][0], sNeighborMasks[2][2][1] );
+            MaskShift< 15, 15,  0>( sOffsetMasks[2][2][1], sNeighborMasks[2][2][1] );
+            MaskShift< 15, 15, -1>( sOffsetMasks[2][2][2], sNeighborMasks[2][2][1] );
+            // Contribution to mask of lower node at offset (1,-1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,-15,17)
+            MaskShift< 15,-15, 15>( sOffsetMasks[2][0][2], sNeighborMasks[2][0][2] );
+        }
+
+        if (warpID == 2) {
+            // Contribution to mask of lower node at offset (0,-1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,-15,1)
+            MaskShift<  1,-15,  1>( sOffsetMasks[0][0][0], sNeighborMasks[1][0][1] );
+            MaskShift<  1,-15,  0>( sOffsetMasks[0][0][1], sNeighborMasks[1][0][1] );
+            MaskShift<  1,-15, -1>( sOffsetMasks[0][0][2], sNeighborMasks[1][0][1] );
+            MaskShift<  0,-15,  1>( sOffsetMasks[1][0][0], sNeighborMasks[1][0][1] );
+            MaskShift<  0,-15,  0>( sOffsetMasks[1][0][1], sNeighborMasks[1][0][1] );
+            MaskShift<  0,-15, -1>( sOffsetMasks[1][0][2], sNeighborMasks[1][0][1] );
+            MaskShift< -1,-15,  1>( sOffsetMasks[2][0][0], sNeighborMasks[1][0][1] );
+            MaskShift< -1,-15,  0>( sOffsetMasks[2][0][1], sNeighborMasks[1][0][1] );
+            MaskShift< -1,-15, -1>( sOffsetMasks[2][0][2], sNeighborMasks[1][0][1] );
+            // Contribution to mask of lower node at offset (0,1,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,17,1)
+            MaskShift<  1, 15,  1>( sOffsetMasks[0][2][0], sNeighborMasks[1][2][1] );
+            MaskShift<  1, 15,  0>( sOffsetMasks[0][2][1], sNeighborMasks[1][2][1] );
+            MaskShift<  1, 15, -1>( sOffsetMasks[0][2][2], sNeighborMasks[1][2][1] );
+            MaskShift<  0, 15,  1>( sOffsetMasks[1][2][0], sNeighborMasks[1][2][1] );
+            MaskShift<  0, 15,  0>( sOffsetMasks[1][2][1], sNeighborMasks[1][2][1] );
+            MaskShift<  0, 15, -1>( sOffsetMasks[1][2][2], sNeighborMasks[1][2][1] );
+            MaskShift< -1, 15,  1>( sOffsetMasks[2][2][0], sNeighborMasks[1][2][1] );
+            MaskShift< -1, 15,  0>( sOffsetMasks[2][2][1], sNeighborMasks[1][2][1] );
+            MaskShift< -1, 15, -1>( sOffsetMasks[2][2][2], sNeighborMasks[1][2][1] );
+            // Contribution to mask of lower node at offset (-1,0,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,1,-15)
+            MaskShift<-15,  1,-15>( sOffsetMasks[0][0][0], sNeighborMasks[0][1][0] );
+            MaskShift<-15,  0,-15>( sOffsetMasks[0][1][0], sNeighborMasks[0][1][0] );
+            MaskShift<-15, -1,-15>( sOffsetMasks[0][2][0], sNeighborMasks[0][1][0] );
+            // Contribution to mask of lower node at offset (-1,0,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,1,17)
+            MaskShift<-15,  1, 15>( sOffsetMasks[0][0][2], sNeighborMasks[0][1][2] );
+            MaskShift<-15,  0, 15>( sOffsetMasks[0][1][2], sNeighborMasks[0][1][2] );
+            MaskShift<-15, -1, 15>( sOffsetMasks[0][2][2], sNeighborMasks[0][1][2] );
+            // Contribution to mask of lower node at offset (1,0,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,1,-15)
+            MaskShift< 15,  1,-15>( sOffsetMasks[2][0][0], sNeighborMasks[2][1][0] );
+            MaskShift< 15,  0,-15>( sOffsetMasks[2][1][0], sNeighborMasks[2][1][0] );
+            MaskShift< 15, -1,-15>( sOffsetMasks[2][2][0], sNeighborMasks[2][1][0] );
+            // Contribution to mask of lower node at offset (1,0,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,1,17)
+            MaskShift< 15,  1, 15>( sOffsetMasks[2][0][2], sNeighborMasks[2][1][2] );
+            MaskShift< 15,  0, 15>( sOffsetMasks[2][1][2], sNeighborMasks[2][1][2] );
+            MaskShift< 15, -1, 15>( sOffsetMasks[2][2][2], sNeighborMasks[2][1][2] );
+            // Contribution to mask of lower node at offset (1,1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,17,-15)
+            MaskShift< 15, 15,-15>( sOffsetMasks[2][2][0], sNeighborMasks[2][2][0] );
+        }
+
+        if (warpID == 3) {
+            // Contribution to mask of lower node at offset (-1,0,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (-15,1,1)
+            MaskShift<-15,  1,  1>( sOffsetMasks[0][0][0], sNeighborMasks[0][1][1] );
+            MaskShift<-15,  1,  0>( sOffsetMasks[0][0][1], sNeighborMasks[0][1][1] );
+            MaskShift<-15,  1, -1>( sOffsetMasks[0][0][2], sNeighborMasks[0][1][1] );
+            MaskShift<-15,  0,  1>( sOffsetMasks[0][1][0], sNeighborMasks[0][1][1] );
+            MaskShift<-15,  0,  0>( sOffsetMasks[0][1][1], sNeighborMasks[0][1][1] );
+            MaskShift<-15,  0, -1>( sOffsetMasks[0][1][2], sNeighborMasks[0][1][1] );
+            MaskShift<-15, -1,  1>( sOffsetMasks[0][2][0], sNeighborMasks[0][1][1] );
+            MaskShift<-15, -1,  0>( sOffsetMasks[0][2][1], sNeighborMasks[0][1][1] );
+            MaskShift<-15, -1, -1>( sOffsetMasks[0][2][2], sNeighborMasks[0][1][1] );
+            // Contribution to mask of lower node at offset (1,0,0)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,1,1)
+            MaskShift< 15,  1,  1>( sOffsetMasks[2][0][0], sNeighborMasks[2][1][1] );
+            MaskShift< 15,  1,  0>( sOffsetMasks[2][0][1], sNeighborMasks[2][1][1] );
+            MaskShift< 15,  1, -1>( sOffsetMasks[2][0][2], sNeighborMasks[2][1][1] );
+            MaskShift< 15,  0,  1>( sOffsetMasks[2][1][0], sNeighborMasks[2][1][1] );
+            MaskShift< 15,  0,  0>( sOffsetMasks[2][1][1], sNeighborMasks[2][1][1] );
+            MaskShift< 15,  0, -1>( sOffsetMasks[2][1][2], sNeighborMasks[2][1][1] );
+            MaskShift< 15, -1,  1>( sOffsetMasks[2][2][0], sNeighborMasks[2][1][1] );
+            MaskShift< 15, -1,  0>( sOffsetMasks[2][2][1], sNeighborMasks[2][1][1] );
+            MaskShift< 15, -1, -1>( sOffsetMasks[2][2][2], sNeighborMasks[2][1][1] );
+            // Contribution to mask of lower node at offset (0,-1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,-15,-15)
+            MaskShift<  1,-15,-15>( sOffsetMasks[0][0][0], sNeighborMasks[1][0][0] );
+            MaskShift<  0,-15,-15>( sOffsetMasks[1][0][0], sNeighborMasks[1][0][0] );
+            MaskShift< -1,-15,-15>( sOffsetMasks[2][0][0], sNeighborMasks[1][0][0] );
+            // Contribution to mask of lower node at offset (0,-1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,-15,17)
+            MaskShift<  1,-15, 15>( sOffsetMasks[0][0][2], sNeighborMasks[1][0][2] );
+            MaskShift<  0,-15, 15>( sOffsetMasks[1][0][2], sNeighborMasks[1][0][2] );
+            MaskShift< -1,-15, 15>( sOffsetMasks[2][0][2], sNeighborMasks[1][0][2] );
+            // Contribution to mask of lower node at offset (0,1,-1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,17,-15)
+            MaskShift<  1, 15,-15>( sOffsetMasks[0][2][0], sNeighborMasks[1][2][0] );
+            MaskShift<  0, 15,-15>( sOffsetMasks[1][2][0], sNeighborMasks[1][2][0] );
+            MaskShift< -1, 15,-15>( sOffsetMasks[2][2][0], sNeighborMasks[1][2][0] );
+            // Contribution to mask of lower node at offset (0,1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (1,17,17)
+            MaskShift<  1, 15, 15>( sOffsetMasks[0][2][2], sNeighborMasks[1][2][2] );
+            MaskShift<  0, 15, 15>( sOffsetMasks[1][2][2], sNeighborMasks[1][2][2] );
+            MaskShift< -1, 15, 15>( sOffsetMasks[2][2][2], sNeighborMasks[1][2][2] );
+            // Contribution to mask of lower node at offset (1,1,1)
+            // Arguments to MaskShift plus indices to sOffsetMasks add up to (17,17,17)
+            MaskShift< 15, 15, 15>( sOffsetMasks[2][2][2], sNeighborMasks[2][2][2] );
+        }
+
+        __syncthreads();
+
+        // Compose contributions to the lower-node masks of the dilated tree
+
+        for (int di = -1; di <= 1; di++)
+        for (int dj = -1; dj <= 1; dj++)
+        for (int dk = -1; dk <= 1; dk++) {
+            int neighborID = (di+1)*9+(dj+1)*3+dk+1;
+            if ((neighborID % WarpsPerBlock) == warpID) {
+                auto neighborOrigin = lower.origin().offsetBy(di*128,dj*128,dk*128);
+                auto upperChildIndex = NanoUpper<BuildT>::CoordToOffset(neighborOrigin);
+                auto& neighborMask = sNeighborMasks[di+1][dj+1][dk+1];
+
+                for (int tOffset = 0; tOffset < Mask<4>::WORD_COUNT; tOffset += 32) {
+                    unsigned long long int computedWord = neighborMask.words()[threadInWarpID+tOffset];
+                    if (computedWord) {
+                        auto dilatedTile = dilatedRoot->probeTile(neighborOrigin);
+                        uint64_t tileChildIndex =
+                            util::PtrDiff(dilatedTile, dilatedRoot->tile(0))
+                            / sizeof(NanoRoot<BuildT>::Tile); // TODO: consider some faster integer division? or a way to avoid this?
+                        auto& outputUpperMask = upperMasks[tileChildIndex];
+                        outputUpperMask.setOnAtomic(upperChildIndex);
+                        auto& outputLowerMask = lowerMasks[tileChildIndex][upperChildIndex];
+                        unsigned long long int *outputWord = reinterpret_cast<unsigned long long int*>(
+                            const_cast<uint64_t*>(&outputLowerMask.words()[threadInWarpID+tOffset]));
+                        atomicOr( outputWord, computedWord); } } } }
+        __syncthreads();
+    }
+
+};
+
+template<class BuildT>
+struct MergeInternalNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 64;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+
+    void __device__
+    operator()(
+        const NanoGrid<BuildT> *srcGrid,
+        const NanoRoot<BuildT> *mergedRoot,
+        void *upperMasks_,
+        void *lowerMasks_)
+    {
+        int tID = threadIdx.x;
+        int lowerID = blockIdx.x;
+
+        using UpperMaskArrayT = Mask<5>*;
+        using LowerMaskArrayT = Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        using LowerMaskT = Mask<4>;
+        const auto& srcTree = srcGrid->tree();
+        const auto& lower = srcTree.template getFirstNode<1>()[lowerID];
+        auto& valueMask = const_cast<LowerMaskT&>(lower.childMask());
+
+        auto mergedTile = mergedRoot->probeTile(lower.origin());
+        uint64_t tileIndex =
+            util::PtrDiff(mergedTile, mergedRoot->tile(0))
+            / sizeof(NanoRoot<BuildT>::Tile); // TODO: consider some faster integer division? or a way to avoid this?
+        auto upperChildIndex = NanoUpper<BuildT>::CoordToOffset(lower.origin());
+
+        auto& outputUpperMask = upperMasks[tileIndex];
+        auto& outputLowerMask = lowerMasks[tileIndex][upperChildIndex];
+        outputLowerMask.words()[tID] |= valueMask.words()[tID];
+        if (tID == 0)
+            outputUpperMask.setOnAtomic(upperChildIndex);
+        __syncthreads();
+    }
+
+};
+
+template <typename BuildT>
+struct PruneInternalNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        const NanoRoot<BuildT>* prunedRoot,
+        const Mask<3>* srcLeafMask,
+        void *upperMasks_,
+        void *lowerMasks_)
+    {
+        using UpperMaskArrayT = Mask<5>*;
+        using LowerMaskArrayT = Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        const auto& leafMask = srcLeafMask[srcLeafID];
+        bool retainLeaf = false;
+        for (uint32_t w = 0; w < Mask<3>::WORD_COUNT; w++)
+            if (srcLeaf.valueMask().words()[w] & leafMask.words()[w])
+                retainLeaf = true;
+        if (retainLeaf) {
+            auto upperChildIndex = NanoUpper<BuildT>::CoordToOffset(srcLeaf.origin());
+            auto lowerChildIndex = NanoLower<BuildT>::CoordToOffset(srcLeaf.origin());
+            auto prunedTile = prunedRoot->probeTile(srcLeaf.origin());
+            uint64_t tileChildIndex =
+                util::PtrDiff(prunedTile, prunedRoot->tile(0))
+                / sizeof(NanoRoot<BuildT>::Tile); // TODO: consider some faster integer division? or a way to avoid
+            auto& outputUpperMask = upperMasks[tileChildIndex];
+            outputUpperMask.setOnAtomic(upperChildIndex);
+            auto& outputLowerMask = lowerMasks[tileChildIndex][upperChildIndex];
+            outputLowerMask.setOnAtomic(lowerChildIndex); }
+    }
+};
+
+template <typename BuildT>
+struct RefineInternalNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        const NanoRoot<BuildT>* prunedRoot,
+        void *upperMasks_,
+        void *lowerMasks_)
+    {
+        using UpperMaskArrayT = Mask<5>*;
+        using LowerMaskArrayT = Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        uint64_t octantPresent[2][2][2] = {};
+        const auto words = srcLeaf.valueMask().words();
+        for (int w = 0; w < 8; w++) {
+            octantPresent[w>>2][0][0] |= ( words[w] & 0x000000000f0f0f0fUL );
+            octantPresent[w>>2][0][1] |= ( words[w] & 0x00000000f0f0f0f0UL );
+            octantPresent[w>>2][1][0] |= ( words[w] & 0x0f0f0f0f00000000UL );
+            octantPresent[w>>2][1][1] |= ( words[w] & 0xf0f0f0f000000000UL );
+        }
+        for (int di = 0; di < 2; di++)
+        for (int dj = 0; dj < 2; dj++)
+        for (int dk = 0; dk < 2; dk++) {
+            if (octantPresent[di][dj][dk]) {
+                const auto refinedOrigin = refineCoord(srcLeaf.origin()+nanovdb::Coord(di*4,dj*4,dk*4));
+                auto upperChildIndex = NanoUpper<BuildT>::CoordToOffset(refinedOrigin);
+                auto lowerChildIndex = NanoLower<BuildT>::CoordToOffset(refinedOrigin);
+                auto prunedTile = prunedRoot->probeTile(refinedOrigin);
+                uint64_t tileChildIndex =
+                    util::PtrDiff(prunedTile, prunedRoot->tile(0))
+                    / sizeof(NanoRoot<BuildT>::Tile); // TODO: consider some faster integer division? or a way to avoid
+                auto& outputUpperMask = upperMasks[tileChildIndex];
+                outputUpperMask.setOnAtomic(upperChildIndex);
+                auto& outputLowerMask = lowerMasks[tileChildIndex][upperChildIndex];
+                outputLowerMask.setOnAtomic(lowerChildIndex);
+            }
+        }
+    }
+};
+
+template <typename BuildT>
+struct CoarsenInternalNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        const NanoRoot<BuildT>* prunedRoot,
+        void *upperMasks_,
+        void *lowerMasks_)
+    {
+        using UpperMaskArrayT = Mask<5>*;
+        using LowerMaskArrayT = Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        if (!srcLeaf.valueMask().isOff()) { // Gratuitous check; leaf should have at least one active voxel
+            auto coarsenedOrigin = coarsenCoord(srcLeaf.origin()); // it's ok if this is not a multiple of 8
+            auto upperChildIndex = NanoUpper<BuildT>::CoordToOffset(coarsenedOrigin);
+            auto lowerChildIndex = NanoLower<BuildT>::CoordToOffset(coarsenedOrigin);
+            auto prunedTile = prunedRoot->probeTile(coarsenedOrigin);
+            uint64_t tileChildIndex =
+                util::PtrDiff(prunedTile, prunedRoot->tile(0))
+                / sizeof(NanoRoot<BuildT>::Tile); // TODO: consider some faster integer division? or a way to avoid
+            auto& outputUpperMask = upperMasks[tileChildIndex];
+            outputUpperMask.setOnAtomic(upperChildIndex);
+            auto& outputLowerMask = lowerMasks[tileChildIndex][upperChildIndex];
+            outputLowerMask.setOnAtomic(lowerChildIndex);
+        }
+    }
+};
+
+struct EnumerateNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 256;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int WarpsPerBlock = MaxThreadsPerBlock >> 5;
+    static constexpr int SlicesPerUpperNode = 256;
+    static constexpr int LowerNodesPerSlice = 32768 / SlicesPerUpperNode;
+
+    void __device__
+    operator()(
+        const void *upperMasks_,
+        const void *lowerMasks_,
+        uint32_t (*lowerCounts)[Mask<5>::SIZE],
+        uint32_t (*leafCounts)[Mask<5>::SIZE] )
+    {
+        int upperID = blockIdx.x;
+        int sliceID = blockIdx.y;
+        int threadInWarpID = threadIdx.x & 0x1f;
+        int warpID = threadIdx.x >> 5;
+
+        using UpperMaskArrayT = const Mask<5>*;
+        using LowerMaskArrayT = const Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        using WarpReduce = cub::WarpReduce<uint32_t>;
+        __shared__ typename WarpReduce::TempStorage temp_storage[WarpsPerBlock];
+
+        for ( std::size_t jj = sliceID*LowerNodesPerSlice + warpID; jj < (sliceID+1)*LowerNodesPerSlice; jj += WarpsPerBlock ) {
+            if (upperMasks[upperID].isOn(jj)) {
+                auto& lowerMask = lowerMasks[upperID][jj];
+                uint32_t lowerCountOn = util::countOn(lowerMask.words()[2*threadInWarpID]) + util::countOn(lowerMask.words()[2*threadInWarpID+1]);
+                lowerCountOn = WarpReduce(temp_storage[warpID]).Sum( lowerCountOn );
+                if (threadInWarpID == 0) { // Only lane 0 in each warp has the proper reduction sum
+                    lowerCounts[upperID][jj] = 1;
+                    leafCounts[upperID][jj] = lowerCountOn; } }
+            else if (threadInWarpID == 0) // TODO: do we need to guard this?
+                lowerCounts[upperID][jj] = leafCounts[upperID][jj] = 0;
+            __syncthreads(); }
+    }
+};
+
+template<typename BuildT>
+struct ProcessLowerNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 256;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int WarpsPerBlock = MaxThreadsPerBlock >> 5;
+    static constexpr int SlicesPerUpperNode = 256;
+    static constexpr int LowerNodesPerSlice = 32768 / SlicesPerUpperNode;
+
+    void __device__
+    operator()(
+        const void *upperMasks_,
+        const void *lowerMasks_,
+        const uint32_t *upperOffsets,
+        const uint32_t (*lowerOffsets)[Mask<5>::SIZE],
+        const uint32_t (*leafOffsets)[Mask<5>::SIZE],
+        NanoGrid<BuildT> *dstGrid,
+        uint32_t *lowerParents,
+        uint32_t *leafParents)
+    {
+        int dilatedTileID = blockIdx.x; // TODO: Rename this so it is not specific to dilation
+        int upperID = upperOffsets[dilatedTileID];
+        int sliceID = blockIdx.y;
+        int threadInWarpID = threadIdx.x & 0x1f;
+        int warpID = threadIdx.x >> 5;
+
+        using UpperMaskArrayT = const Mask<5>*;
+        using LowerMaskArrayT = const Mask<4>(*)[Mask<5>::SIZE];
+        auto upperMasks = static_cast<UpperMaskArrayT>(upperMasks_);
+        auto lowerMasks = static_cast<LowerMaskArrayT>(lowerMasks_);
+
+        using WarpScan = cub::WarpScan<uint32_t>;
+        __shared__ typename WarpScan::TempStorage temp_storage[WarpsPerBlock];
+
+        const auto& dstTree = dstGrid->tree();
+
+        if (upperOffsets[dilatedTileID+1] > upperID) { // check that this particular dilated tile is not empty, i.e. it exists in the tree
+            const auto upperOrigin = dstTree.root().tile(upperID)->origin();
+            auto& upper = const_cast<NanoUpper<BuildT>&>(dstTree.template getFirstNode<2>()[upperID]);
+            for ( int jj = sliceID*LowerNodesPerSlice + warpID; jj < (sliceID+1)*LowerNodesPerSlice; jj += WarpsPerBlock ) {
+                if (upperMasks[dilatedTileID].isOn(jj)) {
+                    const_cast<Mask<5>&>(upper.childMask()).setOnAtomic(jj);
+                    auto lowerID = lowerOffsets[dilatedTileID][jj];
+                    auto& lower = const_cast<NanoLower<BuildT>&>(dstTree.template getFirstNode<1>()[lowerID]);
+                    const auto lowerOrigin = upperOrigin + (NanoUpper<BuildT>::OffsetToLocalCoord(jj) << NanoUpper<BuildT>::ChildNodeType::TOTAL);
+                    upper.setChild(jj, &lower);
+                    lowerParents[lowerID] = upperID;
+
+                    auto lowerWords = lowerMasks[dilatedTileID][jj].words();
+                    lower.mChildMask.words()[2*threadInWarpID  ] = lowerWords[2*threadInWarpID  ];
+                    lower.mChildMask.words()[2*threadInWarpID+1] = lowerWords[2*threadInWarpID+1];
+                    uint32_t prefixSum = util::countOn(lowerWords[2*threadInWarpID]) + util::countOn(lowerWords[2*threadInWarpID+1]);
+                    WarpScan(temp_storage[warpID]).ExclusiveSum(prefixSum, prefixSum);
+                    for ( int wordID = 2*threadInWarpID; wordID <= 2*threadInWarpID+1; wordID++ )
+                        for ( int bitID = 0; bitID < 64; bitID++)
+                            if ( lowerWords[wordID] & (1UL << bitID) ) {
+                                int kk = (wordID << 6) + bitID;
+                                int leafID = leafOffsets[dilatedTileID][jj] + prefixSum;
+                                auto& leaf = const_cast<NanoLeaf<BuildT>&>(dstTree.template getFirstNode<0>()[leafID]);
+                                lower.setChild(kk, &leaf);
+                                leafParents[leafID] = lowerID;
+                                const auto leafOrigin = lowerOrigin + (NanoLower<BuildT>::OffsetToLocalCoord(kk) << NanoLower<BuildT>::ChildNodeType::TOTAL);
+                                leaf.mBBoxMin = leafOrigin; // To be further updated after the leaf-level dilation is complete
+                                prefixSum++;
+                                // TODO: Is this accurate? Any other flags that should be set?
+                                leaf.mFlags = (uint64_t)GridFlags::HasBBox; }
+                    lower.mBBox = CoordBBox(); // To be further updated after the leaf-level dilation is complete
+                    // TODO: Is this accurate? Any other flags that should be set?
+                    lower.mFlags = (uint64_t)GridFlags::HasBBox;
+                }
+            }
+        }
+    }
+};
+
+template<class BuildT, tools::morphology::NearestNeighbors nnType>
+struct DilateLeafNodesFunctor;
+
+template<class BuildT>
+struct DilateLeafNodesFunctor<BuildT, tools::morphology::NN_FACE>
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int SlicesPerLowerNode = 8;
+    static constexpr int LeafNodesPerSlice = 4096 / SlicesPerLowerNode;
+
+    __device__
+    void operator()(
+        const NanoGrid<BuildT> *srcGrid,
+        NanoGrid<BuildT> *dstGrid )
+    {
+        int tID = threadIdx.x;
+        int lowerID = blockIdx.x;
+        int sliceID = blockIdx.y;
+
+        const auto& srcTree = srcGrid->tree();
+        const auto& dstTree = dstGrid->tree();
+        const auto& dstLower = dstTree.template getFirstNode<1>()[lowerID];
+        for ( std::size_t jj = sliceID*LeafNodesPerSlice; jj < (sliceID+1)*LeafNodesPerSlice; jj += MaxThreadsPerBlock )
+            if ( dstLower.childMask().isOn(jj+tID) )
+            {
+                auto& dstLeaf = *dstLower.data()->getChild(jj+tID);
+                const auto leafOrigin = dstLeaf.origin();
+                auto originalLeafPtr  = srcTree.root().probeLeaf(leafOrigin);
+                uint64_t originalWords[8] = {}, dilatedWords[8]; // Keep these in registers
+                if (originalLeafPtr)
+                    for (int i = 0; i < 8; i++)
+                        originalWords[i] = originalLeafPtr->valueMask().words()[i];
+
+                for (int i = 0; i < 8; i++) {
+                    dilatedWords[i] = originalWords[i];
+                    // Activate voxel if the neighbor at stencil offset ( 1, 0, 0) is active
+                    if (i < 7) dilatedWords[i] |= originalWords[i+1];
+                    // Activate voxel if the neighbor at stencil offset (-1, 0, 0) is active
+                    if (i > 0) dilatedWords[i] |= originalWords[i-1];
+
+                    // Activate voxel if the neighbor at stencil offset ( 0, 1, 0) is active
+                    dilatedWords[i] |= (originalWords[i] & 0xffffffffffffff00UL) >> 8;
+                    // Activate voxel if the neighbor at stencil offset ( 0,-1, 0) is active
+                    dilatedWords[i] |= (originalWords[i] & 0x00ffffffffffffffUL) << 8;
+
+                    // Activate voxel if the neighbor at stencil offset ( 0, 0, 1) is active
+                    dilatedWords[i] |= (originalWords[i] & 0xfefefefefefefefeUL) >> 1;
+                    // Activate voxel if the neighbor at stencil offset ( 0, 0,-1) is active
+                    dilatedWords[i] |= (originalWords[i] & 0x7f7f7f7f7f7f7f7fUL) << 1;
+                }
+
+                auto leafPlusXPtr  = srcTree.root().probeLeaf(leafOrigin.offsetBy( 8, 0, 0));
+                auto leafMinusXPtr = srcTree.root().probeLeaf(leafOrigin.offsetBy(-8, 0, 0));
+                auto leafPlusYPtr  = srcTree.root().probeLeaf(leafOrigin.offsetBy( 0, 8, 0));
+                auto leafMinusYPtr = srcTree.root().probeLeaf(leafOrigin.offsetBy( 0,-8, 0));
+                auto leafPlusZPtr  = srcTree.root().probeLeaf(leafOrigin.offsetBy( 0, 0, 8));
+                auto leafMinusZPtr = srcTree.root().probeLeaf(leafOrigin.offsetBy( 0, 0,-8));
+
+                // Activate voxel if the neighbor at stencil offset ( 1, 0, 0) is active
+                if (leafPlusXPtr) dilatedWords[7] |= leafPlusXPtr->valueMask().words()[0];
+                // Activate voxel if the neighbor at stencil offset (-1, 0, 0) is active
+                if (leafMinusXPtr) dilatedWords[0] |= leafMinusXPtr->valueMask().words()[7];
+
+                // Activate voxel if the neighbor at stencil offset ( 0, 1, 0) is active
+                if (leafPlusYPtr)
+                    for (int i = 0; i < 8; i++)
+                        dilatedWords[i] |= (leafPlusYPtr->valueMask().words()[i] & 0x00000000000000ffUL) << 56;
+                // Activate voxel if the neighbor at stencil offset ( 0,-1, 0) is active
+                if (leafMinusYPtr)
+                    for (int i = 0; i < 8; i++)
+                        dilatedWords[i] |= (leafMinusYPtr->valueMask().words()[i] & 0xff00000000000000UL) >> 56;
+
+                // Activate voxel if the neighbor at stencil offset ( 0, 0, 1) is active
+                if (leafPlusZPtr)
+                    for (int i = 0; i < 8; i++)
+                        dilatedWords[i] |= (leafPlusZPtr->valueMask().words()[i] & 0x0101010101010101UL) << 7;
+                // Activate voxel if the neighbor at stencil offset ( 0, 0,-1) is active
+                if (leafMinusZPtr)
+                    for (int i = 0; i < 8; i++)
+                        dilatedWords[i] |= (leafMinusZPtr->valueMask().words()[i] & 0x8080808080808080UL) >> 7;
+
+                auto& dilatedMask = const_cast<Mask<3>&>(dstLeaf.valueMask());
+                for (int i = 0; i < 8; i++)
+                    dilatedMask.words()[i] = dilatedWords[i];
+            }
+        return;
+    }
+
+};
+
+template<class BuildT>
+struct DilateLeafNodesFunctor<BuildT, tools::morphology::NN_FACE_EDGE_VERTEX>
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int SlicesPerLowerNode = 8;
+    static constexpr int LeafNodesPerSlice = 4096 / SlicesPerLowerNode;
+
+    __device__
+    void operator()(
+        const NanoGrid<BuildT> *srcGrid,
+        NanoGrid<BuildT> *dstGrid)
+    {
+        int tID = threadIdx.x;
+        int lowerID = blockIdx.x;
+        int sliceID = blockIdx.y;
+
+        const auto& srcTree = srcGrid->tree();
+        const auto& dstTree = dstGrid->tree();
+        const auto& dstLower = dstTree.template getFirstNode<1>()[lowerID];
+        for ( std::size_t jj = sliceID*LeafNodesPerSlice; jj < (sliceID+1)*LeafNodesPerSlice; jj += MaxThreadsPerBlock )
+            if ( dstLower.childMask().isOn(jj+tID) )
+            {
+                auto& dstLeaf = *dstLower.data()->getChild(jj+tID);
+                const auto leafOrigin = dstLeaf.origin();
+
+                uint64_t originalWordsShifted[10][3][3] = {};
+                using WordStencilT = uint64_t (&)[10][3][3]; // Dimensions: [x-voxel offset][y-block offset][z-block offset]
+                auto& originalWords = reinterpret_cast<WordStencilT>(originalWordsShifted[1][1][1]); // Range: [-1,8][-1,1][-1,1]
+
+                for (int dBi = -1; dBi <= 1; dBi++)
+                for (int dBj = -1; dBj <= 1; dBj++)
+                for (int dBk = -1; dBk <= 1; dBk++) {
+                    auto neighborOrigin = leafOrigin.offsetBy( dBi*8, dBj*8, dBk*8);
+                    if (auto neighborLeafPtr = srcTree.root().probeLeaf(neighborOrigin)) {
+                        auto neighborWords = neighborLeafPtr->valueMask().words();
+                        if (dBi == -1)
+                            originalWords[-1][dBj][dBk] = neighborWords[7];
+                        else if (dBi == 1)
+                            originalWords[8][dBj][dBk] = neighborWords[0];
+                        else
+                            for (int i = 0; i < 8; i++)
+                                originalWords[i][dBj][dBk] = neighborWords[i]; } }
+                // Dilate along z-axis
+                for (int i = -1; i <= 8; i++)
+                for (int dBj = -1; dBj <= 1; dBj++) {
+                    uint64_t dilatedWord = originalWords[i][dBj][0];
+                    // Activate voxel if the neighbor at stencil offset ( 0, 0, 1) is active
+                    dilatedWord |= (originalWords[i][dBj][ 0] & 0xfefefefefefefefeUL) >> 1;
+                    dilatedWord |= (originalWords[i][dBj][ 1] & 0x0101010101010101UL) << 7;
+                    // Activate voxel if the neighbor at stencil offset ( 0, 0,-1) is active
+                    dilatedWord |= (originalWords[i][dBj][ 0] & 0x7f7f7f7f7f7f7f7fUL) << 1;
+                    dilatedWord |= (originalWords[i][dBj][-1] & 0x8080808080808080UL) >> 7;
+                    // Replace original with dilation result
+                    originalWords[i][dBj][0] = dilatedWord; }
+
+                // Dilate along y-axis
+                for (int i = -1; i <= 8; i++) {
+                    uint64_t dilatedWord = originalWords[i][0][0];
+                    // Activate voxel if the neighbor at stencil offset ( 0, 1, 0) is active
+                    dilatedWord |= (originalWords[i][ 0][0] & 0xffffffffffffff00UL) >> 8;
+                    dilatedWord |= (originalWords[i][ 1][0] & 0x00000000000000ffUL) << 56;
+                    // Activate voxel if the neighbor at stencil offset ( 0,-1, 0) is active
+                    dilatedWord |= (originalWords[i][ 0][0] & 0x00ffffffffffffffUL) << 8;
+                    dilatedWord |= (originalWords[i][-1][0] & 0xff00000000000000UL) >> 56;
+                    // Replace original with dilation result
+                    originalWords[i][0][0] = dilatedWord; }
+
+                // Dilate along x-axis
+                auto dilatedWords = const_cast<Mask<3>&>(dstLeaf.valueMask()).words();
+                for (int i = 0; i <= 7; i++)
+                    dilatedWords[i] = originalWords[i-1][0][0] | originalWords[i][0][0] | originalWords[i+1][0][0];
+            }
+        return;
+    }
+
+};
+
+template<class BuildT>
+struct MergeLeafNodesFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::operatorKernel
+    static constexpr int MaxThreadsPerBlock = 128;
+    static constexpr int MinBlocksPerMultiprocessor = 1;
+    static constexpr int SlicesPerLowerNode = 8;
+    static constexpr int LeafNodesPerSlice = 4096 / SlicesPerLowerNode;
+
+    __device__
+    void operator()(
+        const NanoGrid<BuildT> *srcGrid,
+        NanoGrid<BuildT> *dstGrid)
+    {
+        int tID = threadIdx.x;
+        int lowerID = blockIdx.x;
+        int sliceID = blockIdx.y;
+
+        const auto& srcTree = srcGrid->tree();
+        const auto& dstTree = dstGrid->tree();
+        const auto& srcLower = srcTree.template getFirstNode<1>()[lowerID];
+
+        for ( std::size_t jj = sliceID*LeafNodesPerSlice; jj < (sliceID+1)*LeafNodesPerSlice; jj += MaxThreadsPerBlock )
+            if ( srcLower.childMask().isOn(jj+tID) ) {
+                auto& srcLeaf = *srcLower.data()->getChild(jj+tID);
+                const auto leafOrigin = srcLeaf.origin();
+                auto dstLeafPtr = dstTree.root().probeLeaf(leafOrigin);
+                auto& dstMask = const_cast<Mask<3>&>(dstLeafPtr->valueMask());
+                for (uint32_t w = 0; w < nanovdb::Mask<3>::WORD_COUNT; w++)
+                    dstMask.words()[w] |= srcLeaf.valueMask().words()[w]; }
+    }
+
+};
+
+template <typename BuildT>
+struct PruneLeafMasksFunctor
+{
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        NanoGrid<BuildT>* dstGrid,
+        const Mask<3>* srcLeafMask)
+    {
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        auto leafPtr = dstGrid->tree().root().probeLeaf(srcLeaf.origin());
+        if (leafPtr) {
+            const_cast<Mask<3>&>(leafPtr->valueMask()) = srcLeaf.valueMask();
+            const_cast<Mask<3>&>(leafPtr->valueMask()) &= srcLeafMask[srcLeafID]; }
+    }
+};
+
+template <typename BuildT>
+struct RefineLeafMasksFunctor
+{
+    __device__
+    static inline void refineMask(Mask<3>& mask)
+    {
+        for (int w = 0; w < 4; w++) {
+            auto& word = mask.words()[w];
+            // Refine and duplicate along z-axis
+            word &= 0x000000000f0f0f0fUL;
+            word |= (word << 2);
+            word &= 0x0000000033333333UL;
+            word |= (word << 1);
+            word &= 0x0000000055555555UL;
+            word |= (word << 1);
+            // Refine and duplicate along y-axis
+            word |= (word << 16);
+            word &= 0x0000ffff0000ffffUL;
+            word |= (word << 8);
+            word &= 0x00ff00ff00ff00ffUL;
+            word |= (word << 8);
+        }
+        // Refine and duplicate along x-axis
+        for (int w = 7; w > 0; w--)
+            mask.words()[w] = mask.words()[w>>1];
+    }
+
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        NanoGrid<BuildT>* dstGrid)
+    {
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        const auto refinedBaseOrigin = srcLeaf.origin()+srcLeaf.origin();
+        for (int bi = 0; bi < 2; bi++)
+        for (int bj = 0; bj < 2; bj++)
+        for (int bk = 0; bk < 2; bk++) {
+            auto dstLeafPtr = dstGrid->tree().root().probeLeaf(refinedBaseOrigin.offsetBy(8*bi,8*bj,8*bk));
+            if (dstLeafPtr != nullptr) {
+                auto& refinedMask = const_cast<Mask<3>&>(dstLeafPtr->valueMask());
+                for (int w = 0; w < 4; w++)
+                    refinedMask.words()[w] = srcLeaf.valueMask().words()[w+bi*4] >> (4*bk+32*bj);
+                refineMask(refinedMask);
+            }
+        }
+    }
+};
+
+template <typename BuildT>
+struct CoarsenLeafMasksFunctor
+{
+    __device__
+    static inline void coarsenMask(Mask<3>& mask)
+    {
+        // Coarsen along x-axis
+        mask.words()[0] |= mask.words()[1];
+        mask.words()[1] = mask.words()[2] | mask.words()[3];
+        mask.words()[2] = mask.words()[4] | mask.words()[5];
+        mask.words()[3] = mask.words()[6] | mask.words()[7];
+        mask.words()[4] = mask.words()[5] = mask.words()[6] = mask.words()[7] = 0UL;
+
+        for (int w = 0; w < 4; w++) {
+            auto& word = mask.words()[w];
+            // Coarsen along y-axis
+            word |= (word >> 8);
+            word &= 0x00ff00ff00ff00ffUL;
+            word |= (word >> 8);
+            word &= 0x0000ffff0000ffffUL;
+            word |= (word >> 16);
+            word &= 0x00000000ffffffffUL;
+            // Coarsen along z-axis
+            word |= (word >> 1);
+            word &= 0x0000000055555555UL;
+            word |= (word >> 1);
+            word &= 0x0000000033333333UL;
+            word |= (word >> 2);
+            word &= 0x000000000f0f0f0fUL;
+        }
+    }
+
+    // Intended to be called via nanovdb::util::cuda::lambdaKernel
+    __device__
+    void operator()(
+        size_t srcLeafID,
+        const NanoGrid<BuildT>* srcGrid,
+        NanoGrid<BuildT>* dstGrid)
+    {
+        const auto& srcLeaf = srcGrid->tree().template getFirstNode<0>()[srcLeafID];
+        const auto coarsenedOrigin = coarsenCoord(srcLeaf.origin());
+        auto coarsenedMask = srcLeaf.valueMask();
+        coarsenMask(coarsenedMask);
+        int bi = (coarsenedOrigin[0] % 8 != 0);
+        int bj = (coarsenedOrigin[1] % 8 != 0);
+        int bk = (coarsenedOrigin[2] % 8 != 0);
+        auto dstLeafPtr = dstGrid->tree().root().probeLeaf(coarsenedOrigin);
+        auto& dstMask = const_cast<Mask<3>&>(dstLeafPtr->valueMask());
+        for (int w = 0; w < 4; w++)
+            atomicOr( (unsigned long long*)&dstMask.words()[w+4*bi], coarsenedMask.words()[w] << (4*bk+32*bj));
+    }
+};
+
+} // namespace cuda
+
+} // namespace morphology
+
+} // namespace nanovdb::util
+
+#endif // NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGY_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/MorphologyHelpers.cuh
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/MorphologyHelpers.cuh
@@ -1,0 +1,128 @@
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file MorphologyHelpers.cuh
+
+    \author Efty Sifakis
+
+    \date March 17, 2025
+
+    \brief This file implements helper methods used in morphology operations
+*/
+
+#ifndef NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGYHELPERS_CUH_HAS_BEEN_INCLUDED
+#define NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGYHELPERS_CUH_HAS_BEEN_INCLUDED
+
+namespace nanovdb::util {
+
+namespace morphology {
+
+namespace cuda {
+
+template<int di, int dj, int dk, bool combine = true>
+__device__
+void MaskShift( const nanovdb::Mask<4>& inMaskQ, nanovdb::Mask<4>& outMaskQ )
+{
+    static_assert( (di<=15) && (di >= -15) && (dj<=15) && (dj >= -15) && (dk<=15) && (dk >= -15) );
+    using WordBlockType = uint64_t [2][8][4];
+    auto inMask = reinterpret_cast<const WordBlockType&>(*inMaskQ.words());
+    auto outMask = reinterpret_cast<WordBlockType&>(*outMaskQ.words());
+
+    int threadInWarpID = threadIdx.x & 0x1f;
+    int ii = threadInWarpID >> 2;
+    int jj = threadInWarpID & 0x3;
+
+    uint64_t loWord = inMask[0][ii][jj];
+    uint64_t hiWord = inMask[1][ii][jj];
+
+    // Positive X-axis shift
+    if constexpr (di < 0) {
+        uint64_t loShfU = __shfl_up_sync  ( 0xffffffff, loWord,       ((-di)%8) << 2  );
+        uint64_t loShfD = __shfl_down_sync( 0xffffffff, loWord, 32 - (((-di)%8) << 2) );
+        uint64_t hiShfU = __shfl_up_sync  ( 0xffffffff, hiWord,       ((-di)%8) << 2  );
+
+        loWord = ((ii+di) >= 0) ? loShfU : 0UL;
+        if constexpr (di <= -8)
+            hiWord = ((ii+di+8) >= 0) ? loShfU : 0UL;
+        else
+            hiWord = ((ii+di) >= 0) ? hiShfU : loShfD;
+    }
+
+    // Negative X-axis shift
+    if constexpr (di > 0) {
+        uint64_t loShfD = __shfl_down_sync( 0xffffffff, loWord,       (di%8) << 2  );
+        uint64_t hiShfD = __shfl_down_sync( 0xffffffff, hiWord,       (di%8) << 2  );
+        uint64_t hiShfU = __shfl_up_sync  ( 0xffffffff, hiWord, 32 - ((di%8) << 2) );
+
+        if constexpr (di >= 8)
+            loWord = ((ii+di-16) < 0) ? hiShfD : 0UL;
+        else
+            loWord = ((ii+di-8) < 0) ? loShfD : hiShfU;
+        hiWord = ((ii+di) < 8) ? hiShfD : 0UL;
+    }
+
+    // Positive Y-axis shift
+    if constexpr (dj > 0)
+    {
+        int djj = dj >> 2, mjj = dj & 0x3;
+        uint64_t loLSW = __shfl_down_sync( 0xffffffff, loWord, djj ) >> ( 16 * mjj );
+        uint64_t hiLSW = __shfl_down_sync( 0xffffffff, hiWord, djj ) >> ( 16 * mjj );
+        if (jj + djj > 3) loLSW = hiLSW = 0UL;
+        uint64_t loMSW = __shfl_down_sync( 0xffffffff, loWord, djj + 1 ) << (64 - ( 16 * mjj ) );
+        uint64_t hiMSW = __shfl_down_sync( 0xffffffff, hiWord, djj + 1 ) << (64 - ( 16 * mjj ) );
+        if (jj + djj > 2) loMSW = hiMSW = 0UL;
+        loWord = loLSW | loMSW;
+        hiWord = hiLSW | hiMSW;
+    }
+
+    // Negative Y-axis shift
+    if constexpr (dj < 0)
+    {
+        int djj = (-dj) >> 2, mjj = (-dj) & 0x3;
+        uint64_t loLSW = __shfl_up_sync( 0xffffffff, loWord, djj ) << ( 16 * mjj );
+        uint64_t hiLSW = __shfl_up_sync( 0xffffffff, hiWord, djj ) << ( 16 * mjj );
+        if (jj - djj < 0) loLSW = hiLSW = 0UL;
+        uint64_t loMSW = __shfl_up_sync( 0xffffffff, loWord, djj + 1 ) >> (64 - ( 16 * mjj ) );
+        uint64_t hiMSW = __shfl_up_sync( 0xffffffff, hiWord, djj + 1 ) >> (64 - ( 16 * mjj ) );
+        if (jj - djj < 1) loMSW = hiMSW = 0UL;
+        loWord = loLSW | loMSW;
+        hiWord = hiLSW | hiMSW;
+    }
+
+    // Positive Z-axis shift
+    if constexpr (dk > 0)
+    {
+        constexpr uint64_t shortMask = (uint16_t(0xffff) >> dk) << dk;
+        static_assert( shortMask != 0xffffUL ); // Ensure the reciprocating shifts have not been optimized away
+        constexpr uint64_t mask = (shortMask << 48) | (shortMask << 32) | (shortMask << 16) | shortMask;
+        loWord = (loWord & mask) >> dk;
+        hiWord = (hiWord & mask) >> dk;
+    }
+
+    // Negative Z-axis shift
+    if constexpr (dk < 0)
+    {
+        // This awkward expression circumvents an inadvertent elimination by nvcc of the reciprocating shifts
+        constexpr uint64_t shortMask = (uint64_t(uint16_t(0xffff) << (-dk)) & 0x000000000000ffffUL) >> (-dk);
+        static_assert( shortMask != 0xffffUL ); // Ensure the reciprocating shifts have not been optimized away
+        constexpr uint64_t mask = (shortMask << 48) | (shortMask << 32) | (shortMask << 16) | shortMask;
+        loWord = (loWord & mask) << (-dk);
+        hiWord = (hiWord & mask) << (-dk);
+    }
+
+    if constexpr (combine) {
+        outMask[0][ii][jj] |= loWord;
+        outMask[1][ii][jj] |= hiWord; }
+    else {
+        outMask[0][ii][jj] = loWord;
+        outMask[1][ii][jj] = hiWord; }
+}
+
+} // namespace cuda
+
+} // namespace morphology
+
+} // namespace nanovdb::util
+
+#endif // NANOVDB_UTIL_MORPHOLOGY_CUDA_MORPHOLOGYHELPERS_CUH_HAS_BEEN_INCLUDED

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Timer.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Timer.h
@@ -21,12 +21,17 @@ namespace util::cuda {
 class Timer
 {
     cudaStream_t mStream{0};
-    cudaEvent_t mStart, mStop;
+    cudaEvent_t  mStart, mStop;
 
 public:
     /// @brief Default constructor
     /// @param stream CUDA stream to be timed (defaults to stream 0)
     /// @note Starts the timer
+    /// @warning @c cudaEventCreate creates the event for the current device
+    ///          and @c cudaEventRecord requires that the event and stream are
+    ///          associated with the same device. So it's important to call
+    ///          @c cudaSetDevice(device) so @c device matches the one used
+    ///          when @c stream was created.
     Timer(cudaStream_t stream = 0) : mStream(stream)
     {
         cudaEventCreate(&mStart);
@@ -38,6 +43,11 @@ public:
     /// @param msg string message to be printed when timer is started
     /// @param stream CUDA stream to be timed (defaults to stream 0)
     /// @param os output stream for the message above
+    /// @warning @c cudaEventCreate creates the event for the current device
+    ///          and @c cudaEventRecord requires that the event and stream are
+    ///          associated with the same device. So it's important to call
+    ///          @c cudaSetDevice(device) so @c device matches the one used
+    ///          when @c stream was created.
     Timer(const std::string &msg, cudaStream_t stream = 0, std::ostream& os = std::cerr)
         : mStream(stream)
     {
@@ -57,6 +67,10 @@ public:
     /// @brief Start the timer
     /// @param stream CUDA stream to be timed (defaults to stream 0)
     /// @param os output stream for the message above
+    /// @warning @c cudaEventRecord requires that the event and stream are
+    ///          associated with the same device. So it's important to call
+    ///          @c cudaSetDevice(device) so @c device matches the one used
+    ///          when @c mStream was created.
     void start() {cudaEventRecord(mStart, mStream);}
 
     /// @brief Start the timer
@@ -78,31 +92,66 @@ public:
         this->start();
     }
 
-    /// @brief elapsed time (since start) in miliseconds
-    /// @return elapsed time (since start) in miliseconds
-    float elapsed()
+    /// @warning @c cudaEventRecord requires that the event and stream are
+    ///          associated with the same device. So it's important to call
+    ///          @c cudaSetDevice(device) so it matches the device used when
+    ///          @c mStream was created.
+    inline void record()
     {
         cudaEventRecord(mStop, mStream);
         cudaEventSynchronize(mStop);
-        float diff = 0.0f;
-        cudaEventElapsedTime(&diff, mStart, mStop);
-        return diff;
     }
+
+    /// @brief Return the time in milliseconds since record was called
+    inline float milliseconds() const
+    {
+        float msec = 0.0f;
+        cudaEventElapsedTime(&msec, mStart, mStop);
+        return msec;
+    }
+
+    /// @brief elapsed time (since start) in miliseconds
+    /// @return elapsed time (since start) in miliseconds
+    inline float elapsed()
+    {
+        this->record();
+        return this->milliseconds();
+    }
+
+    /// @brief Prints the elapsed time in milliseconds to a stream
+    /// @param os output stream to print to
+    inline void print(std::ostream& os = std::cerr)
+    {
+        const float msec = this->milliseconds();
+        os << "completed in " << msec << " milliseconds" << std::endl;
+    }
+
+    /// @brief Prints a message followed by the elapsed time in milliseconds to a stream
+    /// @param msg message to print before the time
+    /// @param os stream to print to
+    inline void print(const char* msg, std::ostream& os = std::cerr)
+    {
+        os << msg;
+        this->print(os);
+    }
+
+    /// @brief Like the above method but with a std::string arguments
+    inline void print(const std::string &msg, std::ostream& os = std::cerr){this->print(msg.c_str(), os);}
 
     /// @brief stop the timer
     /// @param os output stream for the message above
-    void stop(std::ostream& os = std::cerr)
+    inline void stop(std::ostream& os = std::cerr)
     {
-        float diff = this->elapsed();
-        os << "completed in " << diff << " milliseconds" << std::endl;
+        this->record();
+        this->print(os);
     }
 
     /// @brief stop and start the timer
     /// @param msg string message to be printed when timer is started
     /// @warning Remember to call start before restart
-    void restart(const std::string &msg, std::ostream& os = std::cerr)
+    inline void restart(const std::string &msg, std::ostream& os = std::cerr)
     {
-        this->stop();
+        this->stop(os);
         this->start(msg, os);
     }
 };// Timer

--- a/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Util.h
+++ b/devices/rtx/external/nanovdb/include/nanovdb/util/cuda/Util.h
@@ -109,6 +109,45 @@ inline cudaError_t freeAsync(void* d_ptr, cudaStream_t stream){return cudaFreeAs
 
 #endif
 
+/// @brief Returns the device ID associated with the specified pointer
+/// @note  If @c ptr points to host memory (only) the return ID is either cudaInvalidDeviceId = -2 or cudaCpuDeviceId = -1
+inline int ptrToDevice(void *ptr)
+{
+    cudaPointerAttributes ptrAtt;
+    cudaCheck(cudaPointerGetAttributes(&ptrAtt, ptr));
+    return ptrAtt.device;
+}
+
+/// @brief Returns the ID of the current device
+inline int currentDevice()
+{
+    int current = cudaInvalidDeviceId;
+    cudaCheck(cudaGetDevice(&current));
+    assert(current != cudaInvalidDeviceId);
+    return current;
+}
+
+/// @brief Returns the number of devices with compute capability greater or equal to 1.0 that are available for execution
+inline int deviceCount()
+{
+    int deviceCount = 0;
+    cudaCheck(cudaGetDeviceCount(&deviceCount));
+    return deviceCount;
+}
+
+/// @brief Print information about a specific device
+/// @param device device ID for which information will be printed
+/// @param preMsg optional message printed before the device information
+/// @param file   Optional file stream to print to, e.g. stderr or stdout
+inline void printDevInfo(int device, const char *preMsg = nullptr, std::FILE* file = stderr)
+{
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+    if (preMsg) fprintf(file, "%s ", preMsg);
+    fprintf(file,"GPU #%d, named \"%s\", compute capability %d.%d, %zu GB of VRAM\n",
+            device, prop.name, prop.major, prop.minor, prop.totalGlobalMem >> 30);
+}
+
 /// @brief Simple (naive) implementation of a unique device pointer
 ///        using stream ordered memory allocation and deallocation.
 /// @tparam T Type of the device pointer
@@ -160,6 +199,43 @@ inline size_t blocksPerGrid(size_t numItems, size_t threadsPerBlock)
     return (numItems + threadsPerBlock - 1) / threadsPerBlock;
 }
 
+// CUDA 13.0 changes cudaMemPrefetchAsync and cudaMemPrefetch to use a cudaMemLocation as an argument as
+// opposed to an integer device id. This function provides compatibility by returning the corresponding
+// location in CUDA 13.0 and above while passing through the device in earlier versions.
+#if (CUDART_VERSION < 13000)
+/// @brief Compatbility wrapper for cudaMemAdvise/cudaMemAdvise
+inline cudaError_t memAdvise(const void* devPtr, size_t count, cudaMemoryAdvise advice, int device) {
+    return cudaMemAdvise(devPtr, count, advice, device);
+}
+
+/// @brief Compatbility wrapper for cudaMemPrefetchAsync/cudaMemPrefetchAsync
+inline cudaError_t memPrefetchAsync(const void* devPtr, size_t count, int dstDevice, cudaStream_t stream) {
+    return cudaMemPrefetchAsync(devPtr, count, dstDevice, stream);
+}
+#else
+/// @brief Helper function that converts a device id to a cudaMemLocation
+/// @param device Integer device id
+/// @return cudaMemLocation corresponding to the device id
+inline cudaMemLocation deviceToLocation(int device) {
+    if (device < cudaCpuDeviceId) {
+        return {cudaMemLocationTypeInvalid, device};
+    } else if (device == cudaCpuDeviceId) {
+        return {cudaMemLocationTypeHost, device};
+    } else {
+        return {cudaMemLocationTypeDevice, device};
+    }
+}
+
+/// @brief Compatbility wrapper for cudaMemAdvise/cudaMemAdvise
+inline cudaError_t memAdvise(const void* devPtr, size_t count, cudaMemoryAdvise advice, int device) {
+    return cudaMemAdvise(devPtr, count, advice, deviceToLocation(device));
+}
+
+/// @brief Compatbility wrapper for cudaMemPrefetchAsync/cudaMemPrefetchAsync
+inline cudaError_t memPrefetchAsync(const void* devPtr, size_t count, int dstDevice, cudaStream_t stream) {
+    return cudaMemPrefetchAsync(devPtr, count, deviceToLocation(dstDevice), 0u, stream);
+}
+#endif
 
 #if defined(__CUDACC__)// the following functions only run on the GPU!
 
@@ -172,6 +248,68 @@ __global__ void lambdaKernel(const size_t numItems, Func func, Args... args)
     if (tid >= numItems) return;
     func(tid, args...);
 }// util::cuda::lambdaKernel
+
+/// @brief Cuda kernel that launches device lambda functions with a tid offset
+/// @param numItems Problem size
+/// @param offset Offset for thread id
+template<typename Func, typename... Args>
+__global__ void offsetLambdaKernel(size_t numItems, unsigned int offset, Func func, Args... args)
+{
+    const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= numItems) return;
+    func(tid + offset, args...);
+}// util::cuda::offsetLambdaKernel
+
+/// @brief Cuda kernel that launches device operator functors with arbitrary arguments
+template<class Operator, typename... Args>
+__global__
+__launch_bounds__(Operator::MaxThreadsPerBlock, Operator::MinBlocksPerMultiprocessor)
+void operatorKernel(
+    Args... args)
+{
+    Operator op;
+    op( args... );
+}
+
+/// @brief Cuda kernel that launches device operator functors with arbitrary arguments, using dynamic shared memory
+template<class Operator, typename... Args>
+__global__
+__launch_bounds__(Operator::MaxThreadsPerBlock, Operator::MinBlocksPerMultiprocessor)
+void operatorKernelDynamic(Args... args)
+{
+    extern __shared__ char smem_buf[];
+    Operator op;
+    op( args..., smem_buf );
+}
+
+/// @brief Wrapper for launching a device operator that leverages dynamic shared memory, with a specified size
+/// @code
+/// struct MyFunctor
+/// {
+///     // These are passed to __launch_bounds__
+///     static constexpr int MaxThreadsPerBlock = <nThreads>
+///     static constexpr int MinBlocksPerMultiprocessor = 1;
+///
+///     struct SharedStorage {
+///         // Include whatever is needed in smem
+///     };
+///
+///     __device__
+///     void operator()(Args ... myArgs, char smem_buf[])
+///     { ... }
+/// };
+///
+/// dynamicSharedMemoryLauncher<MyFunctor>(nBlocks, sizeof(typename MyFunctor::SharedStorage), myArgs...);
+/// // smem_buff of size sizeof(MyFunctor::SharedStorage) will be automatically passed along
+/// @endcode
+template<class Operator, typename... Args>
+void dynamicSharedMemoryLauncher(const size_t numItems, const size_t smem_size, cudaStream_t stream, Args... args)
+{
+    cudaCheck(cudaFuncSetAttribute(operatorKernelDynamic<Operator, Args...>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,smem_size));
+    operatorKernelDynamic<Operator>
+        <<<numItems, Operator::MaxThreadsPerBlock, smem_size, stream>>>( args ... );
+}
 
 #endif// __CUDACC__
 

--- a/tsd/apps/tools/CMakeLists.txt
+++ b/tsd/apps/tools/CMakeLists.txt
@@ -19,3 +19,7 @@ project_link_libraries(
   tsd_ext_tinyexr_impl
   stb_image
 )
+
+project(tsdVolumeToNanoVDB)
+project_add_executable(tsdVolumeToNanoVDB.cpp)
+project_link_libraries(tsd_core tsd_io)

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -63,14 +63,14 @@ int main(int argc, const char *argv[])
 
     if (arg == "--undefined" || arg == "-u") {
       if (i + 1 >= argc) {
-        tsd::core::logError("Option {} requires a value", arg);
+        tsd::core::logError("Option %s requires a value", std::string(arg).c_str());
         printUsage(argv[0]);
         return 1;
       }
       try {
         undefinedValue = std::stof(std::string(argv[++i]));
       } catch (const std::exception &e) {
-        tsd::core::logError("Invalid undefined value: {}", argv[i]);
+        tsd::core::logError("Invalid undefined value: %s", std::string(argv[i] ).c_str());
         printUsage(argv[0]);
         return 1;
       }
@@ -94,7 +94,7 @@ int main(int argc, const char *argv[])
       } else if (precStr == "float32") {
         precision = tsd::io::VDBPrecision::Float32;
       } else {
-        tsd::core::logError("Unknown precision type: %s", precStr);
+        tsd::core::logError("Unknown precision type: %s", std::string(precStr).c_str());
         printUsage(argv[0]);
         return 1;
       }
@@ -106,12 +106,12 @@ int main(int argc, const char *argv[])
       } else if (!outputFile) {
         outputFile = std::string(arg);
       } else {
-        tsd::core::logError("Unexpected positional argument: {}", arg);
+        tsd::core::logError("Unexpected positional argument: %s", std::string(arg).c_str());
         printUsage(argv[0]);
         return 1;
       }
     } else {
-      tsd::core::logError("Unknown option: {}", arg);
+      tsd::core::logError("Unknown option: %s", std::string(arg).c_str());
       printUsage(argv[0]);
       return 1;
     }
@@ -125,7 +125,7 @@ int main(int argc, const char *argv[])
 
   tsd::core::setLogToStdout();
 
-  tsd::core::logStatus("Loading volume from: {}", *inputFile);
+  tsd::core::logStatus("Loading volume from: %s", inputFile->c_str());
 
   tsd::core::Scene scene;
   auto volume = tsd::io::import_volume(scene, inputFile->c_str());

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -19,11 +19,18 @@ static void printUsage(std::string_view progName)
   fmt::print(
       "  --undefined <value>     Skip voxels with this undefined value\n");
   fmt::print("  -u <value>              Short form of --undefined\n");
+  fmt::print(
+      "  --precision <type>      Quantization precision (fp4|fp8|fp16|fpn|half|float32)\n");
+  fmt::print("                          Default: fp16\n");
+  fmt::print("  -p <type>               Short form of --precision\n");
+  fmt::print("  --dither                Enable dithering for quantization\n");
+  fmt::print("  -d                      Short form of --dither\n");
   fmt::print("\n");
   fmt::print("Examples:\n");
   fmt::print("  {} input.raw output.vdb\n", progName);
   fmt::print("  {} --undefined 0.0 input.vti output.vdb\n", progName);
   fmt::print("  {} --undefined 0.5 input.mhd output.vdb\n", progName);
+  fmt::print("  {} --precision fp8 --dither input.mhd output.vdb\n", progName);
   fmt::print("\n");
   fmt::print("Supported input formats: .raw, .vti, .vtu, .mhd, .hdf5, .nvdb\n");
 }
@@ -47,6 +54,8 @@ int main(int argc, const char *argv[])
   std::optional<float> undefinedValue;
   std::optional<std::string> inputFile;
   std::optional<std::string> outputFile;
+  tsd::io::VDBPrecision precision = tsd::io::VDBPrecision::Fp16;
+  bool enableDithering = false;
 
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
@@ -65,7 +74,33 @@ int main(int argc, const char *argv[])
         printUsage(argv[0]);
         return 1;
       }
-    } else if (!arg.empty() && arg[0] != '-') {
+    } else if (arg == "--precision" || arg == "-p") {
+      if (i + 1 >= argc) {
+        tsd::core::logError("Option --precision requires a value");
+        printUsage(argv[0]);
+        return 1;
+      }
+      std::string_view precStr = argv[++i];
+      if (precStr == "fp4") {
+        precision = tsd::io::VDBPrecision::Fp4;
+      } else if (precStr == "fp8") {
+        precision = tsd::io::VDBPrecision::Fp8;
+      } else if (precStr == "fp16") {
+        precision = tsd::io::VDBPrecision::Fp16;
+      } else if (precStr == "fpn") {
+        precision = tsd::io::VDBPrecision::FpN;
+      } else if (precStr == "half") {
+        precision = tsd::io::VDBPrecision::Half;
+      } else if (precStr == "float32") {
+        precision = tsd::io::VDBPrecision::Float32;
+      } else {
+        tsd::core::logError("Unknown precision type: %s", precStr);
+        printUsage(argv[0]);
+        return 1;
+      }
+    } else if (arg == "--dither" || arg == "-d") {
+      enableDithering = true;
+    } else if (argv[i][0] != '-') {
       if (!inputFile) {
         inputFile = std::string(arg);
       } else if (!outputFile) {
@@ -111,7 +146,9 @@ int main(int argc, const char *argv[])
   tsd::io::export_StructuredRegularVolumeToVDB(spatialField,
       outputFile->c_str(),
       undefinedValue.has_value(),
-      undefinedValue.value_or(0.0f));
+      undefinedValue.value_or(0.0f),
+      precision,
+      enableDithering);
 
   tsd::core::logStatus("Export complete");
   return 0;

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -143,7 +143,7 @@ int main(int argc, const char *argv[])
     return 1;
   }
 
-  tsd::io::export_StructuredRegularVolumeToVDB(spatialField,
+  tsd::io::export_StructuredRegularVolumeToNanoVDB(spatialField,
       outputFile->c_str(),
       undefinedValue.has_value(),
       undefinedValue.value_or(0.0f),

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -1,0 +1,118 @@
+// Copyright 2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/format.h>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tsd/core/Logging.hpp>
+#include <tsd/core/scene/Scene.hpp>
+#include <tsd/io/importers.hpp>
+#include <tsd/io/serialization.hpp>
+
+static void printUsage(std::string_view progName)
+{
+  fmt::print("usage: {} [options] <input_volume> <output.vdb>\n", progName);
+  fmt::print("\n");
+  fmt::print("Options:\n");
+  fmt::print("  --help, -h              Show this help message\n");
+  fmt::print(
+      "  --undefined <value>     Skip voxels with this undefined value\n");
+  fmt::print("  -u <value>              Short form of --undefined\n");
+  fmt::print("\n");
+  fmt::print("Examples:\n");
+  fmt::print("  {} input.raw output.vdb\n", progName);
+  fmt::print("  {} --undefined 0.0 input.vti output.vdb\n", progName);
+  fmt::print("  {} --undefined 0.5 input.mhd output.vdb\n", progName);
+  fmt::print("\n");
+  fmt::print("Supported input formats: .raw, .vti, .vtu, .mhd, .hdf5, .nvdb\n");
+}
+
+int main(int argc, const char *argv[])
+{
+  if (argc < 2) {
+    printUsage(argv[0]);
+    return 1;
+  }
+
+  // Check for help flag
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg{argv[i]};
+    if (arg == "--help" || arg == "-h") {
+      printUsage(argv[0]);
+      return 0;
+    }
+  }
+
+  std::optional<float> undefinedValue;
+  std::optional<std::string> inputFile;
+  std::optional<std::string> outputFile;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view arg{argv[i]};
+
+    if (arg == "--undefined" || arg == "-u") {
+      if (i + 1 >= argc) {
+        tsd::core::logError("Option {} requires a value", arg);
+        printUsage(argv[0]);
+        return 1;
+      }
+      try {
+        undefinedValue = std::stof(std::string(argv[++i]));
+      } catch (const std::exception &e) {
+        tsd::core::logError("Invalid undefined value: {}", argv[i]);
+        printUsage(argv[0]);
+        return 1;
+      }
+    } else if (!arg.empty() && arg[0] != '-') {
+      if (!inputFile) {
+        inputFile = std::string(arg);
+      } else if (!outputFile) {
+        outputFile = std::string(arg);
+      } else {
+        tsd::core::logError("Unexpected positional argument: {}", arg);
+        printUsage(argv[0]);
+        return 1;
+      }
+    } else {
+      tsd::core::logError("Unknown option: {}", arg);
+      printUsage(argv[0]);
+      return 1;
+    }
+  }
+
+  if (!inputFile || !outputFile) {
+    tsd::core::logError("Missing required arguments");
+    printUsage(argv[0]);
+    return 1;
+  }
+
+  tsd::core::setLogToStdout();
+
+  tsd::core::logStatus("Loading volume from: {}", *inputFile);
+
+  tsd::core::Scene scene;
+  auto volume = tsd::io::import_volume(scene, inputFile->c_str());
+
+  if (!volume) {
+    tsd::core::logError("Failed to load volume");
+    return 1;
+  }
+
+  const auto *spatialField =
+      volume->parameterValueAsObject<tsd::core::SpatialField>("value");
+
+  if (!spatialField) {
+    tsd::core::logError("Volume does not have a spatial field");
+    return 1;
+  }
+
+  tsd::io::export_StructuredRegularVolumeToVDB(spatialField,
+      outputFile->c_str(),
+      undefinedValue.has_value(),
+      undefinedValue.value_or(0.0f));
+
+  tsd::core::logStatus("Export complete");
+  return 0;
+}

--- a/tsd/cmake/Findtsd_nanovdb.cmake
+++ b/tsd/cmake/Findtsd_nanovdb.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+if (TARGET tsd::nanovdb)
+  return()
+endif()
+
+add_library(tsd::nanovdb INTERFACE IMPORTED)
+target_include_directories(tsd::nanovdb
+INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/../../devices/rtx/external/nanovdb/include
+)

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -20,6 +20,7 @@
 namespace tsd::ui::imgui {
 struct BlockingTaskModal;
 struct ImportFileDialog;
+struct ExportNanoVDBFileDialog;
 } // namespace tsd::ui::imgui
 
 namespace tsd::app {
@@ -190,6 +191,7 @@ struct Windows
 {
   tsd::ui::imgui::BlockingTaskModal *taskModal{nullptr};
   tsd::ui::imgui::ImportFileDialog *importDialog{nullptr};
+  tsd::ui::imgui::ExportNanoVDBFileDialog *exportNanoVDBDialog{nullptr};
   float fontScale{1.f};
   float uiRounding{9.f};
 };

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -5,12 +5,12 @@
 
 // tsd_core
 #include "tsd/core/scene/Scene.hpp"
+#include "tsd/core/ColorMapUtil.hpp"
 // tsd_rendering
 #include "tsd/rendering/index/RenderIndex.hpp"
 #include "tsd/rendering/view/Manipulator.hpp"
 // std
 #include <map>
-#include <memory>
 #include <string>
 #include <utility>
 
@@ -57,6 +57,8 @@ enum class ImporterType
   XYZDP,
   VOLUME,
   TSD,
+  XF, // Special case for transfer function files
+      // Not an actual scene importer, but used to set transfer function from CLI
   BLANK, // Must be last import type before 'NONE'
   NONE
 };
@@ -80,7 +82,6 @@ struct CommandLineOptions
   ImporterType importerType{ImporterType::NONE};
   std::vector<std::string> libraryList;
   std::string secondaryViewportLibrary;
-  std::string transferFunctionFile;
   std::string cameraFile;
 };
 
@@ -148,6 +149,10 @@ struct CameraState
   tsd::rendering::Manipulator manipulator;
 };
 
+struct ImporterState {
+  core::TransferFunction transferFunction;
+};
+
 struct OfflineRenderSequenceConfig
 {
   struct FrameSettings
@@ -208,6 +213,7 @@ struct Core
   ANARIDeviceManager anari;
   LogState logging;
   CameraState view;
+  ImporterState importer;
   OfflineRenderSequenceConfig offline;
   Windows windows;
   Tasking jobs;
@@ -226,7 +232,6 @@ struct Core
       const std::vector<ImportFile> &files, tsd::core::LayerNodeRef root = {});
   void importAnimations(const std::vector<ImportAnimationFiles> &files,
       tsd::core::LayerNodeRef root = {});
-  void applyTransferFunctionToAllVolumes(const std::string &filepath);
 
   // Offline rendering //
 

--- a/tsd/src/tsd/core/ColorMapUtil.hpp
+++ b/tsd/src/tsd/core/ColorMapUtil.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+// tsd_math
 #include "tsd/core/TSDMath.hpp"
 // std
 #include <vector>
@@ -11,6 +12,12 @@ namespace tsd::core {
 
 using ColorPoint = float4;
 using OpacityPoint = float2;
+
+struct TransferFunction {
+  std::vector<ColorPoint> colorPoints;
+  std::vector<OpacityPoint> opacityPoints;
+  math::box1 range = {};
+};
 
 std::vector<math::float4> makeDefaultColorMap(size_t size = 256);
 

--- a/tsd/src/tsd/core/Logging.cpp
+++ b/tsd/src/tsd/core/Logging.cpp
@@ -101,6 +101,13 @@ void setLogToStdout()
   });
 }
 
+void setLogToStderr()
+{
+  setLoggingCallback([](LogLevel level, std::string message) {
+    fmt::print(stderr, "{}", message);
+  });
+}
+
 void setNoLogging()
 {
   g_loggingCallback = {};

--- a/tsd/src/tsd/core/Logging.hpp
+++ b/tsd/src/tsd/core/Logging.hpp
@@ -32,6 +32,7 @@ using LoggingCallback = std::function<void(LogLevel, std::string)>;
 
 void setLoggingCallback(LoggingCallback cb);
 void setLogToStdout();
+void setLogToStderr();
 void setNoLogging();
 
 } // namespace tsd::core

--- a/tsd/src/tsd/core/scene/objects/Volume.cpp
+++ b/tsd/src/tsd/core/scene/objects/Volume.cpp
@@ -52,6 +52,7 @@ anari::Object Volume::makeANARIObject(anari::Device d) const
 
 namespace tokens::volume {
 
+const Token structuredRegular = "structuredRegular";
 const Token transferFunction1D = "transferFunction1D";
 
 } // namespace tokens::volume

--- a/tsd/src/tsd/core/scene/objects/Volume.hpp
+++ b/tsd/src/tsd/core/scene/objects/Volume.hpp
@@ -25,6 +25,7 @@ using VolumeRef = ObjectPoolRef<Volume>;
 
 namespace tokens::volume {
 
+extern const Token structuredRegular;
 extern const Token transferFunction1D;
 
 } // namespace tokens::volume

--- a/tsd/src/tsd/io/CMakeLists.txt
+++ b/tsd/src/tsd/io/CMakeLists.txt
@@ -48,6 +48,7 @@ PRIVATE
   procedural/generate_noiseVolume.cpp
   procedural/generate_randomSpheres.cpp
   procedural/generate_rtow.cpp
+  procedural/generate_sphereSetVolume.cpp
   serialization/export_SceneToUSD.cpp
   serialization/serialization_datatree.cpp
 )

--- a/tsd/src/tsd/io/CMakeLists.txt
+++ b/tsd/src/tsd/io/CMakeLists.txt
@@ -49,6 +49,7 @@ PRIVATE
   procedural/generate_randomSpheres.cpp
   procedural/generate_rtow.cpp
   procedural/generate_sphereSetVolume.cpp
+  serialization/export_RegularVolumeToNanoVDB.cpp
   serialization/export_SceneToUSD.cpp
   serialization/serialization_datatree.cpp
 )
@@ -72,6 +73,11 @@ PRIVATE
   $<BUILD_INTERFACE:tsd_ext_tinygltf>
   $<BUILD_INTERFACE:stb_image>
 )
+
+# Always use nanovdb
+find_package(tsd_nanovdb MODULE REQUIRED)
+project_link_libraries(PRIVATE tsd::nanovdb)
+
 
 ## Setup optional dependencies ##
 

--- a/tsd/src/tsd/io/importers.hpp
+++ b/tsd/src/tsd/io/importers.hpp
@@ -25,7 +25,7 @@ void import_PDB(Scene &scene, const char *filename, LayerNodeRef location = {});
 void import_PLY(Scene &scene, const char *filename, LayerNodeRef location = {});
 void import_POINTSBIN(Scene &scene, const std::vector<std::string> &filepaths, LayerNodeRef location = {});
 void import_PT(Scene &scene, const char *filename, LayerNodeRef location = {});
-void import_SILO(Scene &scene, const char *filename, LayerNodeRef location = {});
+void import_SILO(Scene &scene, const char *filename, LayerNodeRef location);
 void import_SMESH(Scene &scene, const char *filename, LayerNodeRef location = {}, bool isAnimation = false);
 void import_SWC(Scene &scene, const char *filename, LayerNodeRef location = {});
 void import_TRK(Scene &scene, const char *filename, LayerNodeRef location = {});
@@ -39,6 +39,8 @@ SpatialFieldRef import_NVDB(Scene &scene, const char *filename);
 SpatialFieldRef import_MHD(Scene &scene, const char *filename);
 SpatialFieldRef import_VTI(Scene &scene, const char *filename);
 SpatialFieldRef import_VTU(Scene &scene, const char *filename);
+SpatialFieldRef import_SILO(Scene &scene, const char *filename);
+
 
 VolumeRef import_volume(Scene &scene,
     const char *filename,

--- a/tsd/src/tsd/io/importers.hpp
+++ b/tsd/src/tsd/io/importers.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "tsd/core/ColorMapUtil.hpp"
 #include "tsd/core/scene/Scene.hpp"
 
 namespace tsd::io {
@@ -29,8 +30,8 @@ void import_SILO(Scene &scene, const char *filename, LayerNodeRef location);
 void import_SMESH(Scene &scene, const char *filename, LayerNodeRef location = {}, bool isAnimation = false);
 void import_SWC(Scene &scene, const char *filename, LayerNodeRef location = {});
 void import_TRK(Scene &scene, const char *filename, LayerNodeRef location = {});
-void import_USD(Scene &scene, const char *filename, LayerNodeRef location = {}, bool useDefaultMaterial = false);
-void import_USD2(Scene &scene, const char *filename, LayerNodeRef location = {}, bool useDefaultMaterial = false);
+void import_USD(Scene &scene, const char *filename, LayerNodeRef location = {});
+void import_USD2(Scene &scene, const char *filename, LayerNodeRef location = {});
 void import_XYZDP(Scene &scene, const char *filename, LayerNodeRef location = {});
 
 SpatialFieldRef import_RAW(Scene &scene, const char *filename);
@@ -44,9 +45,12 @@ SpatialFieldRef import_SILO(Scene &scene, const char *filename);
 
 VolumeRef import_volume(Scene &scene,
     const char *filename,
-    LayerNodeRef location = {},
-    ArrayRef colors = {},
-    ArrayRef opacities = {});
+    LayerNodeRef location = {});
+
+VolumeRef import_volume(Scene &scene,
+    const char *filename,
+    const core::TransferFunction &transferFunction,
+    LayerNodeRef location = {});
 
 // clang-format on
 

--- a/tsd/src/tsd/io/importers/detail/importer_common.hpp
+++ b/tsd/src/tsd/io/importers/detail/importer_common.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "tsd/core/scene/Scene.hpp"
+#include "tsd/core/ColorMapUtil.hpp"
 // std
 #include <cstdio>
 #include <string>
@@ -28,6 +29,9 @@ tsd::core::SamplerRef importTexture(tsd::core::Scene &scene,
 
 tsd::core::SamplerRef makeDefaultColorMapSampler(
     tsd::core::Scene &scene, const tsd::math::float2 &range);
+
+// Transfer function import functions
+core::TransferFunction importTransferFunction(const std::string &filepath);
 
 bool calcTangentsForTriangleMesh(const tsd::math::uint3 *indices,
     const tsd::math::float3 *vertexPositions,

--- a/tsd/src/tsd/io/importers/import_USD.cpp
+++ b/tsd/src/tsd/io/importers/import_USD.cpp
@@ -939,9 +939,9 @@ static void import_usd_volume(Scene &scene,
         opacityControlPoints.data(),
         opacityControlPoints.size());
   } else {
-    // Create a default color map
+    // Use default transfer function if available, otherwise create default
     colorArray = scene.createArray(ANARI_FLOAT32_VEC4, 256);
-    colorArray->setData(makeDefaultColorMap(colorArray->size()).data());
+    colorArray->setData(makeDefaultColorMap(colorArray->size()));
   }
 
   volume->setParameterObject("color", *colorArray);
@@ -1192,7 +1192,7 @@ static void import_usd_prim_recursive(Scene &scene,
     LayerNodeRef parent,
     pxr::UsdGeomXformCache &xformCache,
     const std::string &basePath,
-    const pxr::GfMatrix4d &parentWorldXform = pxr::GfMatrix4d(1.0))
+    const pxr::GfMatrix4d &parentWorldXform)
 {
   // if (prim.IsPrototype()) return;
   if (prim.IsInstance()) {
@@ -1298,8 +1298,7 @@ static void import_usd_prim_recursive(Scene &scene,
 
 void import_USD(Scene &scene,
     const char *filepath,
-    LayerNodeRef location,
-    bool useDefaultMaterial)
+    LayerNodeRef location)
 {
   pxr::UsdStageRefPtr stage = pxr::UsdStage::Open(filepath);
   if (!stage) {
@@ -1330,15 +1329,14 @@ void import_USD(Scene &scene,
   for (pxr::UsdPrim const &prim : stage->Traverse()) {
     // if (prim.IsPrototype()) continue;
     if (prim.GetParent() && prim.GetParent().IsPseudoRoot()) {
-      import_usd_prim_recursive(scene, prim, usd_root, xformCache, basePath);
+      import_usd_prim_recursive(scene, prim, usd_root, xformCache, basePath, pxr::GfMatrix4d(1.0));
     }
   }
 }
 #else
 void import_USD(Scene &scene,
     const char *filepath,
-    LayerNodeRef location,
-    bool useDefaultMaterial)
+    LayerNodeRef location)
 {
   tsd::core::logError("[import_USD] USD not enabled in TSD build.");
 }

--- a/tsd/src/tsd/io/importers/import_USD2.cpp
+++ b/tsd/src/tsd/io/importers/import_USD2.cpp
@@ -32,8 +32,11 @@
 #endif
 // std
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
+
+using namespace std::string_view_literals;
 
 namespace tsd::io {
 
@@ -91,12 +94,12 @@ static void importUsdGeomCamera(Scene &scene, const pxr::UsdPrim &prim)
   float fStop = gfCamera.GetFStop();
 
   // Set ANARI camera parameters
-  if (cameraType == "perspective") {
+  if (cameraType == "perspective"sv) {
     camera->setParameter("fovy", fovVertical);
     camera->setParameter("aspect", horizontalAperture / verticalAperture);
   }
   // For orthographic camera, set height based on vertical aperture
-  else if (cameraType == "orthographic") {
+  else if (cameraType == "orthographic"sv) {
     camera->setParameter("height", verticalAperture);
     camera->setParameter("aspect", horizontalAperture / verticalAperture);
   }
@@ -232,8 +235,7 @@ static void importUsdGeomCamera(Scene &scene, const pxr::UsdPrim &prim)
 
 void import_USD2(Scene &scene,
     const char *filename,
-    LayerNodeRef location,
-    bool useDefaultMaterial)
+    LayerNodeRef location)
 {
   // Open the USD stage
   pxr::UsdStageRefPtr stage = pxr::UsdStage::Open(filename);

--- a/tsd/src/tsd/io/importers/import_USD2.cpp
+++ b/tsd/src/tsd/io/importers/import_USD2.cpp
@@ -395,8 +395,7 @@ void import_USD2(Scene &scene,
 #else
 void import_USD2(Scene &scene,
     const char *filename,
-    LayerNodeRef location,
-    bool useDefaultMaterial)
+    LayerNodeRef location)
 {
   tsd::core::logError("[import_USD2] USD not enabled in TSD build.");
 }

--- a/tsd/src/tsd/io/importers/import_volume.cpp
+++ b/tsd/src/tsd/io/importers/import_volume.cpp
@@ -34,6 +34,8 @@ VolumeRef import_volume(Scene &scene,
     field = import_VTU(scene, filepath);
   else if (ext == ".vti")
     field = import_VTI(scene, filepath);
+  else if (ext == ".silo" || ext == ".sil")
+    field = import_SILO(scene, filepath);
   else {
     logError("[import_volume] no loader for file type '%s'", ext.c_str());
     return {};

--- a/tsd/src/tsd/io/procedural.hpp
+++ b/tsd/src/tsd/io/procedural.hpp
@@ -20,6 +20,7 @@ void generate_monkey(Scene &scene, LayerNodeRef location = {});
 VolumeRef generate_noiseVolume(Scene &scene, LayerNodeRef location = {}, ArrayRef colors = {}, ArrayRef opacities = {});
 void generate_randomSpheres(Scene &scene, LayerNodeRef location = {}, bool useDefaultMaterial = false);
 void generate_rtow(Scene &scene, LayerNodeRef location = {});
+void generate_sphereSetVolume(Scene &scene, LayerNodeRef location = {});
 
 // clang-format on
 

--- a/tsd/src/tsd/io/procedural/generate_sphereSetVolume.cpp
+++ b/tsd/src/tsd/io/procedural/generate_sphereSetVolume.cpp
@@ -1,0 +1,103 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/core/ColorMapUtil.hpp"
+#include "tsd/io/procedural.hpp"
+// std
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace tsd::io {
+
+void generate_sphereSetVolume(Scene &scene, LayerNodeRef location)
+{
+  if (!location)
+    location = scene.defaultLayer()->root();
+
+  location = scene.insertChildTransformNode(location);
+
+  auto root = scene.insertChildNode(location);
+  (*root)->name() = "Sphere Set Volume";
+
+  constexpr int volumeSize = 512;
+  constexpr float voxelSpacing = 1.0f / volumeSize;
+  constexpr float3 volumeOrigin{-0.5f, -0.5f, -0.5f};
+  constexpr int maxColorValue = 255;
+  constexpr int colorMapSize = 256;
+
+  auto voxelArray =
+      scene.createArray(ANARI_UFIXED8, volumeSize, volumeSize, volumeSize);
+  auto *voxels = voxelArray->mapAs<uint8_t>();
+
+  // RBF centers and radii, normalized volume space [0,1]
+  struct RBFCenter
+  {
+    float3 center;
+    float radius; // support radius for RBF
+    float weight; // contribution weight
+  };
+
+  constexpr std::array<RBFCenter, 5> rbfCenters{{
+      {{0.3f, 0.3f, 0.3f}, 0.15f, 1.0f},
+      {{0.7f, 0.7f, 0.3f}, 0.12f, 1.0f},
+      {{0.5f, 0.5f, 0.7f}, 0.18f, 1.0f},
+      {{0.2f, 0.7f, 0.6f}, 0.10f, 1.0f},
+      {{0.8f, 0.3f, 0.7f}, 0.14f, 1.0f},
+  }};
+
+  // Gaussian RBF kernel: exp(-r²/h²)
+  constexpr auto gaussianRBF = [](float r, float h) noexcept -> float {
+    if (r >= h)
+      return 0.0f;
+    const float normalized = r / h;
+    return std::exp(-normalized * normalized);
+  };
+
+  // Fill volume using RBF interpolation
+  for (int z = 0; z < volumeSize; ++z) {
+    for (int y = 0; y < volumeSize; ++y) {
+      for (int x = 0; x < volumeSize; ++x) {
+        const float3 pos{x / float(volumeSize),
+            y / float(volumeSize),
+            z / float(volumeSize)};
+
+        // Sum contributions from all RBF centers
+        float value = 0.0f;
+        for (const auto &rbf : rbfCenters) {
+          const float dist = linalg::length(pos - rbf.center);
+          value += rbf.weight * gaussianRBF(dist, rbf.radius);
+        }
+
+        // Clamp to [0, 1] range
+        value = std::clamp(value, 0.0f, 1.0f);
+
+        const size_t idx = z * volumeSize * volumeSize + y * volumeSize + x;
+        voxels[idx] = static_cast<uint8_t>(value * maxColorValue);
+      }
+    }
+  }
+
+  voxelArray->unmap();
+
+  // Create spatial field //
+  auto field = scene.createObject<SpatialField>(
+      tokens::spatial_field::structuredRegular);
+  field->setName("sphere_set_volume_field");
+  field->setParameter("origin", volumeOrigin);
+  field->setParameter(
+      "spacing", float3{voxelSpacing, voxelSpacing, voxelSpacing});
+  field->setParameterObject("data", *voxelArray);
+
+  // Create TransferFunction1D volume //
+  auto colorArray = scene.createArray(ANARI_FLOAT32_VEC4, colorMapSize);
+  colorArray->setData(makeDefaultColorMap(colorMapSize).data());
+
+  auto [volumeNode, volume] = scene.insertNewChildObjectNode<Volume>(
+      root, tokens::volume::transferFunction1D);
+  volume->setName("slice_test_volume");
+  volume->setParameterObject("color", *colorArray);
+  volume->setParameterObject("value", *field);
+}
+
+} // namespace tsd::io

--- a/tsd/src/tsd/io/serialization.hpp
+++ b/tsd/src/tsd/io/serialization.hpp
@@ -36,9 +36,7 @@ void load_Scene(Scene &scene, const char *filename);
 void load_Scene(Scene &scene, core::DataNode &root);
 
 void export_SceneToUSD(Scene &scene, const char *filename);
-
-void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField, std::string_view outputFilename, bool useUndefinedValue, float undefinedValue);
-void export_StructuredRegularVolumeToVDB(const SpatialField* spatialField, std::string_view outputFilename, bool useUndefinedValue = false, float undefinedValue = std::numeric_limits<float>::quiet_NaN(), VDBPrecision precision = VDBPrecision::Fp16, bool enableDithering = false);
+void export_StructuredRegularVolumeToNanoVDB(const SpatialField* spatialField, std::string_view outputFilename, bool useUndefinedValue = false, float undefinedValue = std::numeric_limits<float>::quiet_NaN(), VDBPrecision precision = VDBPrecision::Fp16, bool enableDithering = false);
 
 // clang-format on
 

--- a/tsd/src/tsd/io/serialization.hpp
+++ b/tsd/src/tsd/io/serialization.hpp
@@ -11,6 +11,17 @@ namespace tsd::io {
 
 using namespace tsd::core;
 
+// NanoVDB quantization precision options
+enum class VDBPrecision
+{
+  Float32, // No quantization (32-bit float)
+  Fp4, // 4-bit fixed-point (~8:1 compression)
+  Fp8, // 8-bit fixed-point (~4:1 compression)
+  Fp16, // 16-bit fixed-point (~2:1 compression)
+  FpN, // Variable bit fixed-point
+  Half // IEEE 16-bit half float
+};
+
 // clang-format off
 
 void objectToNode(const Object &obj, core::DataNode &node);
@@ -25,7 +36,9 @@ void load_Scene(Scene &scene, const char *filename);
 void load_Scene(Scene &scene, core::DataNode &root);
 
 void export_SceneToUSD(Scene &scene, const char *filename);
+
 void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField, std::string_view outputFilename, bool useUndefinedValue, float undefinedValue);
+void export_StructuredRegularVolumeToVDB(const SpatialField* spatialField, std::string_view outputFilename, bool useUndefinedValue = false, float undefinedValue = std::numeric_limits<float>::quiet_NaN(), VDBPrecision precision = VDBPrecision::Fp16, bool enableDithering = false);
 
 // clang-format on
 

--- a/tsd/src/tsd/io/serialization.hpp
+++ b/tsd/src/tsd/io/serialization.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <limits>
 #include "tsd/core/scene/Scene.hpp"
 #include "tsd/rendering/view/Manipulator.hpp"
 
@@ -24,6 +25,7 @@ void load_Scene(Scene &scene, const char *filename);
 void load_Scene(Scene &scene, core::DataNode &root);
 
 void export_SceneToUSD(Scene &scene, const char *filename);
+void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField, std::string_view outputFilename, bool useUndefinedValue, float undefinedValue);
 
 // clang-format on
 

--- a/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
+++ b/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
@@ -1,0 +1,240 @@
+// Copyright 2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// tsd
+#include "tsd/core/Logging.hpp"
+#include "tsd/core/scene/objects/Array.hpp"
+#include "tsd/core/scene/objects/SpatialField.hpp"
+#include "tsd/io/serialization.hpp"
+
+// nanovdb
+#include <nanovdb/io/IO.h>
+#include <nanovdb/tools/CreateNanoGrid.h>
+#include <nanovdb/tools/GridBuilder.h>
+#include <nanovdb/tools/GridStats.h>
+
+// std
+#include <array>
+#include <string_view>
+#include <type_traits>
+
+namespace tsd::io {
+
+template <typename T>
+void doExportStructuredRegularVolumeToNanoVDB(const T *data,
+    math::float3 origin,
+    math::float3 spacing,
+    math::int3 dims,
+    std::string_view outputFilename,
+    bool useUndefinedValue,
+    float undefinedValue)
+{
+  tsd::core::logStatus(
+      "[export_StructuredRegularVolumeToVDB] Volume dimensions: %u x %u x %u",
+      dims.x,
+      dims.y,
+      dims.z);
+  tsd::core::logStatus(
+      "[export_StructuredRegularVolumeToVDB] Origin: (%.3f, %.3f, %.3f)",
+      origin.x,
+      origin.y,
+      origin.z);
+  tsd::core::logStatus(
+      "[export_StructuredRegularVolumeToVDB] Spacing: (%.3f, %.3f, %.3f)",
+      spacing.x,
+      spacing.y,
+      spacing.z);
+
+  // Adjust spacing to account node vs cell storage
+  spacing = spacing / dims * (dims - math::int3(1));
+
+  // Create a build grid, for now, always float. We can always use nanovdb
+  // toolings to convert later if needed.
+  auto buildGrid = std::make_shared<nanovdb::tools::build::Grid<float>>(
+      useUndefinedValue ? undefinedValue : 0.0f);
+
+  // Grid location. Seems that NanoVDB expects uniform voxel size, so we use the
+  // average of spacing components This is ugly, but I am not sure how to deal
+  // with that otherwise. Basically, the final built grid is supposed to handle
+  // the non-uniform spacing, but the builder API only allows for uniform
+  // scaling. Let's assume this works and force getting the transform as
+  // mutable.
+  constexpr size_t MatrixSize = 3;
+  const std::array<std::array<double, MatrixSize>, MatrixSize> mat = {{
+      {{spacing.x, 0.0, 0.0}}, // row 0
+      {{0.0, spacing.y, 0.0}}, // row 1
+      {{0.0, 0.0, spacing.z}} // row 2
+  }};
+  const std::array<std::array<double, MatrixSize>, MatrixSize> invMat = {{
+      {{1.0 / spacing.x, 0.0, 0.0}}, // row 0
+      {{0.0, 1.0 / spacing.y, 0.0}}, // row 1
+      {{0.0, 0.0, 1.0 / spacing.z}} // row 2
+  }};
+  const std::array<double, MatrixSize> trans = {origin.x, origin.y, origin.z};
+  const_cast<nanovdb::Map &>(buildGrid->map())
+      .set(mat.data(), invMat.data(), trans.data());
+
+  auto acc = buildGrid->getAccessor();
+  for (size_t k = 0; k < static_cast<size_t>(dims.z); ++k) {
+    for (size_t j = 0; j < static_cast<size_t>(dims.y); ++j) {
+      for (size_t i = 0; i < static_cast<size_t>(dims.x); ++i) {
+        const size_t idx = i + j * dims.x + k * dims.x * dims.y;
+        double value = data[idx];
+
+        if constexpr (std::is_integral_v<T>) {
+          // For integral types, normalize and consider signedness
+          if constexpr (std::is_signed_v<T>) {
+            if (value >= 0) {
+              value = value / std::numeric_limits<T>::max();
+            } else {
+              value = value / -std::numeric_limits<T>::min();
+            }
+          } else {
+            value = value / std::numeric_limits<T>::max();
+          }
+        }
+
+        if (useUndefinedValue && std::abs(value - undefinedValue) < 1e-6) {
+          continue;
+        }
+
+        const nanovdb::Coord ijk(
+            static_cast<int>(i), static_cast<int>(j), static_cast<int>(k));
+        acc.setValue(ijk, value);
+      }
+    }
+  }
+
+  // Convert build grid to NanoVDB grid
+  auto handle = nanovdb::tools::createNanoGrid(
+      *buildGrid, nanovdb::tools::StatsMode::All, nanovdb::CheckMode::Full);
+
+  const auto activeVoxelsCount = handle.gridMetaData()->activeVoxelCount();
+  const auto totalVoxelsCount = handle.gridMetaData()->indexBBox().volume();
+
+  tsd::core::logStatus(
+      "[export_StructuredRegularVolumeToVDB] Populated grid: %zu/%zu active voxels",
+      activeVoxelsCount,
+      totalVoxelsCount);
+
+  if (!handle) {
+    tsd::core::logError(
+        "[export_StructuredRegularVolumeToVDB] Failed to create NanoVDB grid.");
+    return;
+  }
+
+  // Write to file
+  try {
+    nanovdb::io::writeGrid(
+        std::string(outputFilename).c_str(), handle, nanovdb::io::Codec::NONE);
+    tsd::core::logStatus(
+        "[export_StructuredRegularVolumeToVDB] Successfully wrote VDB file: %s",
+        std::string(outputFilename).c_str());
+  } catch (const std::exception &e) {
+    tsd::core::logError(
+        "[export_StructuredRegularVolumeToVDB] Failed to write VDB file: %s",
+        e.what());
+  }
+}
+
+void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField,
+    std::string_view outputFilename,
+    bool useUndefinedValue,
+    float undefinedValue)
+{
+  if (spatialField->subtype() != tokens::volume::structuredRegular) {
+    tsd::core::logError(
+        "[export_StructuredRegularVolumeToVDB] Not a structuredRegularVolume.");
+    return;
+  }
+
+  tsd::core::logStatus("Exporting StructuredRegularVolume to VDB file: %s",
+      std::string(outputFilename).c_str());
+
+  // Get volume data array object
+  const auto *volumeData = spatialField->parameterValueAsObject<Array>("data");
+  if (!volumeData) {
+    tsd::core::logError(
+        "[export_StructuredRegularVolumeToVDB] No volume data found.");
+    return;
+  }
+
+  const auto dims =
+      math::int3(volumeData->dim(0), volumeData->dim(1), volumeData->dim(2));
+
+  const auto origin =
+      spatialField->parameterValueAs<math::float3>("origin").value_or(
+          math::float3(0.0f));
+  const auto spacing =
+      spatialField->parameterValueAs<math::float3>("spacing").value_or(
+          math::float3(1.0f));
+
+  switch (volumeData->elementType()) {
+  case ANARI_UFIXED8:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const uint8_t *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  case ANARI_FIXED8:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const int8_t *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  case ANARI_UFIXED16:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const uint16_t *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  case ANARI_FIXED16:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const int16_t *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  case ANARI_FLOAT32:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const float *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  case ANARI_FLOAT64:
+    doExportStructuredRegularVolumeToNanoVDB(
+        reinterpret_cast<const double *>(volumeData->data()),
+        origin,
+        spacing,
+        dims,
+        outputFilename,
+        useUndefinedValue,
+        undefinedValue);
+    break;
+  default:
+    tsd::core::logError(
+        "[export_StructuredRegularVolumeToVDB] Volume data is not of a supported float type.");
+    return;
+  }
+}
+
+} // namespace tsd::io

--- a/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
+++ b/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
@@ -32,17 +32,17 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     bool enableDithering)
 {
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Volume dimensions: %u x %u x %u",
+      "[export_StructuredRegularVolumeToNanoVDB] Volume dimensions: %u x %u x %u",
       dims.x,
       dims.y,
       dims.z);
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Origin: (%.3f, %.3f, %.3f)",
+      "[export_StructuredRegularVolumeToNanoVDB] Origin: (%.3f, %.3f, %.3f)",
       origin.x,
       origin.y,
       origin.z);
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Spacing: (%.3f, %.3f, %.3f)",
+      "[export_StructuredRegularVolumeToNanoVDB] Spacing: (%.3f, %.3f, %.3f)",
       spacing.x,
       spacing.y,
       spacing.z);
@@ -138,7 +138,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
       : 0.0f;
 
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Active voxels: %zu/%zu (%.1f%% inactive cell compression)",
+      "[export_StructuredRegularVolumeToNanoVDB] Active voxels: %zu/%zu (%.1f%% inactive cell compression)",
       activeVoxelsCount,
       totalVoxelsCount,
       inactiveCellCompression * 100.0f);
@@ -148,11 +148,11 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
   // Validate quantization choice
   if (precision == VDBPrecision::Fp4 && valueRange > 30.0f) {
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToVDB] Fp4 quantization with value range %.2f may introduce significant error (recommended < 30.0)",
+        "[export_StructuredRegularVolumeToNanoVDB] Fp4 quantization with value range %.2f may introduce significant error (recommended < 30.0)",
         valueRange);
   } else if (precision == VDBPrecision::Fp8 && valueRange > 500.0f) {
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToVDB] Fp8 quantization with value range %.2f may introduce significant error (recommended < 500.0)",
+        "[export_StructuredRegularVolumeToNanoVDB] Fp8 quantization with value range %.2f may introduce significant error (recommended < 500.0)",
         valueRange);
   }
 
@@ -199,7 +199,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     break;
   case VDBPrecision::Half:
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToVDB] Half precision not supported in this NanoVDB build, using Fp16 instead");
+        "[export_StructuredRegularVolumeToNanoVDB] Half precision not supported in this NanoVDB build, using Fp16 instead");
     handle = nanovdb::tools::createNanoGrid<nanovdb::tools::build::Grid<float>,
         nanovdb::Fp16>(*buildGrid,
         nanovdb::tools::StatsMode::All,
@@ -211,7 +211,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
 
   if (!handle) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToVDB] Failed to create NanoVDB grid.");
+        "[export_StructuredRegularVolumeToNanoVDB] Failed to create NanoVDB grid.");
     return;
   }
 
@@ -225,12 +225,12 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
       : 0.0f;
 
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Quantization compression: %.1f%% (%.2f MB -> %.2f MB)",
+      "[export_StructuredRegularVolumeToNanoVDB] Quantization compression: %.1f%% (%.2f MB -> %.2f MB)",
       quantizationCompression * 100.0f,
       uncompressedActiveSize / (1024.0f * 1024.0f),
       finalSize / (1024.0f * 1024.0f));
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToVDB] Total compression: %.1f%% (%.2f MB -> %.2f MB)",
+      "[export_StructuredRegularVolumeToNanoVDB] Total compression: %.1f%% (%.2f MB -> %.2f MB)",
       totalCompression * 100.0f,
       uncompressedSize / (1024.0f * 1024.0f),
       finalSize / (1024.0f * 1024.0f));
@@ -240,16 +240,16 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     nanovdb::io::writeGrid(
         std::string(outputFilename).c_str(), handle, nanovdb::io::Codec::NONE);
     tsd::core::logStatus(
-        "[export_StructuredRegularVolumeToVDB] Successfully wrote VDB file: %s",
+        "[export_StructuredRegularVolumeToNanoVDB] Successfully wrote VDB file: %s",
         std::string(outputFilename).c_str());
   } catch (const std::exception &e) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToVDB] Failed to write VDB file: %s",
+        "[export_StructuredRegularVolumeToNanoVDB] Failed to write VDB file: %s",
         e.what());
   }
 }
 
-void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField,
+void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
     std::string_view outputFilename,
     bool useUndefinedValue,
     float undefinedValue,
@@ -258,7 +258,7 @@ void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField,
 {
   if (spatialField->subtype() != tokens::volume::structuredRegular) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToVDB] Not a structuredRegularVolume.");
+        "[export_StructuredRegularVolumeToNanoVDB] Not a structuredRegularVolume.");
     return;
   }
 
@@ -269,7 +269,7 @@ void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField,
   const auto *volumeData = spatialField->parameterValueAsObject<Array>("data");
   if (!volumeData) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToVDB] No volume data found.");
+        "[export_StructuredRegularVolumeToNanoVDB] No volume data found.");
     return;
   }
 
@@ -358,7 +358,7 @@ void export_StructuredRegularVolumeToVDB(const SpatialField *spatialField,
     break;
   default:
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToVDB] Volume data is not of a supported float type.");
+        "[export_StructuredRegularVolumeToNanoVDB] Volume data is not of a supported float type.");
     return;
   }
 }

--- a/tsd/src/tsd/ui/imgui/Application.cpp
+++ b/tsd/src/tsd/ui/imgui/Application.cpp
@@ -90,9 +90,11 @@ anari_viewer::WindowArray Application::setupWindows()
   m_taskModal = std::make_unique<BlockingTaskModal>(this);
   m_offlineRenderModal = std::make_unique<OfflineRenderModal>(this);
   m_fileDialog = std::make_unique<ImportFileDialog>(this);
+  m_exportNanoVDBFileDialog = std::make_unique<ExportNanoVDBFileDialog>(this);
 
   m_core.windows.taskModal = m_taskModal.get();
   m_core.windows.importDialog = m_fileDialog.get();
+  m_core.windows.exportNanoVDBDialog = m_exportNanoVDBFileDialog.get();
 
   m_applicationName = SDL_GetWindowTitle(sdlWindow());
   updateWindowTitle();
@@ -143,7 +145,12 @@ void Application::uiFrameStart()
     modalActive = true;
   }
 
-  // Handle app shortcuts //
+    // Handle app shortcuts //
+    if (m_exportNanoVDBFileDialog->visible()) {
+      m_exportNanoVDBFileDialog->renderUI();
+      modalActive = true;
+    }
+
 
   if (ImGui::IsKeyChordPressed(ImGuiMod_Ctrl | ImGuiMod_Shift | ImGuiKey_S))
     this->getFilenameFromDialog(m_filenameToSaveNextFrame, true);

--- a/tsd/src/tsd/ui/imgui/Application.h
+++ b/tsd/src/tsd/ui/imgui/Application.h
@@ -5,6 +5,7 @@
 
 #include "modals/AppSettingsDialog.h"
 #include "modals/BlockingTaskModal.h"
+#include "modals/ExportNanoVDBFileDialog.h"
 #include "modals/OfflineRenderModal.h"
 #include "modals/ImportFileDialog.h"
 // tsd_app
@@ -66,6 +67,7 @@ class Application : public anari_viewer::Application
   std::unique_ptr<BlockingTaskModal> m_taskModal;
   std::unique_ptr<OfflineRenderModal> m_offlineRenderModal;
   std::unique_ptr<ImportFileDialog> m_fileDialog;
+  std::unique_ptr<ExportNanoVDBFileDialog> m_exportNanoVDBFileDialog;
 
   tsd::core::DataTree m_settings;
 

--- a/tsd/src/tsd/ui/imgui/CMakeLists.txt
+++ b/tsd/src/tsd/ui/imgui/CMakeLists.txt
@@ -10,6 +10,7 @@ project_add_library(OBJECT)
 project_sources(PRIVATE
   modals/AppSettingsDialog.cpp
   modals/BlockingTaskModal.cpp
+  modals/ExportNanoVDBFileDialog.cpp
   modals/OfflineRenderModal.cpp
   modals/ImportFileDialog.cpp
   modals/Modal.cpp

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -69,6 +69,22 @@ void ExportNanoVDBFileDialog::buildUI()
 
   ImGui::NewLine();
 
+  // Quantization precision
+  const char* precisionItems[] = {
+    "Float32 (no compression)",
+    "Fp4 (~8:1 compression)",
+    "Fp8 (~4:1 compression)",
+    "Fp16 (~2:1 compression, recommended)",
+    "FpN (variable compression)",
+    "Half (IEEE 16-bit)"
+  };
+  ImGui::Combo("Precision", &m_precisionIndex, precisionItems, 6);
+
+  // Dithering
+  ImGui::Checkbox("Enable dithering", &m_enableDithering);
+
+  ImGui::NewLine();
+
   ImGuiIO &io = ImGui::GetIO();
   if (ImGui::Button("cancel") || ImGui::IsKeyDown(ImGuiKey_Escape))
     this->hide();
@@ -99,11 +115,25 @@ void ExportNanoVDBFileDialog::buildUI()
         return;
       }
 
+      // Convert precision index to enum
+      io::VDBPrecision precision;
+      switch (m_precisionIndex) {
+        case 0: precision = io::VDBPrecision::Float32; break;
+        case 1: precision = io::VDBPrecision::Fp4; break;
+        case 2: precision = io::VDBPrecision::Fp8; break;
+        case 3: precision = io::VDBPrecision::Fp16; break;
+        case 4: precision = io::VDBPrecision::FpN; break;
+        case 5: precision = io::VDBPrecision::Half; break;
+        default: precision = io::VDBPrecision::Fp16; break;
+      }
+
       io::export_StructuredRegularVolumeToVDB(
           static_cast<const core::SpatialField*>(spatialFieldObject),
           m_filename.c_str(),
           m_enableUndefinedValue,
-          m_undefinedValue);
+          m_undefinedValue,
+          precision,
+          m_enableDithering);
     };
 
     if (!appCore()->windows.taskModal)

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -8,9 +8,8 @@
 
 // tsd_io
 #include "tsd/io/serialization.hpp"
-#include "tsd/io/serialization.hpp"
 
-//tsd ui
+// tsd ui
 #include "tsd/ui/imgui/Application.h"
 #include "tsd/ui/imgui/modals/BlockingTaskModal.h"
 
@@ -62,7 +61,7 @@ void ExportNanoVDBFileDialog::buildUI()
 
   // Undefined value parameters
   ImGui::Checkbox("Enable undefined value", &m_enableUndefinedValue);
-  
+
   if (m_enableUndefinedValue) {
     ImGui::InputFloat("Undefined value", &m_undefinedValue);
   }
@@ -70,14 +69,12 @@ void ExportNanoVDBFileDialog::buildUI()
   ImGui::NewLine();
 
   // Quantization precision
-  const char* precisionItems[] = {
-    "Float32 (no compression)",
-    "Fp4 (~8:1 compression)",
-    "Fp8 (~4:1 compression)",
-    "Fp16 (~2:1 compression, recommended)",
-    "FpN (variable compression)",
-    "Half (IEEE 16-bit)"
-  };
+  const char *precisionItems[] = {"Float32 (no compression)",
+      "Fp4 (~8:1 compression)",
+      "Fp8 (~4:1 compression)",
+      "Fp16 (~2:1 compression, recommended)",
+      "FpN (variable compression)",
+      "Half (IEEE 16-bit)"};
   ImGui::Combo("Precision", &m_precisionIndex, precisionItems, 6);
 
   // Dithering
@@ -98,18 +95,22 @@ void ExportNanoVDBFileDialog::buildUI()
       auto *core = appCore();
       auto selectedObject = core->tsd.selectedObject;
       if (!selectedObject) {
-        core::logError("[ExportVDBFileDialog] No object selected for VDB export.");
+        core::logError(
+            "[ExportVDBFileDialog] No object selected for VDB export.");
         return;
       }
 
-      if (selectedObject->subtype() != core::tokens::volume::transferFunction1D) {
+      if (selectedObject->subtype()
+          != core::tokens::volume::transferFunction1D) {
         core::logError(
             "[ExportVDBFileDialog] Selected object is not a transfer function 1D.");
         return;
       }
       auto spatialFieldObject = selectedObject->parameterValueAsObject("value");
 
-      if (!spatialFieldObject || !spatialFieldObject->subtype() == core::tokens::volume::structuredRegular) {
+      if (!spatialFieldObject
+          || !spatialFieldObject->subtype()
+              == core::tokens::volume::structuredRegular) {
         core::logError(
             "[ExportVDBFileDialog] Selected TransferFunction1D does not reference a structured regular volume.");
         return;
@@ -118,17 +119,31 @@ void ExportNanoVDBFileDialog::buildUI()
       // Convert precision index to enum
       io::VDBPrecision precision;
       switch (m_precisionIndex) {
-        case 0: precision = io::VDBPrecision::Float32; break;
-        case 1: precision = io::VDBPrecision::Fp4; break;
-        case 2: precision = io::VDBPrecision::Fp8; break;
-        case 3: precision = io::VDBPrecision::Fp16; break;
-        case 4: precision = io::VDBPrecision::FpN; break;
-        case 5: precision = io::VDBPrecision::Half; break;
-        default: precision = io::VDBPrecision::Fp16; break;
+      case 0:
+        precision = io::VDBPrecision::Float32;
+        break;
+      case 1:
+        precision = io::VDBPrecision::Fp4;
+        break;
+      case 2:
+        precision = io::VDBPrecision::Fp8;
+        break;
+      case 3:
+        precision = io::VDBPrecision::Fp16;
+        break;
+      case 4:
+        precision = io::VDBPrecision::FpN;
+        break;
+      case 5:
+        precision = io::VDBPrecision::Half;
+        break;
+      default:
+        precision = io::VDBPrecision::Fp16;
+        break;
       }
 
-      io::export_StructuredRegularVolumeToVDB(
-          static_cast<const core::SpatialField*>(spatialFieldObject),
+      io::export_StructuredRegularVolumeToNanoVDB(
+          static_cast<const core::SpatialField *>(spatialFieldObject),
           m_filename.c_str(),
           m_enableUndefinedValue,
           m_undefinedValue,

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -1,0 +1,118 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ExportNanoVDBFileDialog.h"
+
+// tsd
+#include "tsd/core/Logging.hpp"
+
+// tsd_io
+#include "tsd/io/serialization.hpp"
+#include "tsd/io/serialization.hpp"
+
+//tsd ui
+#include "tsd/ui/imgui/Application.h"
+#include "tsd/ui/imgui/modals/BlockingTaskModal.h"
+
+// imgui
+#include "imgui.h"
+
+namespace tsd::ui::imgui {
+
+ExportNanoVDBFileDialog::ExportNanoVDBFileDialog(Application *app)
+    : Modal(app, "ExportVDBFileDialog")
+{}
+
+ExportNanoVDBFileDialog::~ExportNanoVDBFileDialog() = default;
+
+void ExportNanoVDBFileDialog::buildUI()
+{
+  constexpr int MAX_LENGTH = 2000;
+  m_filename.reserve(MAX_LENGTH);
+
+  static std::string outPath;
+  if (ImGui::Button("...")) {
+    outPath.clear();
+    m_app->getFilenameFromDialog(outPath, true);
+  }
+
+  if (!outPath.empty()) {
+    m_filename = outPath;
+    outPath.clear();
+  }
+
+  ImGui::SameLine();
+
+  auto text_cb = [](ImGuiInputTextCallbackData *cbd) {
+    auto &fname = *(std::string *)cbd->UserData;
+    fname.resize(cbd->BufTextLen);
+    return 0;
+  };
+
+  ImGui::InputText("##filename",
+      m_filename.data(),
+      MAX_LENGTH,
+      ImGuiInputTextFlags_CallbackEdit,
+      text_cb,
+      &m_filename);
+
+  //////////
+
+  ImGui::NewLine();
+
+  // Undefined value parameters
+  ImGui::Checkbox("Enable undefined value", &m_enableUndefinedValue);
+  
+  if (m_enableUndefinedValue) {
+    ImGui::InputFloat("Undefined value", &m_undefinedValue);
+  }
+
+  ImGui::NewLine();
+
+  ImGuiIO &io = ImGui::GetIO();
+  if (ImGui::Button("cancel") || ImGui::IsKeyDown(ImGuiKey_Escape))
+    this->hide();
+
+  ImGui::SameLine();
+
+  if (ImGui::Button("export")) {
+    this->hide();
+
+    auto doExport = [&]() {
+      auto *core = appCore();
+      auto selectedObject = core->tsd.selectedObject;
+      if (!selectedObject) {
+        core::logError("[ExportVDBFileDialog] No object selected for VDB export.");
+        return;
+      }
+
+      if (selectedObject->subtype() != core::tokens::volume::transferFunction1D) {
+        core::logError(
+            "[ExportVDBFileDialog] Selected object is not a transfer function 1D.");
+        return;
+      }
+      auto spatialFieldObject = selectedObject->parameterValueAsObject("value");
+
+      if (!spatialFieldObject || !spatialFieldObject->subtype() == core::tokens::volume::structuredRegular) {
+        core::logError(
+            "[ExportVDBFileDialog] Selected TransferFunction1D does not reference a structured regular volume.");
+        return;
+      }
+
+      io::export_StructuredRegularVolumeToVDB(
+          static_cast<const core::SpatialField*>(spatialFieldObject),
+          m_filename.c_str(),
+          m_enableUndefinedValue,
+          m_undefinedValue);
+    };
+
+    if (!appCore()->windows.taskModal)
+      doExport();
+    else {
+      appCore()->windows.taskModal->activate(
+          doExport, "Please Wait: Importing Data...");
+    }
+  }
+}
+
+} // namespace tsd::ui::imgui

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -109,8 +109,8 @@ void ExportNanoVDBFileDialog::buildUI()
       auto spatialFieldObject = selectedObject->parameterValueAsObject("value");
 
       if (!spatialFieldObject
-          || !spatialFieldObject->subtype()
-              == core::tokens::volume::structuredRegular) {
+          || spatialFieldObject->subtype()
+              != core::tokens::volume::structuredRegular) {
         core::logError(
             "[ExportVDBFileDialog] Selected TransferFunction1D does not reference a structured regular volume.");
         return;
@@ -155,7 +155,7 @@ void ExportNanoVDBFileDialog::buildUI()
       doExport();
     else {
       appCore()->windows.taskModal->activate(
-          doExport, "Please Wait: Importing Data...");
+          doExport, "Please Wait: Exporting to NanoVDB...");
     }
   }
 }

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.h
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.h
@@ -19,6 +19,8 @@ struct ExportNanoVDBFileDialog : public Modal
   int m_selectedFileType{0};
   bool m_enableUndefinedValue{false};
   float m_undefinedValue{0.0f};
+  int m_precisionIndex{3}; // Default to Fp16 (index 3)
+  bool m_enableDithering{false};
 };
 
 } // namespace tsd::ui::imgui

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.h
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.h
@@ -1,0 +1,24 @@
+// Copyright 2024-2025 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Modal.h"
+
+namespace tsd::ui::imgui {
+
+struct ExportNanoVDBFileDialog : public Modal
+{
+  ExportNanoVDBFileDialog(Application *app);
+  ~ExportNanoVDBFileDialog() override;
+
+  void buildUI() override;
+
+ private:
+  std::string m_filename;
+  int m_selectedFileType{0};
+  bool m_enableUndefinedValue{false};
+  float m_undefinedValue{0.0f};
+};
+
+} // namespace tsd::ui::imgui

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "LayerTree.h"
+
+// tsd_core
+#include "tsd/core/scene/objects/Volume.hpp"
 // tsd_io
 #include "tsd/io/procedural.hpp"
 // tsd_app
 #include "tsd/app/Core.h"
 // tsd_ui_imgui
 #include "tsd/ui/imgui/modals/ImportFileDialog.h"
+#include "tsd/ui/imgui/modals/ExportNanoVDBFileDialog.h"
 #include "tsd/ui/imgui/tsd_ui_imgui.h"
 
 namespace tsd::ui::imgui {
@@ -451,6 +455,16 @@ void LayerTree::buildUI_objectSceneMenu()
     }
 
     if (nodeSelected) {
+      if ((*menuNode)->isObject() && (*menuNode)->getObject()->subtype() == core::tokens::volume::transferFunction1D) {
+        auto tf1D = (*menuNode)->getObject();
+        auto spatialFieldObject = tf1D->parameterValueAsObject("value");
+        if (spatialFieldObject && spatialFieldObject->subtype() == core::tokens::volume::structuredRegular) {
+          ImGui::Separator();
+          if (ImGui::MenuItem("export to NanoVDB")) {
+            appCore()->windows.exportNanoVDBDialog->show();
+          }
+        }
+      }
       ImGui::Separator();
 
       if (ImGui::MenuItem("delete selected")) {

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -439,6 +439,11 @@ void LayerTree::buildUI_objectSceneMenu()
           clearSelectedNode = true;
         }
 
+        if (ImGui::MenuItem("sphere set volume")) {
+          tsd::io::generate_sphereSetVolume(scene, menuNode);
+          clearSelectedNode = true;
+        }
+
         ImGui::EndMenu();
       }
 

--- a/tsd/src/tsd/ui/imgui/windows/TransferFunctionEditor.h
+++ b/tsd/src/tsd/ui/imgui/windows/TransferFunctionEditor.h
@@ -36,10 +36,9 @@ class TransferFunctionEditor : public Window
   void setMap(int which = 0);
   void setObjectPtrsFromSelectedObject();
   void loadDefaultMaps();
-  void loadColormapFrom1dt(
+  void loadColormap(
       const std::string &filepath, const std::string &name);
-  void loadColormapFromParaview(
-      const std::string &filepath, const std::string &name);
+
   void saveColormapTo1dt(const std::string &filepath);
   void saveColormapToParaview(const std::string &filepath);
   void getTransferFunctionFilenameFromDialog(


### PR DESCRIPTION
The PR addresses a few points:
- VisRTX
  - Update the raymarching code to support side-by-side volumes where a shared faces is only accounted for once
- TSD
  - Exporting a StructuredRegular SpatialField as a NanoVDB file. The exporter broadcast values as-is, meaning that TSD's vertex centric values will be saved as voxel values in the NanoVDB file. The extent will be preserved. This is mostly OK from a TSD perspective where only vertex centric structured regular volumes are supported and that's how NanoVDB are addressed internally anyway. This will have to be improved later on. The exporter is available from the command line for batch conversions, or from the UI (right-click on a volume node the layer panel)
  - Update the extent computation on the SILO importer so that the extent is preserved from the original SILO file in case of a rectilinear grid and the uniform cell size is the averaged from there. This makes side-by-side volumes correctly stitching instead of possibly creating gaps/overlaps. Note that rectilinear grid is still imported as a uniform grid.
  - Rework the transfer function loading mechanism so a default colormap can be set and applied to subsequently loaded volumes. The makes the case of compound volumes easier to deal with.