### PR TITLE
Add animation time change callback to UpdateDelegate system

### DIFF
--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -548,6 +548,10 @@ void Scene::setAnimationTime(float time)
   m_animations.time = time;
   for (auto &a : m_animations.objects)
     a->update(time);
+  
+  // Signal delegates that animation time changed
+  if (m_updateDelegate)
+    m_updateDelegate->signalAnimationTimeChanged(time);
 }
 
 float Scene::getAnimationTime() const

--- a/tsd/src/tsd/core/scene/UpdateDelegate.cpp
+++ b/tsd/src/tsd/core/scene/UpdateDelegate.cpp
@@ -137,4 +137,10 @@ void MultiUpdateDelegate::signalInvalidateCachedObjects()
     d->signalInvalidateCachedObjects();
 }
 
+void MultiUpdateDelegate::signalAnimationTimeChanged(float time)
+{
+  for (auto &d : m_delegates)
+    d->signalAnimationTimeChanged(time);
+}
+
 } // namespace tsd::core

--- a/tsd/src/tsd/core/scene/UpdateDelegate.hpp
+++ b/tsd/src/tsd/core/scene/UpdateDelegate.hpp
@@ -35,6 +35,7 @@ struct BaseUpdateDelegate
   virtual void signalActiveLayersChanged() = 0;
   virtual void signalObjectFilteringChanged() = 0;
   virtual void signalInvalidateCachedObjects() = 0;
+  virtual void signalAnimationTimeChanged(float time) = 0;
 
   // Not copyable or movable
   BaseUpdateDelegate(const BaseUpdateDelegate &) = delete;
@@ -64,6 +65,7 @@ struct EmptyUpdateDelegate : public BaseUpdateDelegate
   void signalActiveLayersChanged() override {}
   void signalObjectFilteringChanged() override {}
   void signalInvalidateCachedObjects() override {}
+  void signalAnimationTimeChanged(float) override {}
 };
 
 /// Update delegate that dispatches signals to N held other update delegates
@@ -99,6 +101,7 @@ struct MultiUpdateDelegate : public BaseUpdateDelegate
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;
   void signalInvalidateCachedObjects() override;
+  void signalAnimationTimeChanged(float time) override;
 
  private:
   std::vector<std::unique_ptr<BaseUpdateDelegate>> m_delegates;

--- a/tsd/src/tsd/rendering/index/RenderIndex.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.cpp
@@ -174,4 +174,9 @@ void RenderIndex::signalInvalidateCachedObjects()
   updateWorld();
 }
 
+void RenderIndex::signalAnimationTimeChanged(float)
+{
+  // no-op
+}
+
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/index/RenderIndex.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.hpp
@@ -49,6 +49,7 @@ struct RenderIndex : public BaseUpdateDelegate
   void signalObjectRemoved(const Object *o) override;
   void signalRemoveAllObjects() override;
   void signalInvalidateCachedObjects() override;
+  void signalAnimationTimeChanged(float time) override;
 
  protected:
   virtual void updateWorld() = 0;


### PR DESCRIPTION
This commit extends the TSD UpdateDelegate architecture to support animation time change notifications, enabling applications to respond when scene.setAnimationTime() is called.