### PR TITLE
MDL texture fixes

### DIFF
--- a/devices/rtx/device/volume/TransferFunction1D.cpp
+++ b/devices/rtx/device/volume/TransferFunction1D.cpp
@@ -80,7 +80,7 @@ void TransferFunction1D::finalize()
   discritizeTFData();
   createTFTexture();
   m_field->m_uniformGrid.computeMaxOpacities(
-      deviceState()->stream, m_textureObject, m_tfDim);
+      deviceState()->stream, m_textureObject, m_tfDim, m_valueRange);
   upload();
 }
 


### PR DESCRIPTION
MDL does not know 1D texture and tries to access them as a 2D texture.
In that case, invSize was incorrectly computed leading to incorrect texture access.

Also fix computeMaxOpacities call in TransferFunction1D.