### PR TITLE
Refactor renderer implementations

### DIFF
--- a/devices/rtx/device/frame/Frame.cu
+++ b/devices/rtx/device/frame/Frame.cu
@@ -316,6 +316,12 @@ void Frame::renderFrame()
       1));
   instrument::rangePop(); // optixLaunch()
 
+  // Increment frameID after rendering completes
+  if (checkerboarding())
+    hd.fb.frameID += int(hd.fb.checkerboardID == 3);
+  else
+    hd.fb.frameID += m_renderer->spp();
+
   if (m_denoise)
     m_denoiser.launch();
 
@@ -682,10 +688,6 @@ void Frame::newFrame()
           vec3(0.0f));
     }
   } else {
-    if (checkerboarding())
-      hd.fb.frameID += int(hd.fb.checkerboardID == 3);
-    else
-      hd.fb.frameID += m_renderer->spp();
     hd.fb.checkerboardID =
         checkerboarding() ? ((hd.fb.checkerboardID + 1) & 0x3) : -1;
   }

--- a/devices/rtx/device/frame/Frame.cu
+++ b/devices/rtx/device/frame/Frame.cu
@@ -567,14 +567,13 @@ void *Frame::mapAlbedoBuffer(bool gpu)
 void *Frame::mapNormalBuffer(bool gpu)
 {
   auto &state = *deviceState();
-  const float invFrameID = m_invFrameID;
   auto begin = thrust::device_pointer_cast<vec3>((vec3 *)m_accumNormal.ptr());
   auto end = begin + numPixels();
   thrust::transform(thrust::cuda::par.on(state.stream),
       begin,
       end,
       thrust::device_pointer_cast<vec3>(m_normalBuffer.dataDevice()),
-      [=] __device__(const vec3 &in) { return in * invFrameID; });
+      [=] __device__(const vec3 &in) { return normalize(in); });
   if (gpu)
     return m_normalBuffer.dataDevice();
   else {

--- a/devices/rtx/device/gpu/intersectRay.h
+++ b/devices/rtx/device/gpu/intersectRay.h
@@ -102,12 +102,4 @@ VISRTX_DEVICE void intersectVolume(ScreenSample &ss,
   detail::launchRay(ss, r, rayType, false, dataPtr, optixFlags);
 }
 
-template <typename T>
-VISRTX_DEVICE float surfaceAttenuation(ScreenSample &ss, Ray r, T rayType)
-{
-  float a = 0.f;
-  intersectSurface(ss, r, rayType, &a, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
-  return a;
-}
-
 } // namespace visrtx

--- a/devices/rtx/device/gpu/renderer/common.h
+++ b/devices/rtx/device/gpu/renderer/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,34 +31,22 @@
 
 #pragma once
 
-#include "gpu/intersectRay.h"
+// Common constants and types used across multiple renderers
 
 namespace visrtx {
 
-VISRTX_DEVICE float computeAO(ScreenSample &ss,
-    const Ray &primaryRay,
-    const Hit &currentHit,
-    float dist,
-    int numSamples,
-    float (*surfaceAttenuation)(ScreenSample &, const Ray&))
+// Threshold for considering a surface fully opaque
+constexpr float OPACITY_THRESHOLD = 0.99f;
+
+// Minimum contribution weight to continue tracing
+constexpr float MIN_CONTRIBUTION_EPSILON = 1.0e-8f;
+
+// Standard ray types used across all renderers
+// All renderers should use these standard types for consistency
+enum class RayType
 {
-  float weights = 0.0f;
-  float hits = 0.0f;
-  Ray aoRay;
-  aoRay.org = currentHit.hitpoint + currentHit.Ns * currentHit.epsilon;
-  aoRay.t.lower = currentHit.epsilon;
-  aoRay.t.upper = dist;
-
-  for (int i = 0; i < numSamples; i++) {
-    aoRay.dir = randomDir(ss.rs, currentHit.Ns);
-    float weight = max(0.f, dot(aoRay.dir, currentHit.Ns));
-    if (weight > 1e-8f) {
-      weights += weight;
-      hits += weight * surfaceAttenuation(ss, aoRay);
-    }
-  }
-
-  return weights > 0.f ? (1.f - hits / weights) : 0.f;
-}
+  PRIMARY = 0, // Primary/shading rays
+  SHADOW = 1, // Shadow/occlusion rays (used for light visibility, AO, etc.)
+};
 
 } // namespace visrtx

--- a/devices/rtx/device/gpu/renderer/raygen_helpers.h
+++ b/devices/rtx/device/gpu/renderer/raygen_helpers.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "gpu/evalShading.h"
+#include "gpu/intersectRay.h"
+#include "gpu/renderer/common.h"
+#include "gpu/shadingState.h"
+
+// Shared helper functions for ray generation across renderers
+
+namespace visrtx {
+
+// Compute surface attenuation for shadow/occlusion rays
+// Uses the standard SHADOW ray type for consistency across all renderers
+VISRTX_DEVICE float surfaceAttenuation(ScreenSample &ss, const Ray &r)
+{
+  float a = 0.0f;
+  intersectSurface(
+      ss, r, RayType::SHADOW, &a, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
+  return a;
+}
+
+// Compute volume attenuation for shadow rays
+// Uses the standard SHADOW ray type for consistency across all renderers
+VISRTX_DEVICE float volumeAttenuation(ScreenSample &ss, const Ray &r)
+{
+  float attenuation = 0.0f;
+  intersectVolume(
+      ss, r, RayType::SHADOW, &attenuation, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
+  return attenuation;
+}
+
+// Evaluate opacity including transmission
+VISRTX_DEVICE float evaluateOpacity(const MaterialShadingState &shadingState)
+{
+  return materialEvaluateOpacity(shadingState)
+      * (1.0f - glm::luminosity(materialEvaluateTransmission(shadingState)));
+}
+
+// Templated rendering loop
+// ShadingPolicy must implement:
+//   static VISRTX_DEVICE vec4 shadeSurface(
+//       const MaterialShadingState &shadingState,
+//       ScreenSample &ss,
+//       const Ray &ray,
+//       const SurfaceHit &hit)
+template <typename ShadingPolicy>
+VISRTX_DEVICE void renderPixel(FrameGPUData &frameData, ScreenSample ss)
+{
+  auto &rendererParams = frameData.renderer;
+
+  for (int i = 0; i < frameData.renderer.numIterations; i++) {
+    // First go with the main ray, pixel centered if first frame.
+    // Jittered samples are produced by next iterations.
+    bool isVeryFirstRay = i == 0 && ss.frameData->fb.frameID == 0;
+    auto ray = makePrimaryRay(ss, isVeryFirstRay);
+    float tmax = ray.t.upper;
+
+    // Output accumulators
+    vec3 outputColor(0.f);
+    vec3 outputAlbedo(0.f);
+    vec3 outputNormal(0.f);
+    float outputOpacity = 0.f;
+
+    // First hit metadata (for picking)
+    float depth = std::numeric_limits<float>::max();
+    uint32_t primID = ~0u;
+    uint32_t objID = ~0u;
+    uint32_t instID = ~0u;
+
+    // Transparency traversal loop
+    while (outputOpacity < OPACITY_THRESHOLD) {
+      ray.t.upper = tmax;
+
+      // Find next surface
+      SurfaceHit surfaceHit;
+      surfaceHit.foundHit = false;
+      intersectSurface(ss,
+          ray,
+          RayType::PRIMARY,
+          &surfaceHit,
+          primaryRayOptiXFlags(rendererParams));
+
+      float hitDist = surfaceHit.foundHit ? surfaceHit.t : ray.t.upper;
+
+      // Ray march volumes up to this surface hit
+      vec3 volumeColor(0.f);
+      float volumeOpacity = 0.f;
+      uint32_t volObjID = ~0u;
+      uint32_t volInstID = ~0u;
+
+      float volumeDepth = rayMarchAllVolumes(ss,
+          ray,
+          RayType::PRIMARY,
+          hitDist,
+          rendererParams.inverseVolumeSamplingRate,
+          volumeColor,
+          volumeOpacity,
+          volObjID,
+          volInstID);
+
+      // Accumulate volume contribution if any
+      if (volumeDepth < depth) {
+        accumulateValue(outputColor, volumeColor, outputOpacity);
+        accumulateValue(outputAlbedo, volumeColor, outputOpacity);
+        accumulateNormal(outputNormal, -ray.dir, outputOpacity);
+        accumulateValue(outputOpacity, volumeOpacity, outputOpacity);
+
+        depth = volumeDepth;
+        objID = volObjID;
+        instID = volInstID;
+        primID = volObjID;
+      }
+
+      // Handle surface hit if any
+      if (surfaceHit.foundHit) {
+        MaterialShadingState shadingState;
+        materialInitShading(
+            &shadingState, frameData, *surfaceHit.material, surfaceHit);
+
+        // Call the renderer-specific shading function
+        const vec4 surfaceColor =
+            ShadingPolicy::shadeSurface(shadingState, ss, ray, surfaceHit);
+
+        // Accumulate surface contribution
+        accumulateValue(
+            outputColor, vec3(surfaceColor) * surfaceColor.a, outputOpacity);
+        accumulateValue(outputAlbedo,
+            materialEvaluateTint(shadingState) * surfaceColor.a,
+            outputOpacity);
+        accumulateNormal(
+            outputNormal, materialEvaluateNormal(shadingState), outputOpacity);
+        accumulateValue(outputOpacity, surfaceColor.a, outputOpacity);
+
+        // Track first hit from surface
+        if (surfaceHit.t < depth) {
+          depth = surfaceHit.t;
+          primID = surfaceHit.primID;
+          objID = surfaceHit.objID;
+          instID = surfaceHit.instID;
+        }
+
+        // Advance ray past this surface for next iteration
+        ray.t.lower = surfaceHit.t + surfaceHit.epsilon;
+      }
+
+      // Record first hit metadata
+      if (isVeryFirstRay) {
+        setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
+      }
+
+      // Exit if the current ray left the scene
+      if (!surfaceHit.foundHit)
+        break;
+
+      // Otherwise, continue through transparent surface
+    }
+
+    // Accumulate background for remaining transparency
+    const auto bg = getBackground(frameData, ss.screen, ray.dir);
+    const bool premultiplyBg = rendererParams.premultiplyBackground;
+    vec3 bgColor = premultiplyBg ? vec3(bg) * bg.a : vec3(bg);
+
+    accumulateValue(outputColor, bgColor, outputOpacity);
+    accumulateValue(outputOpacity, bg.a, outputOpacity);
+
+    // Write accumulated sample to framebuffer
+    accumPixelSample(frameData,
+        ss.pixel,
+        vec4(outputColor, outputOpacity),
+        outputAlbedo,
+        outputNormal,
+        i);
+  }
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -123,6 +123,7 @@ VISRTX_DEVICE float _rayMarchVolume(ScreenSample &ss,
   float depth = std::numeric_limits<float>::max();
 
   // Accumulate until full opacity
+  constexpr float MIN_OPACITY_THRESHOLD = 1e-2f;
   constexpr float MAX_OPACITY_THRESHOLD = 0.99f;
   while (opacity < MAX_OPACITY_THRESHOLD && size(interval) >= 0.f) {
     const vec3 p = hit.localRay.org + hit.localRay.dir * interval.lower;
@@ -133,14 +134,15 @@ VISRTX_DEVICE float _rayMarchVolume(ScreenSample &ss,
 
       const float stepAlpha = 1.0f - glm::pow(1.0f - co.w, exponent);
       if (stepAlpha > 0.0f) {
-        // Record depth at first non-zero contribution
-        if (depth == std::numeric_limits<float>::max()) {
-          depth = interval.lower;
-        }
         const float weight = (1.0f - opacity);
         if (color)
           *color += weight * stepAlpha * vec3(co);
         opacity += weight * stepAlpha;
+
+        if (opacity > MIN_OPACITY_THRESHOLD
+            && depth == std::numeric_limits<float>::max()) {
+          depth = interval.lower;
+        }
       }
     }
 

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -200,7 +200,7 @@ VISRTX_CALLABLE
 NextRay __direct_callable__nextRay(
     const MDLShadingState *shadingState, const Ray *ray, RandState *rs)
 {
-  // Before anything, check for opacity. If below, than we just pass through
+  // Before anything, check for opacity. If below, then we just pass through
   if (curand_uniform(rs) > mdlOpacity(&shadingState->state,
           &shadingState->resData,
           shadingState->argBlock)) {

--- a/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
@@ -182,7 +182,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
     const Ray *ray,
     RandState *rs)
 {
-  // Before anything, check for opacity. If below, than we just pass through
+  // Before anything, check for opacity. If below, then we just pass through
   if (curand_uniform(rs) > shadingState->opacity)
   {
     return NextRay{ray->dir, vec3(1.0f)};

--- a/devices/rtx/device/mdl/MaterialRegistry.cpp
+++ b/devices/rtx/device/mdl/MaterialRegistry.cpp
@@ -157,6 +157,12 @@ MaterialRegistry::acquireMaterial(
   auto targetCode = make_handle(
       m_core->getPtxTargetCode(compiledMaterial.get(), transaction.get()));
   std::vector<libmdl::TextureDescriptor> textureDescs;
+  if (!targetCode.is_valid_interface()) {
+    m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
+        "Failed generating PTX target code for material {}",
+        fullMaterialName);
+    return {};
+  }
 
   for (auto i = 1ul; i < targetCode->get_texture_count(); ++i) {
     libmdl::TextureDescriptor textureDesc{i - 1, targetCode->get_texture(i)};

--- a/devices/rtx/device/renderer/AmbientOcclusion.cpp
+++ b/devices/rtx/device/renderer/AmbientOcclusion.cpp
@@ -37,7 +37,7 @@ namespace visrtx {
 
 static const std::vector<HitgroupFunctionNames> g_aoHitNames = {
     {"__closesthit__primary", "__anyhit__primary"},
-    {"__closesthit__ao", "__anyhit__ao"}};
+    {"__closesthit__shadow", "__anyhit__shadow"}};
 
 static const std::vector<std::string> g_aoMissNames = {"__miss__", "__miss__"};
 

--- a/devices/rtx/device/renderer/AmbientOcclusion_ptx.cu
+++ b/devices/rtx/device/renderer/AmbientOcclusion_ptx.cu
@@ -29,29 +29,27 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits>
 #include "gpu/evalShading.h"
+#include "gpu/gpu_decl.h"
 #include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/shading_api.h"
+#include "gpu/renderer/common.h"
+#include "gpu/renderer/raygen_helpers.h"
 
 namespace visrtx {
-
-enum class RayType
-{
-  PRIMARY = 0,
-  AO = 1
-};
 
 DECLARE_FRAME_DATA(frameData)
 
 // OptiX programs /////////////////////////////////////////////////////////////
 
-VISRTX_GLOBAL void __closesthit__ao()
+VISRTX_GLOBAL void __closesthit__shadow()
 {
   // no-op
 }
 
-VISRTX_GLOBAL void __anyhit__ao()
+VISRTX_GLOBAL void __anyhit__shadow()
 {
   SurfaceHit hit;
   ray::populateSurfaceHit(hit);
@@ -63,7 +61,7 @@ VISRTX_GLOBAL void __anyhit__ao()
 
   auto &o = ray::rayData<float>();
   accumulateValue(o, materialEvaluateOpacity(shadingState), o);
-  if (o >= 0.99f)
+  if (o >= OPACITY_THRESHOLD)
     optixTerminateRay();
   else
     optixIgnoreIntersection();
@@ -84,144 +82,44 @@ VISRTX_GLOBAL void __miss__()
   // no-op
 }
 
+// AmbientOcclusion shading policy for templated rendering loop /////////////
+
+struct AmbientOcclusionShadingPolicy
+{
+  static VISRTX_DEVICE vec4 shadeSurface(const MaterialShadingState &shadingState,
+      ScreenSample &ss,
+      const Ray &ray,
+      const SurfaceHit &hit)
+  {
+    const auto &rendererParams = frameData.renderer;
+    const auto &aoParams = rendererParams.params.ao;
+
+    const float aoFactor = aoParams.aoSamples > 0
+        ? computeAO(ss,
+              ray,
+              hit,
+              rendererParams.occlusionDistance,
+              aoParams.aoSamples,
+              &surfaceAttenuation)
+        : 1.f;
+
+    auto materialBaseColor = materialEvaluateTint(shadingState);
+    auto materialOpacity = materialEvaluateOpacity(shadingState);
+
+    const auto lighting =
+        aoFactor * rendererParams.ambientIntensity * rendererParams.ambientColor;
+
+    return vec4(materialBaseColor * lighting, materialOpacity);
+  }
+};
+
 VISRTX_GLOBAL void __raygen__()
 {
-  auto &rendererParams = frameData.renderer;
-  auto &aoParams = rendererParams.params.ao;
-
   auto ss = createScreenSample(frameData);
   if (pixelOutOfFrame(ss.pixel, frameData.fb))
     return;
 
-  for (int i = 0; i < frameData.renderer.numIterations; i++) {
-    auto ray = makePrimaryRay(ss);
-    float tmax = ray.t.upper;
-
-    SurfaceHit surfaceHit;
-    VolumeHit volumeHit;
-    vec3 outputColor(0.f);
-    vec3 outputNormal = ray.dir;
-    float outputOpacity = 0.f;
-    float depth = 1e30f;
-    uint32_t primID = ~0u;
-    uint32_t objID = ~0u;
-    uint32_t instID = ~0u;
-    bool firstHit = true;
-
-    while (outputOpacity < 0.99f) {
-      ray.t.upper = tmax;
-      surfaceHit.foundHit = false;
-      intersectSurface(ss,
-          ray,
-          RayType::PRIMARY,
-          &surfaceHit,
-          primaryRayOptiXFlags(rendererParams));
-
-      vec3 color(0.f);
-      float opacity = 0.f;
-
-      if (surfaceHit.foundHit) {
-        uint32_t vObjID = ~0u;
-        uint32_t vInstID = ~0u;
-        const float vDepth = rayMarchAllVolumes(ss,
-            ray,
-            RayType::PRIMARY,
-            surfaceHit.t,
-            rendererParams.inverseVolumeSamplingRate,
-            color,
-            opacity,
-            vObjID,
-            vInstID);
-
-        if (firstHit) {
-          const bool volumeFirst = vDepth < surfaceHit.t;
-          if (volumeFirst) {
-            outputNormal = -ray.dir;
-            depth = vDepth;
-            primID = 0;
-            objID = vObjID;
-            instID = vInstID;
-          } else {
-            outputNormal = surfaceHit.Ns;
-            depth = surfaceHit.t;
-            primID = computeGeometryPrimId(surfaceHit);
-            objID = surfaceHit.objID;
-            instID = surfaceHit.instID;
-          }
-          firstHit = false;
-        }
-
-        const float aoFactor = aoParams.aoSamples > 0
-            ? computeAO(ss,
-                  ray,
-                  RayType::AO,
-                  surfaceHit,
-                  rendererParams.occlusionDistance,
-                  aoParams.aoSamples)
-            : 1.f;
-
-        MaterialShadingState shadingState;
-        materialInitShading(
-            &shadingState, frameData, *surfaceHit.material, surfaceHit);
-        auto materialBaseColor = materialEvaluateTint(shadingState);
-        auto materialOpacity = materialEvaluateOpacity(shadingState);
-
-        const auto lighting = aoFactor * rendererParams.ambientIntensity
-            * rendererParams.ambientColor;
-        accumulateValue(color, materialBaseColor * lighting, opacity);
-        accumulateValue(opacity, materialOpacity, opacity);
-
-        color *= opacity;
-        accumulateValue(outputColor, color, outputOpacity);
-        accumulateValue(outputOpacity, opacity, outputOpacity);
-
-        ray.t.lower = surfaceHit.t + surfaceHit.epsilon;
-      } else {
-        uint32_t vObjID = ~0u;
-        uint32_t vInstID = ~0u;
-        const float volumeDepth = rayMarchAllVolumes(ss,
-            ray,
-            RayType::PRIMARY,
-            ray.t.upper,
-            rendererParams.inverseVolumeSamplingRate,
-            color,
-            opacity,
-            vObjID,
-            vInstID);
-
-        if (firstHit) {
-          if (opacity > 0.f) {
-            outputNormal = -ray.dir;
-          }
-          depth = min(depth, volumeDepth);
-          primID = 0;
-          objID = vObjID;
-          instID = vInstID;
-        }
-
-        color *= opacity;
-
-        const auto bg = getBackground(frameData, ss.screen, ray.dir);
-        const bool premultiplyBg = rendererParams.premultiplyBackground;
-        accumulateValue(
-            color, premultiplyBg ? vec3(bg) * bg.a : vec3(bg), opacity);
-        accumulateValue(opacity, bg.a, opacity);
-        accumulateValue(outputColor, color, outputOpacity);
-        accumulateValue(outputOpacity, opacity, outputOpacity);
-        break;
-      }
-    }
-
-    setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
-
-    accumPixelSample(frameData,
-        ss.pixel,
-        vec4(outputColor, outputOpacity),
-        depth,
-        outputColor,
-        outputNormal,
-        i);
-  }
+  renderPixel<AmbientOcclusionShadingPolicy>(frameData, ss);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/AmbientOcclusion_ptx.cu
+++ b/devices/rtx/device/renderer/AmbientOcclusion_ptx.cu
@@ -30,6 +30,7 @@
  */
 
 #include "gpu/evalShading.h"
+#include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/shading_api.h"
 
@@ -211,15 +212,14 @@ VISRTX_GLOBAL void __raygen__()
       }
     }
 
-    accumResults(frameData,
+    setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
+
+    accumPixelSample(frameData,
         ss.pixel,
         vec4(outputColor, outputOpacity),
         depth,
         outputColor,
         outputNormal,
-        primID,
-        objID,
-        instID,
         i);
   }
 }

--- a/devices/rtx/device/renderer/Debug_ptx.cu
+++ b/devices/rtx/device/renderer/Debug_ptx.cu
@@ -256,12 +256,7 @@ VISRTX_GLOBAL void __raygen__()
 
   setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
 
-  accumPixelSample(frameData,
-      ss.pixel,
-      vec4(color, 1.f),
-      depth,
-      color,
-      normal);
+  accumPixelSample(frameData, ss.pixel, vec4(color, 1.f), color, normal);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/Debug_ptx.cu
+++ b/devices/rtx/device/renderer/Debug_ptx.cu
@@ -30,6 +30,7 @@
  */
 
 #include "DebugMethod.h"
+#include "gpu/intersectRay.h"
 #include "gpu/shading_api.h"
 
 namespace visrtx {
@@ -253,15 +254,14 @@ VISRTX_GLOBAL void __raygen__()
     instID = vrd.instance->id;
   }
 
-  accumResults(frameData,
+  setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
+
+  accumPixelSample(frameData,
       ss.pixel,
       vec4(color, 1.f),
       depth,
       color,
-      normal,
-      primID,
-      objID,
-      instID);
+      normal);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/DirectLight.cpp
+++ b/devices/rtx/device/renderer/DirectLight.cpp
@@ -36,12 +36,13 @@
 namespace visrtx {
 
 static const std::vector<HitgroupFunctionNames> g_directLightHitNames = {
-    {"__closesthit__primary", "__anyhit__primary"},
+    {"__closesthit__shading", "__anyhit__shading"},
     {"__closesthit__shadow", "__anyhit__shadow"},
-    {"__closesthit__bounce", "__anyhit__bounce"}};
+};
 
 static const std::vector<std::string> g_directLightMissNames = {
-    "__miss__", "__miss__", "__miss__"};
+    "__miss__shading", "__miss__shadow"
+};
 
 DirectLight::DirectLight(DeviceGlobalState *s) : Renderer(s, 0.f) {}
 

--- a/devices/rtx/device/renderer/PathTracer_ptx.cu
+++ b/devices/rtx/device/renderer/PathTracer_ptx.cu
@@ -204,13 +204,8 @@ VISRTX_GLOBAL void __raygen__()
       printf("========== END: FrameID %i ==========\n", frameData.fb.frameID);
     setPixelIds(frameData.fb, ss.pixel, outDepth, primID, objID, instID);
 
-    accumPixelSample(frameData,
-        ss.pixel,
-        vec4(color, 1.f),
-        outDepth,
-        outColor,
-        outNormal,
-        i);
+    accumPixelSample(
+        frameData, ss.pixel, vec4(color, 1.f), outColor, outNormal, i);
   }
 }
 

--- a/devices/rtx/device/renderer/PathTracer_ptx.cu
+++ b/devices/rtx/device/renderer/PathTracer_ptx.cu
@@ -33,6 +33,7 @@
 
 #include "gpu/evalShading.h"
 #include "gpu/gpu_debug.h"
+#include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/shading_api.h"
 namespace visrtx {
@@ -201,15 +202,14 @@ VISRTX_GLOBAL void __raygen__()
       color = vec3(1) - color;
     if (debug())
       printf("========== END: FrameID %i ==========\n", frameData.fb.frameID);
-    accumResults(frameData,
+    setPixelIds(frameData.fb, ss.pixel, outDepth, primID, objID, instID);
+
+    accumPixelSample(frameData,
         ss.pixel,
         vec4(color, 1.f),
         outDepth,
         outColor,
         outNormal,
-        primID,
-        objID,
-        instID,
         i);
   }
 }

--- a/devices/rtx/device/renderer/Raycast_ptx.cu
+++ b/devices/rtx/device/renderer/Raycast_ptx.cu
@@ -33,13 +33,10 @@
 #include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/shading_api.h"
+#include "gpu/renderer/common.h"
+#include "gpu/renderer/raygen_helpers.h"
 
 namespace visrtx {
-
-enum class RayType
-{
-  PRIMARY
-};
 
 DECLARE_FRAME_DATA(frameData)
 
@@ -58,129 +55,36 @@ VISRTX_GLOBAL void __miss__()
   // no-op
 }
 
+// Raycast shading policy for templated rendering loop //////////////////////
+
+struct RaycastShadingPolicy
+{
+  static VISRTX_DEVICE vec4 shadeSurface(
+      const MaterialShadingState &shadingState,
+      ScreenSample &ss,
+      const Ray &ray,
+      const SurfaceHit &hit)
+  {
+    const auto &rendererParams = frameData.renderer;
+
+    // Simple cosine-weighted diffuse lighting
+    auto materialBaseColor = materialEvaluateTint(shadingState);
+    auto materialOpacity = materialEvaluateOpacity(shadingState);
+
+    const auto lighting = glm::abs(glm::dot(ray.dir, hit.Ns))
+        * rendererParams.ambientColor;
+
+    return vec4(materialBaseColor * lighting, materialOpacity);
+  }
+};
+
 VISRTX_GLOBAL void __raygen__()
 {
-  auto &rendererParams = frameData.renderer;
-
   auto ss = createScreenSample(frameData);
   if (pixelOutOfFrame(ss.pixel, frameData.fb))
     return;
-  auto ray = makePrimaryRay(ss, true /*pixel centered*/);
-  float tmax = ray.t.upper;
 
-  vec3 outputColor(0.f);
-  vec3 outputNormal = ray.dir;
-  float outputOpacity = 0.f;
-  float depth = 1e30f;
-  uint32_t primID = ~0u;
-  uint32_t objID = ~0u;
-  uint32_t instID = ~0u;
-  bool firstHit = true;
-
-  while (outputOpacity < 0.99f) {
-    SurfaceHit surfaceHit;
-    ray.t.upper = tmax;
-    surfaceHit.foundHit = false;
-    intersectSurface(ss,
-        ray,
-        RayType::PRIMARY,
-        &surfaceHit,
-        primaryRayOptiXFlags(rendererParams));
-
-    vec3 color(0.f);
-    float opacity = 0.f;
-
-    if (surfaceHit.foundHit) {
-      uint32_t vObjID = ~0u;
-      uint32_t vInstID = ~0u;
-      const float vDepth = rayMarchAllVolumes(ss,
-          ray,
-          RayType::PRIMARY,
-          surfaceHit.t,
-          rendererParams.inverseVolumeSamplingRate,
-          color,
-          opacity,
-          vObjID,
-          vInstID);
-
-      if (firstHit) {
-        const bool volumeFirst = vDepth < surfaceHit.t;
-        if (volumeFirst) {
-          outputNormal = -ray.dir;
-          depth = vDepth;
-          primID = 0;
-          objID = vObjID;
-          instID = vInstID;
-        } else {
-          outputNormal = surfaceHit.Ng;
-          depth = surfaceHit.t;
-          primID = computeGeometryPrimId(surfaceHit);
-          objID = surfaceHit.objID;
-          instID = surfaceHit.instID;
-        }
-        firstHit = false;
-      }
-
-      MaterialShadingState shadingState;
-      materialInitShading(
-          &shadingState, frameData, *surfaceHit.material, surfaceHit);
-      auto materialBaseColor = materialEvaluateTint(shadingState);
-      auto materialOpacity = materialEvaluateOpacity(shadingState);
-
-      const auto lighting = glm::abs(glm::dot(ray.dir, surfaceHit.Ns))
-          * rendererParams.ambientColor;
-      accumulateValue(color, materialBaseColor * lighting, opacity);
-      accumulateValue(opacity, materialOpacity, opacity);
-
-      color *= opacity;
-      accumulateValue(outputColor, color, outputOpacity);
-      accumulateValue(outputOpacity, opacity, outputOpacity);
-
-      ray.t.lower = surfaceHit.t + surfaceHit.epsilon;
-    } else {
-      uint32_t vObjID = ~0u;
-      uint32_t vInstID = ~0u;
-      const float volumeDepth = rayMarchAllVolumes(ss,
-          ray,
-          RayType::PRIMARY,
-          ray.t.upper,
-          rendererParams.inverseVolumeSamplingRate,
-          color,
-          opacity,
-          vObjID,
-          vInstID);
-
-      if (firstHit) {
-        if (opacity > 0.f) {
-          outputNormal = -ray.dir;
-        }
-        depth = min(depth, volumeDepth);
-        primID = 0;
-        objID = vObjID;
-        instID = vInstID;
-      }
-
-      color *= opacity;
-
-      const auto bg = getBackground(frameData, ss.screen, ray.dir);
-      const bool premultiplyBg = rendererParams.premultiplyBackground;
-      accumulateValue(
-          color, premultiplyBg ? vec3(bg) * bg.a : vec3(bg), opacity);
-      accumulateValue(opacity, bg.a, opacity);
-      accumulateValue(outputColor, color, outputOpacity);
-      accumulateValue(outputOpacity, opacity, outputOpacity);
-      break;
-    }
-  }
-
-  setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
-
-  accumPixelSample(frameData,
-      ss.pixel,
-      vec4(outputColor, outputOpacity),
-      depth,
-      outputColor,
-      outputNormal);
+  renderPixel<RaycastShadingPolicy>(frameData, ss);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/Raycast_ptx.cu
+++ b/devices/rtx/device/renderer/Raycast_ptx.cu
@@ -30,6 +30,7 @@
  */
 
 #include "gpu/evalShading.h"
+#include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/shading_api.h"
 
@@ -172,15 +173,14 @@ VISRTX_GLOBAL void __raygen__()
     }
   }
 
-  accumResults(frameData,
+  setPixelIds(frameData.fb, ss.pixel, depth, primID, objID, instID);
+
+  accumPixelSample(frameData,
       ss.pixel,
       vec4(outputColor, outputOpacity),
       depth,
       outputColor,
-      outputNormal,
-      primID,
-      objID,
-      instID);
+      outputNormal);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/Test_ptx.cu
+++ b/devices/rtx/device/renderer/Test_ptx.cu
@@ -59,12 +59,7 @@ VISRTX_GLOBAL void __raygen__()
 
   setPixelIds(frameData.fb, ss.pixel, 1.0f, ~0u, ~0u, ~0u);
 
-  accumPixelSample(frameData,
-      ss.pixel,
-      vec4(ray.dir, 1.f),
-      1.f,
-      ray.dir,
-      -ray.dir);
+  accumPixelSample(frameData, ss.pixel, vec4(ray.dir, 1.f), ray.dir, -ray.dir);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/Test_ptx.cu
+++ b/devices/rtx/device/renderer/Test_ptx.cu
@@ -57,15 +57,14 @@ VISRTX_GLOBAL void __raygen__()
     return;
   auto ray = makePrimaryRay(ss);
 
-  accumResults(frameData,
+  setPixelIds(frameData.fb, ss.pixel, 1.0f, ~0u, ~0u, ~0u);
+
+  accumPixelSample(frameData,
       ss.pixel,
       vec4(ray.dir, 1.f),
       1.f,
       ray.dir,
-      -ray.dir,
-      ~0u,
-      ~0u,
-      ~0u);
+      -ray.dir);
 }
 
 } // namespace visrtx


### PR DESCRIPTION
Consolidates duplicated ray traversal logic across renderers (Raycast, AmbientOcclusion, DirectLight) into a templated rendering loop in gpu/renderer/raygen_helpers.h.

Each renderer now provides a simple ShadingPolicy that implements surface shading, while the common loop handles ray marching, transparency traversal, and volume integration.

Key changes:

- Extract shared rendering loop into template accepting ShadingPolicy
- Standardize ray types across renderers (PRIMARY/SHADOW)
- Separate buffer ID assignment (setPixelIds) from pixel accumulation (accumPixelSample)
- Fix frameID sample count discrepancy by incrementing after render completes
- Simplify DirectLight indirect lighting to single-bounce cosine-weighted diffuse
- Add shared constants (OPACITY_THRESHOLD, MIN_CONTRIBUTION_EPSILON)
- Add opacity pass-through check to material shaders (MDL, PhysicallyBased)

PT, Debug and Test renderers are purposefully excluded from this rework as they don't fit into the exposed paradigm.
A quick assessment shows that performances are on par with our previous implementation.