### PR TITLE
import_GLTF to signal layer change on load

### DIFF
--- a/tsd/src/tsd/io/importers/import_GLTF.cpp
+++ b/tsd/src/tsd/io/importers/import_GLTF.cpp
@@ -1394,6 +1394,8 @@ void import_GLTF(Scene &scene, const char *filename, LayerNodeRef location)
   } else {
     logWarning("[import_GLTF] no scenes found in glTF file");
   }
+
+  scene.signalLayerChange(targetLocation->container());
 }
 
 } // namespace tsd::io


### PR DESCRIPTION
Otherwise, loading a gltf file after the scene settles might not be captured by the render index.