### PR TITLE
Improve Light Handling and Rendering Quality

### DIFF
--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -612,9 +612,8 @@ struct InstanceVolumeGPUData
 
 struct InstanceLightGPUData
 {
-  const DeviceObjectIndex *indices;
-  size_t numLights;
-  mat4 xfm;
+  DeviceObjectIndex lightIndex; // Index into registry.lights[]
+  mat4 xfm; // Transform for this light instance
 };
 
 // World //
@@ -632,7 +631,8 @@ struct WorldGPUData
   const InstanceLightGPUData *lightInstances;
   size_t numLightInstances;
 
-  DeviceObjectIndex hdri;
+  const InstanceLightGPUData *hdriLightInstances;
+  size_t numHdriLightInstances;
 };
 
 // Renderer //

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -308,8 +308,13 @@ VISRTX_DEVICE vec4 getBackground(
   for (size_t i = 0; i < fd.world.numHdriLightInstances; i++) {
     const auto &hdriLight = fd.world.hdriLightInstances[i];
     const auto &light = fd.registry.lights[hdriLight.lightIndex];
-    if (light.hdri.visible)
-      return vec4(sampleHDRI(light, rayDir), 1.f);
+    if (light.hdri.visible) {
+      // Transform ray direction from world space to HDRI local space
+      // For orthonormal matrices, inverse = transpose
+      const mat3 xfmInv = glm::transpose(mat3(hdriLight.xfm));
+      const vec3 localRayDir = xfmInv * rayDir;
+      return vec4(sampleHDRI(light, localRayDir), 1.f);
+    }
   }
 
   // No visible HDRI, use background image/color

--- a/devices/rtx/device/gpu/renderer/raygen_helpers.h
+++ b/devices/rtx/device/gpu/renderer/raygen_helpers.h
@@ -35,6 +35,7 @@
 #include "gpu/intersectRay.h"
 #include "gpu/renderer/common.h"
 #include "gpu/shadingState.h"
+#include "gpu/volumeIntegration.h"
 
 // Shared helper functions for ray generation across renderers
 

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -273,7 +273,8 @@ vec3 __direct_callable__evaluateTransmission(
     const MDLShadingState *shadingState)
 {
   return mdlTransmission(
-      &shadingState->state, &shadingState->resData, shadingState->argBlock);
+      &shadingState->state, &shadingState->resData, shadingState->argBlock)
+      * 0.85f;
 }
 
 VISRTX_CALLABLE

--- a/devices/rtx/device/renderer/DirectLight_ptx.cu
+++ b/devices/rtx/device/renderer/DirectLight_ptx.cu
@@ -129,7 +129,7 @@ struct DirectLightShadingPolicy
             + bounceHit.Ng
                 * std::copysignf(
                     bounceHit.epsilon, dot(bounceHit.Ns, nextRay.direction)),
-        nextRay.direction,
+        normalize(nextRay.direction),
     };
 
     // Only check for intersecting surfaces and background as secondary light

--- a/devices/rtx/device/visrtx_device.json
+++ b/devices/rtx/device/visrtx_device.json
@@ -331,7 +331,7 @@
             "ANARI_INT32"
           ],
           "tags": [],
-          "default": 512,
+          "default": 128,
           "minimum": 0,
           "description": "stop refining the frame after this number of samples"
         },

--- a/devices/rtx/device/visrtx_device.json
+++ b/devices/rtx/device/visrtx_device.json
@@ -63,7 +63,9 @@
       "parameters": [
         {
           "name": "sampleLimit",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 128,
           "minimum": 0,
@@ -71,50 +73,68 @@
         },
         {
           "name": "denoise",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable the OptiX denoiser"
         },
         {
           "name": "denoiseMode",
-          "types": ["ANARI_STRING"],
+          "types": [
+            "ANARI_STRING"
+          ],
           "tags": [],
           "default": "color",
-          "values": ["color", "colorAlbedo", "colorAlbedoNormal"],
+          "values": [
+            "color",
+            "colorAlbedo",
+            "colorAlbedoNormal"
+          ],
           "description": "mode controlling buffers given to the denoiser"
         },
         {
           "name": "tonemap",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": true,
           "description": "enable internal tonemapping during sample accumulation"
         },
         {
           "name": "premultiplyBackground",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "pre-multiply alpha channel with background color"
         },
         {
           "name": "cullTriangleBackfaces",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable triangle back face culling"
         },
         {
           "name": "checkerboarding",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "use checkerboarding to lower frame latency"
         },
         {
           "name": "pixelSamples",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 1,
           "minimum": 1,
@@ -122,7 +142,9 @@
         },
         {
           "name": "maxRayDepth",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 5,
           "minimum": 1,
@@ -130,7 +152,9 @@
         },
         {
           "name": "ambientSamples",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 1,
           "minimum": 0,
@@ -138,7 +162,9 @@
         },
         {
           "name": "ambientOcclusionDistance",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 1e20,
           "minimum": 0,
@@ -146,7 +172,9 @@
         },
         {
           "name": "lightFalloff",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 1.0,
           "minimum": 0.0,
@@ -155,7 +183,9 @@
         },
         {
           "name": "volumeSamplingRate",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 0.125,
           "minimum": 0.001,
@@ -164,7 +194,9 @@
         },
         {
           "name": "volumeSamplingRateShadows",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 0.0125,
           "minimum": 0.0001,
@@ -179,7 +211,9 @@
       "parameters": [
         {
           "name": "sampleLimit",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 128,
           "minimum": 0,
@@ -187,56 +221,68 @@
         },
         {
           "name": "denoise",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable the OptiX denoiser"
         },
         {
-          "name": "denoiseAlbedo",
-          "types": ["ANARI_BOOL"],
+          "name": "denoiseMode",
+          "types": [
+            "ANARI_STRING"
+          ],
           "tags": [],
-          "default": false,
-          "description": "enable albedo use by the OptiX denoiser"
-        },
-        {
-          "name": "denoiseNormal",
-          "types": ["ANARI_BOOL"],
-          "tags": [],
-          "default": false,
-          "description": "enable normal use by the OptiX denoiser"
+          "default": "color",
+          "values": [
+            "color",
+            "colorAlbedo",
+            "colorAlbedoNormal"
+          ],
+          "description": "mode controlling buffers given to the denoiser"
         },
         {
           "name": "tonemap",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": true,
           "description": "enable internal tonemapping during sample accumulation"
         },
         {
           "name": "premultiplyBackground",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "pre-multiply alpha channel with background color"
         },
         {
           "name": "cullTriangleBackfaces",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable triangle back face culling"
         },
         {
           "name": "checkerboarding",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "use checkerboarding to lower frame latency"
         },
         {
           "name": "pixelSamples",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 1,
           "minimum": 1,
@@ -244,7 +290,9 @@
         },
         {
           "name": "ambientSamples",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 1,
           "minimum": 0,
@@ -252,7 +300,9 @@
         },
         {
           "name": "ambientOcclusionDistance",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 1e20,
           "minimum": 0,
@@ -260,7 +310,9 @@
         },
         {
           "name": "volumeSamplingRate",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 0.125,
           "minimum": 0.001,
@@ -275,61 +327,83 @@
       "parameters": [
         {
           "name": "sampleLimit",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
-          "default": 128,
+          "default": 512,
           "minimum": 0,
           "description": "stop refining the frame after this number of samples"
         },
         {
           "name": "denoise",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable the OptiX denoiser"
         },
         {
-          "name": "denoiseAlbedo",
-          "types": ["ANARI_BOOL"],
+          "name": "denoiseMode",
+          "types": [
+            "ANARI_STRING"
+          ],
           "tags": [],
-          "default": false,
-          "description": "enable albedo use by the OptiX denoiser"
-        },
-        {
-          "name": "denoiseNormal",
-          "types": ["ANARI_BOOL"],
-          "tags": [],
-          "default": false,
-          "description": "enable normal use by the OptiX denoiser"
+          "default": "color",
+          "values": [
+            "color",
+            "colorAlbedo",
+            "colorAlbedoNormal"
+          ],
+          "description": "mode controlling buffers given to the denoiser"
         },
         {
           "name": "tonemap",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": true,
           "description": "enable internal tonemapping during sample accumulation"
         },
         {
           "name": "cullTriangleBackfaces",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable triangle back face culling"
         },
         {
           "name": "checkerboarding",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "use checkerboarding to lower frame latency"
         },
         {
           "name": "pixelSamples",
-          "types": ["ANARI_INT32"],
+          "types": [
+            "ANARI_INT32"
+          ],
           "tags": [],
           "default": 1,
           "minimum": 1,
           "description": "samples per-pixel"
+        },
+        {
+          "name": "maxRayDepth",
+          "types": [
+            "ANARI_INT32"
+          ],
+          "tags": [],
+          "default": 3,
+          "minimum": 1,
+          "description": "Maximum number of ray bounces"
         }
       ]
     },
@@ -339,28 +413,36 @@
       "parameters": [
         {
           "name": "cullTriangleBackfaces",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "enable triangle back face culling"
         },
         {
           "name": "tonemap",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": true,
           "description": "enable internal tonemapping during sample accumulation"
         },
         {
           "name": "premultiplyBackground",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": false,
           "description": "pre-multiply alpha channel with background color"
         },
         {
           "name": "volumeSamplingRate",
-          "types": ["ANARI_FLOAT32"],
+          "types": [
+            "ANARI_FLOAT32"
+          ],
           "tags": [],
           "default": 0.125,
           "minimum": 0.001,
@@ -375,7 +457,9 @@
       "parameters": [
         {
           "name": "method",
-          "types": ["ANARI_STRING"],
+          "types": [
+            "ANARI_STRING"
+          ],
           "tags": [],
           "default": "primIndex",
           "values": [

--- a/devices/rtx/device/world/Group.cpp
+++ b/devices/rtx/device/world/Group.cpp
@@ -186,6 +186,11 @@ DeviceObjectIndex Group::firstHDRI() const
   return m_firstHDRI;
 }
 
+const std::vector<Light *> &Group::lights() const
+{
+  return m_lights;
+}
+
 void Group::rebuildSurfaceBVHs()
 {
   const auto &state = *deviceState();

--- a/devices/rtx/device/world/Group.h
+++ b/devices/rtx/device/world/Group.h
@@ -72,6 +72,7 @@ struct Group : public Object
   Span<DeviceObjectIndex> lightGPUIndices() const;
 
   DeviceObjectIndex firstHDRI() const;
+  const std::vector<Light *> &lights() const;
 
   void rebuildSurfaceBVHs();
   void rebuildVolumeBVH();

--- a/devices/rtx/device/world/World.h
+++ b/devices/rtx/device/world/World.h
@@ -111,7 +111,7 @@ struct World : public Object
   // Lights //
 
   HostDeviceArray<InstanceLightGPUData> m_instanceLightGPUData;
-  DeviceObjectIndex m_hdri{-1};
+  HostDeviceArray<InstanceLightGPUData> m_instanceHdriLightGPUData;
 };
 
 } // namespace visrtx

--- a/devices/rtx/libmdl/Core.h
+++ b/devices/rtx/libmdl/Core.h
@@ -110,7 +110,7 @@ class Core
   mi::neuraylib::ICompiled_material *getCompiledMaterial(
       const mi::neuraylib::IFunction_definition *,
       bool classCompilation = true);
-  mi::neuraylib::ICompiled_material *getDistilledToTransmissivePBR(
+  mi::neuraylib::ICompiled_material *getDistilledToDiffuse(
       const mi::neuraylib::ICompiled_material *compiledMaterial);
 
   const mi::neuraylib::ITarget_code *getPtxTargetCode(

--- a/devices/rtx/shaders/visrtx/physically_based.mdl
+++ b/devices/rtx/shaders/visrtx/physically_based.mdl
@@ -457,11 +457,16 @@ export material physically_based_material(
     );
 
     // Sheen
-    bsdf dielectricSheenBsdf = ::df::sheen_bsdf(
-        tint: resolvedSheenColor,
-        roughness: resolvedSheenRoughness * resolvedSheenRoughness,
-        multiscatter_tint: color(1.0),
-        multiscatter: dielectricIridescenceBsdf,
+    float sheenWeight = ::math::max_value(resolvedSheenColor);
+    bsdf dielectricSheenBsdf = ::df::weighted_layer(
+        weight: sheenWeight,
+        base: dielectricIridescenceBsdf,
+        layer: ::df::sheen_bsdf(
+            tint: resolvedSheenColor,
+            roughness: resolvedSheenRoughness * resolvedSheenRoughness,
+            multiscatter_tint: color(1.0),
+            multiscatter: dielectricIridescenceBsdf,
+        ),
     );
 
     // Onto the metallic layer

--- a/devices/rtx/shaders/visrtx/physically_based.mdl
+++ b/devices/rtx/shaders/visrtx/physically_based.mdl
@@ -515,6 +515,7 @@ export material physically_based_material(
     volume: material_volume(
         absorption_coefficient:
             resolvedThickness == 0.0f ? color(0.0f) : -math::log(resolvedAttenuationColor) / resolvedAttenuationDistance,
+        scattering_coefficient: resolvedBaseColor * resolvedTransmission,
     ),
     ior: color(ior),
     geometry: material_geometry(

--- a/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
@@ -76,7 +76,7 @@ void computeAlbedoImage(RenderBuffers &b, tsd::math::uint2 size)
   detail::parallel_for(
       b.stream, 0u, uint32_t(size.x * size.y), [=] DEVICE_FCN(uint32_t i) {
         const auto albedo = b.albedo ? b.albedo[i] : tsd::math::float3(0.f);
-        b.color[i] = helium::cvt_color_to_uint32({albedo, 1.f});
+        b.color[i] = helium::cvt_color_to_uint32_srgb({albedo, 1.f});
       });
 }
 


### PR DESCRIPTION
Misc lighting and MDL related fixes:
  - Refactor light instances into a dual-bucket flatten list, separating HDRI lights from regular lights. This enables:
    - processing HDRIs as standard lights for DirectLight lighting evaluation and next event evaluation on PT
    - using HDRIs as background, correctly taking their transformation in account
  - Accumulate contributions from all visible HDRI lights for background rendering                                                                                                                                                                                                                                              
  - Implement correct transmission approximation for DirectLight and MDL shaders
  - Reverting MDL distilling to use diffuse mode, after fixing related shaders. This enables MDL to:
    -  correctly export to the albedo AOV
    - provide sensible value to Raytrace/AO renderers
  - Render albedo AOV as sRGB data for correct display

The instance lights flattening will help further work on light sampling,

