### PR TITLE
Multi-selection, copy/paste and drag n drop support

### DIFF
--- a/tsd/apps/interactive/demos/animatedVolume/tsdDemoAnimatedVolume.cpp
+++ b/tsd/apps/interactive/demos/animatedVolume/tsdDemoAnimatedVolume.cpp
@@ -79,12 +79,12 @@ class Application : public TSDApplication
     volume->setParameterObject("value", *field);
     volume->setParameterObject("color", *colorArray);
 
-    scene.defaultLayer()->root()->insert_first_child(
+    auto volumeNode = scene.defaultLayer()->root()->insert_first_child(
         {ANARI_VOLUME, volume.index(), &core->tsd.scene});
 
     // Setup app //
 
-    core->tsd.selectedObject = volume.data();
+    core->setSelected(volumeNode);
 
     tsd::core::logStatus(
         "%s", tsd::core::objectDBInfo(scene.objectDB()).c_str());

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -57,6 +57,8 @@ int main(int argc, const char *argv[])
   tsd::io::VDBPrecision precision = tsd::io::VDBPrecision::Fp16;
   bool enableDithering = false;
 
+  tsd::core::setLogToStderr();
+
   // Parse command line arguments
   for (int i = 1; i < argc; ++i) {
     const std::string_view arg{argv[i]};
@@ -122,8 +124,6 @@ int main(int argc, const char *argv[])
     printUsage(argv[0]);
     return 1;
   }
-
-  tsd::core::setLogToStdout();
 
   tsd::core::logStatus("Loading volume from: %s", inputFile->c_str());
 

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -248,6 +248,9 @@ struct Core
   void removeFromSelection(tsd::core::LayerNodeRef node);
   bool isSelected(tsd::core::LayerNodeRef node) const;
   void clearSelected();
+  
+  // Returns only parent nodes from selection (filters out children of selected nodes)
+  std::vector<tsd::core::LayerNodeRef> getParentOnlySelectedNodes() const;
 
   // Camera poses //
 

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -89,7 +89,7 @@ struct TSDState
 {
   tsd::core::Scene scene;
   bool sceneLoadComplete{false};
-  tsd::core::LayerNodeRef selectedNode;
+  std::vector<tsd::core::LayerNodeRef> selectedNodes;
 };
 
 struct ANARIDeviceManager
@@ -239,9 +239,13 @@ struct Core
 
   // Selection //
 
-  tsd::core::LayerNodeRef getSelected() const;
+  tsd::core::LayerNodeRef getSelected() const; // Returns first selected or invalid
+  const std::vector<tsd::core::LayerNodeRef>& getSelectedNodes() const;
   void setSelected(tsd::core::LayerNodeRef node);
+  void setSelected(const std::vector<tsd::core::LayerNodeRef>& nodes);
   void setSelected(const tsd::core::Object *obj);
+  void addToSelection(tsd::core::LayerNodeRef node);
+  void removeFromSelection(tsd::core::LayerNodeRef node);
   bool isSelected(tsd::core::LayerNodeRef node) const;
   void clearSelected();
 

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -87,9 +87,15 @@ struct CommandLineOptions
 
 struct TSDState
 {
+  struct StashedSelection {
+    std::vector<tsd::core::LayerNodeRef> nodes;
+    bool shouldDeleteAfterPaste{false};
+  };
+
   tsd::core::Scene scene;
   bool sceneLoadComplete{false};
   std::vector<tsd::core::LayerNodeRef> selectedNodes;
+  StashedSelection stashedSelection;
 };
 
 struct ANARIDeviceManager

--- a/tsd/src/tsd/app/Core.h
+++ b/tsd/src/tsd/app/Core.h
@@ -89,7 +89,6 @@ struct TSDState
 {
   tsd::core::Scene scene;
   bool sceneLoadComplete{false};
-  tsd::core::Object *selectedObject{nullptr};
   tsd::core::LayerNodeRef selectedNode;
 };
 
@@ -240,9 +239,10 @@ struct Core
 
   // Selection //
 
-  void setSelectedObject(tsd::core::Object *o);
-  void setSelectedNode(tsd::core::LayerNode &n);
-  bool objectIsSelected() const;
+  tsd::core::LayerNodeRef getSelected() const;
+  void setSelected(tsd::core::LayerNodeRef node);
+  void setSelected(const tsd::core::Object *obj);
+  bool isSelected(tsd::core::LayerNodeRef node) const;
   void clearSelected();
 
   // Camera poses //

--- a/tsd/src/tsd/core/Forest.hpp
+++ b/tsd/src/tsd/core/Forest.hpp
@@ -139,6 +139,10 @@ struct Forest
   NodeRef copy_subtree(NodeRef source, NodeRef newParent);
   void move_subtree(NodeRef source, NodeRef newParent);
 
+  // Queries //
+
+  bool isAncestorOf(NodeRef potentialAncestor, NodeRef node) const;
+
   // Traversal //
 
   void traverse(NodeRef start, ForestVisitor<T> &visitor);
@@ -494,6 +498,23 @@ inline typename Forest<T>::NodeRef Forest<T>::copy_subtree(
 }
 
 template <typename T>
+inline bool Forest<T>::isAncestorOf(
+    Forest<T>::NodeRef potentialAncestor, Forest<T>::NodeRef node) const
+{
+  if (!potentialAncestor || !node)
+    return false;
+
+  auto current = node;
+  while (current.valid()) {
+    if (current == potentialAncestor)
+      return true;
+    current = current->parent();
+  }
+
+  return false;
+}
+
+template <typename T>
 inline void Forest<T>::move_subtree(
     Forest<T>::NodeRef source, Forest<T>::NodeRef newParent)
 {
@@ -503,10 +524,8 @@ inline void Forest<T>::move_subtree(
   if (source->isRoot())
     return;
 
-  for (auto current = newParent; current; current = current->parent()) {
-    if (current == source)
-      return; // Would create a cycle
-  }
+  if (isAncestorOf(source, newParent))
+    return;
 
   // If already a child of newParent, no-op
   if (source->parent() == newParent)

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -93,7 +93,8 @@ void ExportNanoVDBFileDialog::buildUI()
 
     auto doExport = [&]() {
       auto *core = appCore();
-      auto selectedObject = core->tsd.selectedObject;
+      auto selectedNode = core->getSelected();
+      auto selectedObject = selectedNode.valid() ? (*selectedNode)->getObject() : nullptr;
       if (!selectedObject) {
         core::logError(
             "[ExportVDBFileDialog] No object selected for VDB export.");

--- a/tsd/src/tsd/ui/imgui/modals/ImportFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ImportFileDialog.cpp
@@ -96,8 +96,8 @@ void ImportFileDialog::buildUI()
       auto *core = appCore();
       auto &scene = core->tsd.scene;
       auto *layer = core->tsd.scene.defaultLayer();
-      auto importRoot = core->tsd.selectedNode;
-      if (!importRoot)
+      auto importRoot = core->getSelected();
+      if (!importRoot.valid())
         importRoot = layer->root();
       app::ImportFile file{
           static_cast<app::ImporterType>(m_selectedFileType), m_filename};

--- a/tsd/src/tsd/ui/imgui/windows/IsosurfaceEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/IsosurfaceEditor.cpp
@@ -21,7 +21,8 @@ void IsosurfaceEditor::buildUI()
 
   tsd::core::Object *selectedIsosurface = nullptr;
   tsd::core::Object *selectedVolume = nullptr;
-  tsd::core::Object *selectedObject = appCore()->tsd.selectedObject;
+  auto selectedNode = appCore()->getSelected();
+  tsd::core::Object *selectedObject = selectedNode.valid() ? (*selectedNode)->getObject() : nullptr;
 
   if (selectedObject != nullptr) {
     if (selectedObject->type() == ANARI_VOLUME)
@@ -94,7 +95,8 @@ void IsosurfaceEditor::buildUI()
 
 void IsosurfaceEditor::addIsosurfaceGeometryFromSelected()
 {
-  tsd::core::Object *selectedObject = appCore()->tsd.selectedObject;
+  auto selectedNode = appCore()->getSelected();
+  tsd::core::Object *selectedObject = selectedNode.valid() ? (*selectedNode)->getObject() : nullptr;
   auto &scene = appCore()->tsd.scene;
   auto *layer = scene.defaultLayer();
 
@@ -113,7 +115,7 @@ void IsosurfaceEditor::addIsosurfaceGeometryFromSelected()
 
   auto n = layer->insert_last_child(layer->root(), {s});
 
-  appCore()->setSelectedNode(*n);
+  appCore()->setSelected(n);
   scene.signalLayerChange(layer);
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -153,13 +153,24 @@ void LayerTree::buildUI_tree()
 
       auto selectedNodeRef = appCore()->getSelected();
       auto currentNodeRef = layer.at(node.index());
-      const bool isSelectedNode = selectedNodeRef.valid() && (currentNodeRef == selectedNodeRef);
-      const bool sameObject = selectedNodeRef.valid() && obj 
-          && (*selectedNodeRef)->getObject() == obj;
-      const bool strongHighlight = isSelectedNode 
-          && (selectedNodeRef->container() == &layer);
-      const bool lightHighlight = !isSelectedNode && sameObject 
-          && (selectedNodeRef->container() == &layer);
+
+      // Check if this node is in the selection set
+      const bool isSelectedNode = appCore()->isSelected(currentNodeRef);
+
+      // Check if any selected node's object matches this node's object
+      bool sameObject = false;
+      if (obj) {
+        const auto &selectedNodes = appCore()->getSelectedNodes();
+        for (const auto &selected : selectedNodes) {
+          if (selected.valid() && (*selected)->getObject() == obj) {
+            sameObject = true;
+            break;
+          }
+        }
+      }
+
+      const bool strongHighlight = isSelectedNode;
+      const bool lightHighlight = !isSelectedNode && sameObject;
 
       if (strongHighlight) {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 1.f, 0.f, 1.f));

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -151,12 +151,21 @@ void LayerTree::buildUI_tree()
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 0.3f, 0.3f, 1.f));
       }
 
-      const bool selected = (obj && appCore()->tsd.selectedObject == obj)
-          || (appCore()->tsd.selectedNode
-              && node == *appCore()->tsd.selectedNode);
-      if (selected) {
+      auto selectedNodeRef = appCore()->getSelected();
+      auto currentNodeRef = layer.at(node.index());
+      const bool isSelectedNode = selectedNodeRef.valid() && (currentNodeRef == selectedNodeRef);
+      const bool sameObject = selectedNodeRef.valid() && obj 
+          && (*selectedNodeRef)->getObject() == obj;
+      const bool strongHighlight = isSelectedNode 
+          && (selectedNodeRef->container() == &layer);
+      const bool lightHighlight = !isSelectedNode && sameObject 
+          && (selectedNodeRef->container() == &layer);
+
+      if (strongHighlight) {
         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 1.f, 0.f, 1.f));
         node_flags |= ImGuiTreeNodeFlags_Selected;
+      } else if (lightHighlight) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 1.f, 0.f, 0.75f));
       }
 
       const char *nameText = "<unhandled UI node type>";
@@ -223,9 +232,9 @@ void LayerTree::buildUI_tree()
       }
 
       if (ImGui::IsItemClicked() && m_menuNode == TSD_INVALID_INDEX)
-        appCore()->setSelectedNode(node);
+        appCore()->setSelected(layer.at(node.index()));
 
-      if (selected)
+      if (strongHighlight || lightHighlight)
         ImGui::PopStyleColor(1);
 
       return open;

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -439,7 +439,7 @@ void LayerTree::buildUI_tree()
       ImGui::EndDragDropTarget();
     }
 
-    // Defered handling of the drop event
+    // Deferred handling of the drop event
     if (dragAndDropTarget.valid() && !droppedNodes.empty()) {
       ImGuiIO &io = ImGui::GetIO();
       copyNodesTo(dragAndDropTarget, droppedNodes, !io.KeyCtrl);

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.h
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.h
@@ -37,6 +37,13 @@ struct LayerTree : public Window
       bool cutOperation
   );
 
+  bool isValidDropTarget(
+      tsd::core::Layer& layer,
+      tsd::core::LayerNodeRef targetParent,
+      const tsd::core::LayerNodeRef* sourceNodes,
+      size_t count
+  ) const;
+
   // Data //
 
   bool m_enableAddRemove{true};

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.h
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.h
@@ -26,6 +26,11 @@ struct LayerTree : public Window
   void buildUI_newLayerSceneMenu();
   void buildUI_setActiveLayersSceneMenus();
 
+  std::vector<tsd::core::LayerNodeRef> computeSelectionRange(
+      tsd::core::Layer &layer,
+      const tsd::core::LayerNodeRef &anchor,
+      const tsd::core::LayerNodeRef &target);
+
   // Data //
 
   bool m_enableAddRemove{true};
@@ -36,6 +41,7 @@ struct LayerTree : public Window
   bool m_menuVisible{false};
   std::vector<int> m_needToTreePop;
   int m_layerIdx{0};
+  tsd::core::LayerNodeRef m_anchorNode;
 };
 
 } // namespace tsd::ui::imgui

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.h
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.h
@@ -30,6 +30,12 @@ struct LayerTree : public Window
       tsd::core::Layer &layer,
       const tsd::core::LayerNodeRef &anchor,
       const tsd::core::LayerNodeRef &target);
+  
+  std::vector<tsd::core::LayerNodeRef> copyNodesTo(
+      tsd::core::LayerNodeRef targetParent,
+      const std::vector<tsd::core::LayerNodeRef>& sourceNodes,
+      bool cutOperation
+  );
 
   // Data //
 

--- a/tsd/src/tsd/ui/imgui/windows/TransferFunctionEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/TransferFunctionEditor.cpp
@@ -345,7 +345,8 @@ void TransferFunctionEditor::setMap(int selection)
 void TransferFunctionEditor::setObjectPtrsFromSelectedObject()
 {
   tsd::core::Volume *selectedVolume = nullptr;
-  tsd::core::Object *selectedObject = appCore()->tsd.selectedObject;
+  auto selectedNode = appCore()->getSelected();
+  tsd::core::Object *selectedObject = selectedNode.valid() ? (*selectedNode)->getObject() : nullptr;
 
   if (!selectedVolume) {
     if (selectedObject && selectedObject->type() == ANARI_VOLUME)


### PR DESCRIPTION
- Update Forest<> to be able to handle hierarchy copy and move
- Selection is now based on nodes instead of object, making the selection specific as an object can be referenced by multiple nodes.
- The above enabled multi-selection
- LayerTree has updated to support:
  - drag and drop (move by default, copy when CTRL is pressed)
  - copy/cut/paste
- Also sneaked in a fix for volumeToNanoVDB where the errors were not popping up on the console