### PR TITLE
Improve volume sampling and fix rendering issues

### DIFF
--- a/devices/rtx/device/gpu/gpu_math.h
+++ b/devices/rtx/device/gpu/gpu_math.h
@@ -143,6 +143,9 @@ struct SurfaceHit
 
 struct VolumeHit
 {
+  mat3x4 worldToObject;
+  mat3x4 objectToWorld;
+
   const VolumeGPUData *volume{nullptr};
   const InstanceVolumeGPUData *instance{nullptr};
   Ray localRay;

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -416,11 +416,18 @@ struct StructuredRegularData
   StructuredRegularData() = default;
 };
 
+enum class SpatialFieldFilter : uint8_t
+{
+  Nearest = 0,
+  Linear = 1
+};
+
 struct NVdbRegularData
 {
   nanovdb::GridType gridType;
   const void *gridData;
   bool cellCentered;
+  SpatialFieldFilter filter;
 
   NVdbRegularData() = default;
 };
@@ -442,6 +449,7 @@ struct NVdbRectilinearData
   nanovdb::GridType gridType;
   const void *gridData;
   bool cellCentered;
+  SpatialFieldFilter filter;
   cudaTextureObject_t axisLUT[3];
 
   NVdbRectilinearData() = default;

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -451,6 +451,7 @@ struct NVdbRectilinearData
   bool cellCentered;
   SpatialFieldFilter filter;
   cudaTextureObject_t axisLUT[3];
+  vec3 invAvgVoxelSize;
 
   NVdbRectilinearData() = default;
 };

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -402,6 +402,18 @@ VISRTX_DEVICE void populateVolumeHit(VolumeHit &hit)
   hit.localRay.dir = ray::volume_local_direction();
   hit.localRay.t.lower = ray::t();
   hit.localRay.t.upper = ray::volume_out_t();
+
+  const auto &handle = optixGetTransformListHandle(0);
+  const ::float4 *tW = optixGetInstanceTransformFromHandle(handle);
+  const ::float4 *tO = optixGetInstanceInverseTransformFromHandle(handle);
+
+  hit.objectToWorld[0] = bit_cast<vec4>(tW[0]);
+  hit.objectToWorld[1] = bit_cast<vec4>(tW[1]);
+  hit.objectToWorld[2] = bit_cast<vec4>(tW[2]);
+
+  hit.worldToObject[0] = bit_cast<vec4>(tO[0]);
+  hit.worldToObject[1] = bit_cast<vec4>(tO[1]);
+  hit.worldToObject[2] = bit_cast<vec4>(tO[2]);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -149,6 +149,7 @@ struct StructuredRectilinearSamplerState
   cudaTextureObject_t axisLUT[3];
   vec3 axisBoundsMin;
   vec3 axisBoundsMax;
+  vec3 invAvgVoxelSpacing;
 };
 
 // NanoVDB Sampler States
@@ -198,6 +199,7 @@ struct NvdbRectilinearSamplerState
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
   cudaTextureObject_t axisLUT[3];
+  nanovdb::Vec3f invAvgVoxelSize;
   SpatialFieldFilter filter;
 };
 

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -157,16 +157,22 @@ struct NvdbRegularSamplerState
 {
   using GridType = nanovdb::Grid<nanovdb::NanoTree<T>>;
   using AccessorType = typename GridType::AccessorType;
-  using SamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
+  using NearestSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 0>;
+  using LinearSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
 
   const GridType *grid;
   AccessorType accessor;
-  SamplerType sampler;
+  union
+  {
+    NearestSamplerType nearestSampler;
+    LinearSamplerType linearSampler;
+  };
   nanovdb::Vec3f offsetDown;
   nanovdb::Vec3f offsetUp;
   nanovdb::Vec3f scale;
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
+  SpatialFieldFilter filter;
 };
 
 // NanoVDB Rectilinear Sampler States
@@ -175,11 +181,16 @@ struct NvdbRectilinearSamplerState
 {
   using GridType = nanovdb::Grid<nanovdb::NanoTree<T>>;
   using AccessorType = typename GridType::AccessorType;
-  using SamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
+  using NearestSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 0>;
+  using LinearSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
 
   const GridType *grid;
   AccessorType accessor;
-  SamplerType sampler;
+  union
+  {
+    NearestSamplerType nearestSampler;
+    LinearSamplerType linearSampler;
+  };
   nanovdb::Vec3f offsetDown;
   nanovdb::Vec3f offsetUp;
   nanovdb::Vec3f scaleDown;
@@ -187,6 +198,7 @@ struct NvdbRectilinearSamplerState
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
   cudaTextureObject_t axisLUT[3];
+  SpatialFieldFilter filter;
 };
 
 struct VolumeSamplingState

--- a/devices/rtx/device/material/MDL.h
+++ b/devices/rtx/device/material/MDL.h
@@ -71,9 +71,9 @@ struct MDL : public Material
   std::string m_source;
   std::string m_sourceType;
   struct SamplerDesc {
-    Sampler* sampler;
+    Sampler* sampler = nullptr;
     std::string name;
-    bool isFromRegistry;
+    bool isFromRegistry = false;
     bool operator==(const SamplerDesc &other) const {
       return sampler == other.sampler && name == other.name &&
              isFromRegistry == other.isFromRegistry;

--- a/devices/rtx/device/spatial_field/NvdbRectilinearField.cpp
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearField.cpp
@@ -246,6 +246,9 @@ SpatialFieldGPUData NvdbRectilinearField::gpuData() const
   sf.data.nvdbRectilinear.gridData = m_deviceBuffer.ptr();
   sf.data.nvdbRectilinear.gridType = gridType;
   sf.data.nvdbRectilinear.cellCentered = m_cellCentered;
+  sf.data.nvdbRectilinear.filter = (m_filter == "nearest")
+      ? SpatialFieldFilter::Nearest
+      : SpatialFieldFilter::Linear;
 
   sf.data.nvdbRectilinear.axisLUT[0] = m_axisLutTextures[0];
   sf.data.nvdbRectilinear.axisLUT[1] = m_axisLutTextures[1];

--- a/devices/rtx/device/spatial_field/NvdbRectilinearField.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearField.h
@@ -60,6 +60,7 @@ struct NvdbRectilinearField : public SpatialField
 
   box3 m_bounds;
   vec3 m_voxelSize;
+  vec3 m_invAvgVoxelSize;
   std::string m_filter;
   bool m_cellCentered{true};
   box3 m_roi{box3(vec3(std::numeric_limits<float>::lowest()),

--- a/devices/rtx/device/spatial_field/NvdbRegularField.cpp
+++ b/devices/rtx/device/spatial_field/NvdbRegularField.cpp
@@ -166,6 +166,9 @@ SpatialFieldGPUData NvdbRegularField::gpuData() const
   sf.data.nvdbRegular.gridData = m_deviceBuffer.ptr();
   sf.data.nvdbRegular.gridType = gridType;
   sf.data.nvdbRegular.cellCentered = m_cellCentered;
+  sf.data.nvdbRegular.filter = (m_filter == "nearest")
+      ? SpatialFieldFilter::Nearest
+      : SpatialFieldFilter::Linear;
 
   sf.grid = m_uniformGrid.gpuData();
 

--- a/devices/rtx/device/spatial_field/NvdbRegularSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/NvdbRegularSampler_ptx.cu
@@ -74,7 +74,7 @@ VISRTX_DEVICE void initNvdbSampler(
     state.scale = nanovdb::Vec3f(1.0f);
   } else {
     state.offsetUp = state.offsetDown;
-    state.scale = (dims) / (dims + nanovdb::Vec3f(1.0f));
+    state.scale = (dims - nanovdb::Vec3f(1.0f)) / dims;
   }
 
   state.indexMin = nanovdb::Vec3f(indexBBox.min());

--- a/devices/rtx/device/visrtx_device.json
+++ b/devices/rtx/device/visrtx_device.json
@@ -141,16 +141,6 @@
           "description": "samples per-pixel"
         },
         {
-          "name": "maxRayDepth",
-          "types": [
-            "ANARI_INT32"
-          ],
-          "tags": [],
-          "default": 5,
-          "minimum": 1,
-          "description": "Maximum number of ray bounces"
-        },
-        {
           "name": "ambientSamples",
           "types": [
             "ANARI_INT32"

--- a/devices/rtx/device/volume/TransferFunction1D.cpp
+++ b/devices/rtx/device/volume/TransferFunction1D.cpp
@@ -71,6 +71,12 @@ void TransferFunction1D::finalize()
     return;
   }
 
+  if (m_unitDistance <= 0.f) {
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "unitDistance must be positive on transferFunction1D volume, clamping to minimum");
+    m_unitDistance = 1e-6f;
+  }
+
   discritizeTFData();
   createTFTexture();
   m_field->m_uniformGrid.computeMaxOpacities(
@@ -91,7 +97,7 @@ VolumeGPUData TransferFunction1D::gpuData() const
   retval.stepSize = m_field->stepSize();
   retval.data.tf1d.tfTex = m_textureObject;
   retval.data.tf1d.valueRange = m_valueRange;
-  retval.data.tf1d.oneOverUnitDistance = 1.0f / m_unitDistance;
+  retval.data.tf1d.oneOverUnitDistance = 1.0f / glm::max(m_unitDistance, 1e-6f);
   retval.data.tf1d.field = m_field->index();
   retval.data.tf1d.uniformColor = vec3(m_uniformColor);
   retval.data.tf1d.uniformOpacity = m_uniformOpacity;

--- a/devices/rtx/libmdl/types.h
+++ b/devices/rtx/libmdl/types.h
@@ -26,7 +26,7 @@ enum class Shape
 
 struct TextureDescriptor
 {
-  uint64_t knownIndex;
+  uint64_t knownIndex = 0;
 
   std::string url;
   ColorSpace colorSpace{ColorSpace::sRGB};


### PR DESCRIPTION
- Nearest neighbour interpolation for NanoVDB volumes
- Volume gradient/normal computation across all spatial field types for shading support
- MDL fix for texture resource null-pointer dereference and uninitialized memory access
- Infinite accumulation when unitDistance is 0 in transfer function volumes
- Unused maxRayDepth from default/directLight renderer JSON