### PR TITLE
Hide viewport overlay when other windows are docked atop of the viewport

### DIFF
--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -184,8 +184,6 @@ struct Viewport : public Window
   float m_latestAnariFL{0.f};
   float m_minFL{std::numeric_limits<float>::max()};
   float m_maxFL{-std::numeric_limits<float>::max()};
-
-  std::string m_overlayWindowName;
 };
 
 } // namespace tsd::ui::imgui


### PR DESCRIPTION
Changed the overlay from a separate top-level window to a child window within the viewport. This ensures the overlay is properly occluded when other windows are docked on top of the viewport. Otherwise, other windows such the tranfer function editor would render behind the overlay.

<img width="1700" height="1106" alt="image" src="https://github.com/user-attachments/assets/96e6822c-1788-4c29-9362-eeef1f63ab11" />
