### PR TITLE
TSD: Nvdb sidecar file to store/load additional information

### DIFF
--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -161,7 +161,8 @@ struct NvdbRegularSamplerState
   const GridType *grid;
   AccessorType accessor;
   SamplerType sampler;
-  nanovdb::Vec3f offset;
+  nanovdb::Vec3f offsetDown;
+  nanovdb::Vec3f offsetUp;
   nanovdb::Vec3f scale;
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
@@ -178,8 +179,10 @@ struct NvdbRectilinearSamplerState
   const GridType *grid;
   AccessorType accessor;
   SamplerType sampler;
-  nanovdb::Vec3f offset;
-  nanovdb::Vec3f scale;
+  nanovdb::Vec3f offsetDown;
+  nanovdb::Vec3f offsetUp;
+  nanovdb::Vec3f scaleDown;
+  nanovdb::Vec3f scaleUp;
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
   cudaTextureObject_t axisLUT[3];

--- a/devices/rtx/device/spatial_field/StructuredRectilinearSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearSampler_ptx.cu
@@ -65,13 +65,9 @@ VISRTX_CALLABLE float __direct_callable__sampleStructuredRectilinear(
   vec3 normalizedPos = (*location - state.axisBoundsMin)
       / (state.axisBoundsMax - state.axisBoundsMin);
 
-  normalizedPos =
-      vec3(state.axisLUT[0] ? tex1D<float>(state.axisLUT[0], normalizedPos.x)
-                            : normalizedPos.x,
-          state.axisLUT[1] ? tex1D<float>(state.axisLUT[1], normalizedPos.y)
-                           : normalizedPos.y,
-          state.axisLUT[2] ? tex1D<float>(state.axisLUT[2], normalizedPos.z)
-                           : normalizedPos.z);
+  normalizedPos = vec3(tex1D<float>(state.axisLUT[0], normalizedPos.x),
+      tex1D<float>(state.axisLUT[1], normalizedPos.y),
+      tex1D<float>(state.axisLUT[2], normalizedPos.z));
 
   // Sample texture with transformed coordinates
   auto sampleCoord = normalizedPos * state.dims + state.offset;

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -157,7 +157,7 @@ int main(int argc, const char *argv[])
         "Detected rectilinear grid; writing NanoVDB sidecar with axis coordinates.");
   }
 
-  tsd::io::export_StructuredRegularVolumeToNanoVDB(spatialField,
+  tsd::io::export_StructuredVolumeToNanoVDB(spatialField,
       outputFile->c_str(),
       undefinedValue.has_value(),
       undefinedValue.value_or(0.0f),

--- a/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
+++ b/tsd/apps/tools/tsdVolumeToNanoVDB.cpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <tsd/core/Logging.hpp>
 #include <tsd/core/scene/Scene.hpp>
+#include <tsd/core/scene/objects/SpatialField.hpp>
 #include <tsd/io/importers.hpp>
 #include <tsd/io/serialization.hpp>
 
@@ -65,14 +66,16 @@ int main(int argc, const char *argv[])
 
     if (arg == "--undefined" || arg == "-u") {
       if (i + 1 >= argc) {
-        tsd::core::logError("Option %s requires a value", std::string(arg).c_str());
+        tsd::core::logError(
+            "Option %s requires a value", std::string(arg).c_str());
         printUsage(argv[0]);
         return 1;
       }
       try {
         undefinedValue = std::stof(std::string(argv[++i]));
       } catch (const std::exception &e) {
-        tsd::core::logError("Invalid undefined value: %s", std::string(argv[i] ).c_str());
+        tsd::core::logError(
+            "Invalid undefined value: %s", std::string(argv[i]).c_str());
         printUsage(argv[0]);
         return 1;
       }
@@ -96,7 +99,8 @@ int main(int argc, const char *argv[])
       } else if (precStr == "float32") {
         precision = tsd::io::VDBPrecision::Float32;
       } else {
-        tsd::core::logError("Unknown precision type: %s", std::string(precStr).c_str());
+        tsd::core::logError(
+            "Unknown precision type: %s", std::string(precStr).c_str());
         printUsage(argv[0]);
         return 1;
       }
@@ -108,7 +112,8 @@ int main(int argc, const char *argv[])
       } else if (!outputFile) {
         outputFile = std::string(arg);
       } else {
-        tsd::core::logError("Unexpected positional argument: %s", std::string(arg).c_str());
+        tsd::core::logError(
+            "Unexpected positional argument: %s", std::string(arg).c_str());
         printUsage(argv[0]);
         return 1;
       }
@@ -141,6 +146,15 @@ int main(int argc, const char *argv[])
   if (!spatialField) {
     tsd::core::logError("Volume does not have a spatial field");
     return 1;
+  }
+
+  const auto subtype = spatialField->subtype();
+  const bool isRectilinear =
+      subtype == tsd::core::tokens::spatial_field::structuredRectilinear;
+
+  if (isRectilinear) {
+    tsd::core::logStatus(
+        "Detected rectilinear grid; writing NanoVDB sidecar with axis coordinates.");
   }
 
   tsd::io::export_StructuredRegularVolumeToNanoVDB(spatialField,

--- a/tsd/src/tsd/core/scene/objects/SpatialField.cpp
+++ b/tsd/src/tsd/core/scene/objects/SpatialField.cpp
@@ -150,7 +150,8 @@ tsd::math::float2 SpatialField::computeValueRange()
       retval = *r;
     else if (auto r = getDataRangeFromParameter(parameter("cell.data")); r)
       retval = *r;
-  } else if (subtype() == tokens::spatial_field::nanovdb) {
+  } else if (subtype() == tokens::spatial_field::nanovdb
+      || subtype() == tokens::spatial_field::nanovdbRectilinear) {
     if (auto *range = parameter("range"); range)
       retval = range->value().get<tsd::math::float2>();
   } else if (subtype() == tokens::spatial_field::amr) {

--- a/tsd/src/tsd/core/scene/objects/SpatialField.cpp
+++ b/tsd/src/tsd/core/scene/objects/SpatialField.cpp
@@ -92,7 +92,7 @@ SpatialField::SpatialField(Token stype) : Object(ANARI_SPATIAL_FIELD, stype)
         .setValue({ANARI_ARRAY1D, INVALID_INDEX})
         .setDescription("array of floats containing the scalar voxel data");
   } else if (stype == tokens::spatial_field::nanovdb) {
-    addParameter("gridData")
+    addParameter("data")
         .setValue({ANARI_ARRAY1D, INVALID_INDEX})
         .setDescription("array containing serialzed NanoVDB grid");
     addParameter("filter").setValue("linear").setStringValues(
@@ -108,6 +108,34 @@ SpatialField::SpatialField(Token stype) : Object(ANARI_SPATIAL_FIELD, stype)
         .setValue(tsd::math::box3(
             tsd::math::float3(-math::inf, -math::inf, -math::inf),
             tsd::math::float3(math::inf, math::inf, math::inf)));
+  } else if (stype == tokens::spatial_field::nanovdbRectilinear) {
+    addParameter("data")
+        .setValue({ANARI_ARRAY1D, INVALID_INDEX})
+        .setDescription("array containing serialzed NanoVDB grid");
+    addParameter("filter")
+        .setValue("linear")
+        .setStringValues({"linear", "nearest"})
+        .setStringSelection(0);
+    addParameter("dataCentering")
+        .setValue("cell")
+        .setStringValues({"node", "cell"})
+        .setStringSelection(1)
+        .setDescription(
+            "whether data values are node-centered or cell-centered");
+    addParameter("roi")
+        .setDescription("ROI box in object space")
+        .setValue(tsd::math::box3(
+            tsd::math::float3(-math::inf, -math::inf, -math::inf),
+            tsd::math::float3(math::inf, math::inf, math::inf)));
+    addParameter("coordsX")
+        .setValue({ANARI_ARRAY1D, INVALID_INDEX})
+        .setDescription("X-axis coordinates");
+    addParameter("coordsY")
+        .setValue({ANARI_ARRAY1D, INVALID_INDEX})
+        .setDescription("Y-axis coordinates");
+    addParameter("coordsZ")
+        .setValue({ANARI_ARRAY1D, INVALID_INDEX})
+        .setDescription("Z-axis coordinates");
   }
 }
 
@@ -176,6 +204,7 @@ const Token structuredRectilinear = "structuredRectilinear";
 const Token unstructured = "unstructured";
 const Token amr = "amr";
 const Token nanovdb = "nanovdb";
+const Token nanovdbRectilinear = "nanovdbRectilinear";
 
 } // namespace tokens::spatial_field
 

--- a/tsd/src/tsd/core/scene/objects/SpatialField.hpp
+++ b/tsd/src/tsd/core/scene/objects/SpatialField.hpp
@@ -34,6 +34,7 @@ extern const Token structuredRectilinear;
 extern const Token unstructured;
 extern const Token amr;
 extern const Token nanovdb;
+extern const Token nanovdbRectilinear;
 
 } // namespace tokens::spatial_field
 

--- a/tsd/src/tsd/core/scene/objects/Volume.cpp
+++ b/tsd/src/tsd/core/scene/objects/Volume.cpp
@@ -53,6 +53,7 @@ anari::Object Volume::makeANARIObject(anari::Device d) const
 namespace tokens::volume {
 
 const Token structuredRegular = "structuredRegular";
+const Token structuredRectilinear = "structuredRectilinear";
 const Token transferFunction1D = "transferFunction1D";
 
 } // namespace tokens::volume

--- a/tsd/src/tsd/core/scene/objects/Volume.hpp
+++ b/tsd/src/tsd/core/scene/objects/Volume.hpp
@@ -26,6 +26,7 @@ using VolumeRef = ObjectPoolRef<Volume>;
 namespace tokens::volume {
 
 extern const Token structuredRegular;
+extern const Token structuredRectilinear;
 extern const Token transferFunction1D;
 
 } // namespace tokens::volume

--- a/tsd/src/tsd/io/CMakeLists.txt
+++ b/tsd/src/tsd/io/CMakeLists.txt
@@ -49,7 +49,7 @@ PRIVATE
   procedural/generate_randomSpheres.cpp
   procedural/generate_rtow.cpp
   procedural/generate_sphereSetVolume.cpp
-  serialization/export_RegularVolumeToNanoVDB.cpp
+  serialization/export_StructuredVolumeToNanoVDB.cpp
   serialization/NanoVdbSidecar.cpp
   serialization/export_SceneToUSD.cpp
   serialization/serialization_datatree.cpp

--- a/tsd/src/tsd/io/CMakeLists.txt
+++ b/tsd/src/tsd/io/CMakeLists.txt
@@ -50,6 +50,7 @@ PRIVATE
   procedural/generate_rtow.cpp
   procedural/generate_sphereSetVolume.cpp
   serialization/export_RegularVolumeToNanoVDB.cpp
+  serialization/NanoVdbSidecar.cpp
   serialization/export_SceneToUSD.cpp
   serialization/serialization_datatree.cpp
 )

--- a/tsd/src/tsd/io/serialization.hpp
+++ b/tsd/src/tsd/io/serialization.hpp
@@ -37,7 +37,7 @@ void load_Scene(Scene &scene, core::DataNode &root);
 
 void export_SceneToUSD(
     Scene &scene, const char *filename, int framesPerSecond = 30);
-void export_StructuredRegularVolumeToNanoVDB(
+void export_StructuredVolumeToNanoVDB(
   const SpatialField* spatialField,
   std::string_view outputFilename,
   bool useUndefinedValue = false,

--- a/tsd/src/tsd/io/serialization/NanoVdbSidecar.cpp
+++ b/tsd/src/tsd/io/serialization/NanoVdbSidecar.cpp
@@ -1,0 +1,194 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "NanoVdbSidecar.hpp"
+#include "tsd/core/DataTree.hpp"
+
+// std
+#include <cmath>
+
+namespace tsd::io {
+
+namespace {
+
+bool isFinite(const math::float3 &v)
+{
+  return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+}
+
+bool isFinite(const math::box3 &b)
+{
+  return isFinite(b.lower) && isFinite(b.upper);
+}
+
+std::optional<math::float3> parseFloat3(const core::DataNode *node)
+{
+  if (!node)
+    return std::nullopt;
+
+  math::float3 result;
+  if (!node->getValue(ANARI_FLOAT32_VEC3, &result))
+    return std::nullopt;
+
+  return result;
+}
+
+std::optional<math::box3> parseBox3(const core::DataNode *node)
+{
+  if (!node)
+    return std::nullopt;
+
+  const auto *lower = node->child("lower");
+  const auto *upper = node->child("upper");
+
+  const auto lowerVec = parseFloat3(lower);
+  const auto upperVec = parseFloat3(upper);
+
+  if (!lowerVec || !upperVec)
+    return std::nullopt;
+
+  return math::box3(*lowerVec, *upperVec);
+}
+
+bool parseCoords(const core::DataNode *node, std::vector<double> &out)
+{
+  out.clear();
+  if (!node)
+    return true;
+
+  const double *dataPtr = nullptr;
+  size_t numElements = 0;
+  node->getValueAsArray(&dataPtr, &numElements);
+
+  if (dataPtr && numElements > 0) {
+    out.assign(dataPtr, dataPtr + numElements);
+    return true;
+  }
+
+  return true;
+}
+
+} // namespace
+
+std::filesystem::path makeSidecarPath(const std::filesystem::path &nvdbPath)
+{
+  auto path = nvdbPath;
+  path.replace_extension("tsd");
+  return path;
+}
+
+bool writeSidecar(const NanoVdbSidecar &sidecar,
+    const std::filesystem::path &path,
+    std::string &errorMessage)
+{
+  core::DataTree tree;
+  auto &root = tree.root();
+
+  root["schemaVersion"] = static_cast<int>(sidecar.schemaVersion);
+  root["volumeType"] = sidecar.volumeType;
+
+  if (!sidecar.dataCentering.empty())
+    root["dataCentering"] = sidecar.dataCentering;
+
+  if (sidecar.origin)
+    root["origin"] = *sidecar.origin;
+
+  if (sidecar.spacing)
+    root["spacing"] = *sidecar.spacing;
+
+  if (sidecar.roi && isFinite(*sidecar.roi)) {
+    auto &roiNode = root["roi"];
+    roiNode["lower"] = sidecar.roi->lower;
+    roiNode["upper"] = sidecar.roi->upper;
+  }
+
+  if (!sidecar.coordsX.empty()) {
+    root["coordsX"].setValueAsArray(
+        sidecar.coordsX.data(), sidecar.coordsX.size());
+  }
+
+  if (!sidecar.coordsY.empty()) {
+    root["coordsY"].setValueAsArray(
+        sidecar.coordsY.data(), sidecar.coordsY.size());
+  }
+
+  if (!sidecar.coordsZ.empty()) {
+    root["coordsZ"].setValueAsArray(
+        sidecar.coordsZ.data(), sidecar.coordsZ.size());
+  }
+
+  if (!tree.save(path.string().c_str())) {
+    errorMessage = "failed to save sidecar file";
+    return false;
+  }
+
+  return true;
+}
+
+std::optional<NanoVdbSidecar> readSidecar(
+    const std::filesystem::path &path, std::string &errorMessage)
+{
+  core::DataTree tree;
+  if (!tree.load(path.string().c_str())) {
+    errorMessage = "failed to load sidecar file";
+    return std::nullopt;
+  }
+
+  auto &root = tree.root();
+  NanoVdbSidecar sidecar;
+
+  // Read schema version
+  const auto *schemaVersion = root.child("schemaVersion");
+  if (!schemaVersion) {
+    errorMessage = "sidecar missing schemaVersion";
+    return std::nullopt;
+  }
+  int version = 0;
+  if (!schemaVersion->getValue(ANARI_INT32, &version)) {
+    errorMessage = "sidecar schemaVersion must be numeric";
+    return std::nullopt;
+  }
+  sidecar.schemaVersion = static_cast<uint32_t>(version);
+
+  // Read volume type
+  const auto *volumeType = root.child("volumeType");
+  if (!volumeType) {
+    errorMessage = "sidecar missing volumeType";
+    return std::nullopt;
+  }
+  sidecar.volumeType = volumeType->getValue().is(ANARI_STRING)
+      ? volumeType->getValueAs<std::string>()
+      : "structuredRegular";
+
+  // Read data centering (optional)
+  if (const auto *dc = root.child("dataCentering")) {
+    sidecar.dataCentering = dc->getValueAs<std::string>();
+  }
+
+  // Read origin (optional)
+  sidecar.origin = parseFloat3(root.child("origin"));
+
+  // Read spacing (optional)
+  sidecar.spacing = parseFloat3(root.child("spacing"));
+
+  // Read ROI (optional)
+  if (const auto *roi = root.child("roi")) {
+    sidecar.roi = parseBox3(roi);
+    if (!sidecar.roi) {
+      errorMessage = "sidecar roi must contain lower/upper float3 vectors";
+      return std::nullopt;
+    }
+  }
+
+  // Read coordinate arrays (optional)
+  if (!parseCoords(root.child("coordsX"), sidecar.coordsX)
+      || !parseCoords(root.child("coordsY"), sidecar.coordsY)
+      || !parseCoords(root.child("coordsZ"), sidecar.coordsZ)) {
+    errorMessage = "sidecar coords arrays must be numeric";
+    return std::nullopt;
+  }
+
+  return sidecar;
+}
+
+} // namespace tsd::io

--- a/tsd/src/tsd/io/serialization/NanoVdbSidecar.hpp
+++ b/tsd/src/tsd/io/serialization/NanoVdbSidecar.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tsd/core/TSDMath.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace tsd::io {
+
+struct NanoVdbSidecar
+{
+  int schemaVersion = 1;
+  std::string volumeType;
+  std::string dataCentering;
+  std::optional<math::float3> origin;
+  std::optional<math::float3> spacing;
+  std::optional<math::box3> roi;
+  std::vector<double> coordsX;
+  std::vector<double> coordsY;
+  std::vector<double> coordsZ;
+
+  bool hasCoords() const
+  {
+    return !coordsX.empty() && !coordsY.empty() && !coordsZ.empty();
+  }
+};
+
+std::filesystem::path makeSidecarPath(const std::filesystem::path &nvdbPath);
+
+bool writeSidecar(const NanoVdbSidecar &sidecar,
+    const std::filesystem::path &path,
+    std::string &errorMessage);
+
+std::optional<NanoVdbSidecar> readSidecar(
+    const std::filesystem::path &path, std::string &errorMessage);
+
+} // namespace tsd::io

--- a/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
+++ b/tsd/src/tsd/io/serialization/export_RegularVolumeToNanoVDB.cpp
@@ -369,16 +369,18 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
       return;
     }
 
-    origin = math::float3(static_cast<float>(coordsX.front()),
-        static_cast<float>(coordsY.front()),
-        static_cast<float>(coordsZ.front()));
-
     const auto extent =
         math::float3(static_cast<float>(coordsX.back() - coordsX.front()),
             static_cast<float>(coordsY.back() - coordsY.front()),
             static_cast<float>(coordsZ.back() - coordsZ.front()));
 
-    // For rectilinear grids, only export coordinate arrays, not origin/spacing
+    origin = math::float3(static_cast<float>(coordsX.front()),
+        static_cast<float>(coordsY.front()),
+        static_cast<float>(coordsZ.front()));
+
+    // Compute a uniform voxel spacing equivalent for nanovdb
+    spacing = extent / dims;
+
     sidecar.coordsX = coordsX;
     sidecar.coordsY = coordsY;
     sidecar.coordsZ = coordsZ;

--- a/tsd/src/tsd/io/serialization/export_StructuredVolumeToNanoVDB.cpp
+++ b/tsd/src/tsd/io/serialization/export_StructuredVolumeToNanoVDB.cpp
@@ -28,7 +28,7 @@ using namespace std::string_view_literals;
 namespace tsd::io {
 
 template <typename T>
-void doExportStructuredRegularVolumeToNanoVDB(const T *data,
+void doExportStructuredVolumeToNanoVDB(const T *data,
     math::float3 origin,
     math::float3 spacing,
     math::int3 dims,
@@ -39,17 +39,17 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     bool enableDithering)
 {
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Volume dimensions: %u x %u x %u",
+      "[export_StructuredVolumeToNanoVDB] Volume dimensions: %u x %u x %u",
       dims.x,
       dims.y,
       dims.z);
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Origin: (%.3f, %.3f, %.3f)",
+      "[export_StructuredVolumeToNanoVDB] Origin: (%.3f, %.3f, %.3f)",
       origin.x,
       origin.y,
       origin.z);
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Spacing: (%.3f, %.3f, %.3f)",
+      "[export_StructuredVolumeToNanoVDB] Spacing: (%.3f, %.3f, %.3f)",
       spacing.x,
       spacing.y,
       spacing.z);
@@ -142,7 +142,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
       : 0.0f;
 
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Active voxels: %zu/%zu (%.1f%% inactive cell compression)",
+      "[export_StructuredVolumeToNanoVDB] Active voxels: %zu/%zu (%.1f%% inactive cell compression)",
       activeVoxelsCount,
       totalVoxelsCount,
       inactiveCellCompression * 100.0f);
@@ -152,11 +152,11 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
   // Validate quantization choice
   if (precision == VDBPrecision::Fp4 && valueRange > 30.0f) {
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToNanoVDB] Fp4 quantization with value range %.2f may introduce significant error (recommended < 30.0)",
+        "[export_StructuredVolumeToNanoVDB] Fp4 quantization with value range %.2f may introduce significant error (recommended < 30.0)",
         valueRange);
   } else if (precision == VDBPrecision::Fp8 && valueRange > 500.0f) {
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToNanoVDB] Fp8 quantization with value range %.2f may introduce significant error (recommended < 500.0)",
+        "[export_StructuredVolumeToNanoVDB] Fp8 quantization with value range %.2f may introduce significant error (recommended < 500.0)",
         valueRange);
   }
 
@@ -203,7 +203,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     break;
   case VDBPrecision::Half:
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToNanoVDB] Half precision not supported in this NanoVDB build, using Fp16 instead");
+        "[export_StructuredVolumeToNanoVDB] Half precision not supported in this NanoVDB build, using Fp16 instead");
     handle = nanovdb::tools::createNanoGrid<nanovdb::tools::build::Grid<float>,
         nanovdb::Fp16>(*buildGrid,
         nanovdb::tools::StatsMode::All,
@@ -215,7 +215,7 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
 
   if (!handle) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToNanoVDB] Failed to create NanoVDB grid.");
+        "[export_StructuredVolumeToNanoVDB] Failed to create NanoVDB grid.");
     return;
   }
 
@@ -229,12 +229,12 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
       : 0.0f;
 
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Quantization compression: %.1f%% (%.2f MB -> %.2f MB)",
+      "[export_StructuredVolumeToNanoVDB] Quantization compression: %.1f%% (%.2f MB -> %.2f MB)",
       quantizationCompression * 100.0f,
       uncompressedActiveSize / (1024.0f * 1024.0f),
       finalSize / (1024.0f * 1024.0f));
   tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Total compression: %.1f%% (%.2f MB -> %.2f MB)",
+      "[export_StructuredVolumeToNanoVDB] Total compression: %.1f%% (%.2f MB -> %.2f MB)",
       totalCompression * 100.0f,
       uncompressedSize / (1024.0f * 1024.0f),
       finalSize / (1024.0f * 1024.0f));
@@ -244,16 +244,16 @@ void doExportStructuredRegularVolumeToNanoVDB(const T *data,
     nanovdb::io::writeGrid(
         std::string(outputFilename).c_str(), handle, nanovdb::io::Codec::NONE);
     tsd::core::logStatus(
-        "[export_StructuredRegularVolumeToNanoVDB] Successfully wrote VDB file: %s",
+        "[export_StructuredVolumeToNanoVDB] Successfully wrote VDB file: %s",
         std::string(outputFilename).c_str());
   } catch (const std::exception &e) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToNanoVDB] Failed to write VDB file: %s",
+        "[export_StructuredVolumeToNanoVDB] Failed to write VDB file: %s",
         e.what());
   }
 }
 
-void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
+void export_StructuredVolumeToNanoVDB(const SpatialField *spatialField,
     std::string_view outputFilename,
     bool useUndefinedValue,
     float undefinedValue,
@@ -268,7 +268,7 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
 
   if (!isStructuredRegular && !isStructuredRectilinear) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToNanoVDB] Not a structured volume.");
+        "[export_StructuredVolumeToNanoVDB] Not a structured volume.");
     return;
   }
 
@@ -281,14 +281,13 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
   // Dumb heuristic here: everything but cell is node-centered
   const bool cellCentered = dataCentering == "cell"sv;
 
-  tsd::core::logStatus(
-      "[export_StructuredRegularVolumeToNanoVDB] Data centering: %s",
+  tsd::core::logStatus("[export_StructuredVolumeToNanoVDB] Data centering: %s",
       dataCentering.c_str());
 
   const auto *volumeData = spatialField->parameterValueAsObject<Array>("data");
   if (!volumeData) {
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToNanoVDB] No volume data found.");
+        "[export_StructuredVolumeToNanoVDB] No volume data found.");
     return;
   }
 
@@ -334,7 +333,7 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
 
     if (!axisX || !axisY || !axisZ) {
       tsd::core::logError(
-          "[export_StructuredRegularVolumeToNanoVDB] Missing rectilinear coordinates.");
+          "[export_StructuredVolumeToNanoVDB] Missing rectilinear coordinates.");
       return;
     }
 
@@ -359,13 +358,13 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
     if (!copyAxis(axisX, coordsX) || !copyAxis(axisY, coordsY)
         || !copyAxis(axisZ, coordsZ)) {
       tsd::core::logError(
-          "[export_StructuredRegularVolumeToNanoVDB] Rectilinear coordinates must be float or double.");
+          "[export_StructuredVolumeToNanoVDB] Rectilinear coordinates must be float or double.");
       return;
     }
 
     if (coordsX.size() < 2 || coordsY.size() < 2 || coordsZ.size() < 2) {
       tsd::core::logError(
-          "[export_StructuredRegularVolumeToNanoVDB] Rectilinear coordinates must have at least two entries per axis.");
+          "[export_StructuredVolumeToNanoVDB] Rectilinear coordinates must have at least two entries per axis.");
       return;
     }
 
@@ -387,7 +386,7 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
   }
 
   auto dispatchExport = [&](auto ptr) {
-    doExportStructuredRegularVolumeToNanoVDB(ptr,
+    doExportStructuredVolumeToNanoVDB(ptr,
         origin,
         spacing,
         dims,
@@ -419,7 +418,7 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
     break;
   default:
     tsd::core::logError(
-        "[export_StructuredRegularVolumeToNanoVDB] Volume data is not of a supported float type.");
+        "[export_StructuredVolumeToNanoVDB] Volume data is not of a supported float type.");
     return;
   }
 
@@ -428,12 +427,11 @@ void export_StructuredRegularVolumeToNanoVDB(const SpatialField *spatialField,
   std::string sidecarError;
   if (!writeSidecar(sidecar, sidecarPath, sidecarError)) {
     tsd::core::logWarning(
-        "[export_StructuredRegularVolumeToNanoVDB] Failed to write sidecar %s: %s",
+        "[export_StructuredVolumeToNanoVDB] Failed to write sidecar %s: %s",
         sidecarPath.string().c_str(),
         sidecarError.c_str());
   } else {
-    tsd::core::logStatus(
-        "[export_StructuredRegularVolumeToNanoVDB] Wrote sidecar: %s",
+    tsd::core::logStatus("[export_StructuredVolumeToNanoVDB] Wrote sidecar: %s",
         sidecarPath.string().c_str());
   }
 }

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -111,9 +111,10 @@ void ExportNanoVDBFileDialog::buildUI()
       auto spatialFieldObject = selectedObject->parameterValueAsObject("value");
 
       if (!spatialFieldObject
-          || (spatialFieldObject->subtype() != core::tokens::volume::structuredRegular &&
-              spatialFieldObject->subtype() != core::tokens::volume::structuredRectilinear)
-      ) {
+          || (spatialFieldObject->subtype()
+                  != core::tokens::volume::structuredRegular
+              && spatialFieldObject->subtype()
+                  != core::tokens::volume::structuredRectilinear)) {
         core::logError(
             "[ExportVDBFileDialog] Selected TransferFunction1D does not reference a structured regular volume.");
         return;
@@ -145,7 +146,7 @@ void ExportNanoVDBFileDialog::buildUI()
         break;
       }
 
-      io::export_StructuredRegularVolumeToNanoVDB(
+      io::export_StructuredVolumeToNanoVDB(
           static_cast<const core::SpatialField *>(spatialFieldObject),
           m_filename.c_str(),
           m_enableUndefinedValue,

--- a/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ExportNanoVDBFileDialog.cpp
@@ -111,8 +111,9 @@ void ExportNanoVDBFileDialog::buildUI()
       auto spatialFieldObject = selectedObject->parameterValueAsObject("value");
 
       if (!spatialFieldObject
-          || spatialFieldObject->subtype()
-              != core::tokens::volume::structuredRegular) {
+          || (spatialFieldObject->subtype() != core::tokens::volume::structuredRegular &&
+              spatialFieldObject->subtype() != core::tokens::volume::structuredRectilinear)
+      ) {
         core::logError(
             "[ExportVDBFileDialog] Selected TransferFunction1D does not reference a structured regular volume.");
         return;

--- a/tsd/src/tsd/ui/imgui/tsd_ui_imgui.cpp
+++ b/tsd/src/tsd/ui/imgui/tsd_ui_imgui.cpp
@@ -650,7 +650,8 @@ bool buildUI_parameter(tsd::core::Object &o,
     ImGui::BeginTooltip();
     if (isArray) {
       const auto idx = pVal.getAsObjectIndex();
-      buildUI_array_info_tooltip_text(scene, idx);
+      if (idx != TSD_INVALID_INDEX)
+        buildUI_array_info_tooltip_text(scene, idx);
     } else if (type == ANARI_FLOAT32_MAT4) {
       auto *value_f = (const float *)value;
       ImGui::Text("[%.3f %.3f %.3f %.3f]",

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -775,8 +775,10 @@ void LayerTree::buildUI_objectSceneMenu()
         auto tf1D = (*menuNode)->getObject();
         auto spatialFieldObject = tf1D->parameterValueAsObject("value");
         if (spatialFieldObject
-            && spatialFieldObject->subtype()
-                == core::tokens::volume::structuredRegular) {
+            && (spatialFieldObject->subtype()
+                    == core::tokens::volume::structuredRegular
+                || spatialFieldObject->subtype()
+                    == core::tokens::volume::structuredRectilinear)) {
           ImGui::Separator();
           if (ImGui::MenuItem("export to NanoVDB")) {
             appCore()->windows.exportNanoVDBDialog->show();


### PR DESCRIPTION
Save additional information in a sidecar (jaxn/relaxed json file) so those NVDB files can be exactly reloaded:

- grid type
- dataCentring
- origin/spacing/coordinates

Also fixes coordinates handling on NanoVDB files, when changing dataCentring