### PR TITLE
Add support for Ctrl+A to select all nodes in the current layer treeview

### DIFF
--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.h
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.h
@@ -22,6 +22,7 @@ struct LayerTree : public Window
   void buildUI_layerHeader();
   void buildUI_tree();
   void buildUI_activateObjectSceneMenu();
+  void buildUI_handleSelection();
   void buildUI_objectSceneMenu();
   void buildUI_newLayerSceneMenu();
   void buildUI_setActiveLayersSceneMenus();


### PR DESCRIPTION
Also move the Ctrl+AXCV keyboard logic in its own function.