### PR TITLE
 Add Transform object type and instance attribute composition to TSD

### DIFF
--- a/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
+++ b/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
@@ -45,11 +45,12 @@ void InstancingControls::buildUI()
 void InstancingControls::createScene()
 {
   auto &scene = appCore()->tsd.scene;
-  auto *layer = scene.defaultLayer();
 
   // Clear out previous scene //
 
   scene.removeAllObjects();
+
+  auto *layer = scene.defaultLayer();
 
   // Default (global) material //
 
@@ -130,8 +131,11 @@ void InstancingControls::generateInstances()
   size_t numXfms = size_t(m_numInstances);
   auto xfmArray = scene.createArray(ANARI_FLOAT32_MAT4, numXfms);
 
-  auto xfmArrayNode =
-      scene.defaultLayer()->root()->insert_last_child({xfmArray});
+  auto xfmTransform = scene.createTransform("array_instances");
+  xfmTransform->setParameterObject("transform", *xfmArray);
+
+  auto xfmNode =
+      scene.defaultLayer()->root()->insert_last_child({xfmTransform});
 
   std::mt19937 rng;
   rng.seed(0);
@@ -160,13 +164,12 @@ void InstancingControls::generateInstances()
   });
   attrArray->unmap();
 
-  (*xfmArrayNode)
-      ->setInstanceParameter(
-          "color", tsd::core::Any(ANARI_ARRAY1D, attrArray.index()));
+  (*xfmNode)->getTransformObject()->setParameter(
+      "color", tsd::core::Any(ANARI_ARRAY1D, attrArray.index()));
 
   // Generate mesh //
 
-  tsd::io::generate_monkey(scene, xfmArrayNode);
+  tsd::io::generate_monkey(scene, xfmNode);
 }
 
 } // namespace tsd::demo

--- a/tsd/src/anari_tsd/World.cpp
+++ b/tsd/src/anari_tsd/World.cpp
@@ -120,7 +120,8 @@ void World::updateLayer()
   l->erase_subtree(l->root());
 
   for (auto *inst : m_instances) {
-    auto instNode = l->root()->insert_last_child(inst->xfm());
+    auto instNode = deviceState()->scene.insertChildTransformNode(
+        l->root(), inst->xfm());
     inst->group()->addObjectsToLayer(instNode);
   }
 

--- a/tsd/src/tsd/app/ANARIDeviceManager.cpp
+++ b/tsd/src/tsd/app/ANARIDeviceManager.cpp
@@ -147,12 +147,16 @@ tsd::rendering::RenderIndex *ANARIDeviceManager::acquireRenderIndex(
 {
   auto &liveIdx = m_rIdxs[d];
   if (liveIdx.refCount == 0) {
-    if (useFlatRenderIndex()) {
+    switch (renderIndexKind()) {
+    case RenderIndexKind::FLAT:
       liveIdx.idx =
           m_delegate.emplace<tsd::rendering::RenderIndexFlatRegistry>(c, n, d);
-    } else {
+      break;
+    case RenderIndexKind::ALL_LAYERS:
+    default:
       liveIdx.idx =
           m_delegate.emplace<tsd::rendering::RenderIndexAllLayers>(c, n, d);
+      break;
     }
     liveIdx.idx->populate(false);
   }
@@ -184,25 +188,34 @@ tsd::core::MultiUpdateDelegate &ANARIDeviceManager::getUpdateDelegate()
   return m_delegate;
 }
 
-void ANARIDeviceManager::setUseFlatRenderIndex(bool f)
+void ANARIDeviceManager::setRenderIndexKind(RenderIndexKind k)
 {
-  m_settings.forceFlat = f;
+  m_settings.renderIndexKind = k;
 }
 
-bool ANARIDeviceManager::useFlatRenderIndex() const
+RenderIndexKind ANARIDeviceManager::renderIndexKind() const
 {
-  return m_settings.forceFlat;
+  return m_settings.renderIndexKind;
 }
 
 void ANARIDeviceManager::saveSettings(tsd::core::DataNode &root)
 {
-  root.reset(); // clear all previous values, if they exist
-  root["useFlatRenderIndex"] = m_settings.forceFlat;
+  root.reset();
+  root["renderIndexKind"] = static_cast<int>(m_settings.renderIndexKind);
 }
 
 void ANARIDeviceManager::loadSettings(tsd::core::DataNode &root)
 {
-  root["useFlatRenderIndex"].getValue(ANARI_BOOL, &m_settings.forceFlat);
+  int kind = 0;
+  if (root["renderIndexKind"].getValue(ANARI_INT32, &kind)) {
+    m_settings.renderIndexKind = static_cast<RenderIndexKind>(kind);
+  } else {
+    // Backward compatibility with old bool keys
+    bool flat = false;
+    root["useFlatRenderIndex"].getValue(ANARI_BOOL, &flat);
+    if (flat)
+      m_settings.renderIndexKind = RenderIndexKind::FLAT;
+  }
 }
 
 } // namespace tsd::app

--- a/tsd/src/tsd/app/ANARIDeviceManager.h
+++ b/tsd/src/tsd/app/ANARIDeviceManager.h
@@ -13,6 +13,12 @@
 
 namespace tsd::app {
 
+enum class RenderIndexKind : int
+{
+  ALL_LAYERS = 0,
+  FLAT
+};
+
 using DeviceInitParam = std::pair<std::string, tsd::core::Any>;
 
 struct ANARIDeviceManager
@@ -33,9 +39,8 @@ struct ANARIDeviceManager
 
   tsd::core::MultiUpdateDelegate &getUpdateDelegate();
 
-  void setUseFlatRenderIndex(
-      bool f); // next acquireRenderIndex(...) will use flat render index
-  bool useFlatRenderIndex() const;
+  void setRenderIndexKind(RenderIndexKind k);
+  RenderIndexKind renderIndexKind() const;
 
   void saveSettings(tsd::core::DataNode &root);
   void loadSettings(tsd::core::DataNode &root);
@@ -57,10 +62,7 @@ struct ANARIDeviceManager
 
   struct Settings
   {
-    // Use flat render index by default, unless set otherwise
-    // This is to avoid issues with instancing in the scene graph
-    // and to allow for faster rendering in some cases.
-    bool forceFlat{false};
+    RenderIndexKind renderIndexKind{RenderIndexKind::ALL_LAYERS};
   } m_settings;
 };
 

--- a/tsd/src/tsd/core/Any.hpp
+++ b/tsd/src/tsd/core/Any.hpp
@@ -145,7 +145,7 @@ inline Any::Any(ANARIDataType type, size_t v) : Any()
 {
   if (anari::isObject(type)) {
     m_type = type;
-    std::memcpy(m_storage.data(), &v, anari::sizeOf(type));
+    std::memcpy(m_storage.data(), &v, sizeof(v));
   }
 }
 

--- a/tsd/src/tsd/core/Any.hpp
+++ b/tsd/src/tsd/core/Any.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+// tsd
+#include "tsd/core/TSDTypes.hpp"
 // anari
 #include <anari/anari_cpp.hpp>
 // std
@@ -143,7 +145,7 @@ inline Any::Any(ANARIDataType type, const void *v) : Any()
 
 inline Any::Any(ANARIDataType type, size_t v) : Any()
 {
-  if (anari::isObject(type)) {
+  if (anari::isObject(type) || isTSDTransform(type)) {
     m_type = type;
     std::memcpy(m_storage.data(), &v, sizeof(v));
   }
@@ -190,9 +192,10 @@ inline bool Any::operator==(const Any &rhs) const
   else if (type() == ANARI_STRING)
     return m_string == rhs.m_string;
   else {
-    return std::equal(m_storage.data(),
-        m_storage.data() + ::anari::sizeOf(type()),
-        rhs.m_storage.data());
+    size_t cmpSize =
+        isTSDTransform(type()) ? sizeof(size_t) : ::anari::sizeOf(type());
+    return std::equal(
+        m_storage.data(), m_storage.data() + cmpSize, rhs.m_storage.data());
   }
 }
 
@@ -270,7 +273,7 @@ inline bool Any::is(ANARIDataType t) const
 
 inline bool Any::holdsObject() const
 {
-  return anari::isObject(this->type());
+  return anari::isObject(this->type()) || isTSDTransform(this->type());
 }
 
 inline ANARIDataType Any::type() const

--- a/tsd/src/tsd/core/CMakeLists.txt
+++ b/tsd/src/tsd/core/CMakeLists.txt
@@ -29,6 +29,7 @@ PRIVATE
   scene/objects/Sampler.cpp
   scene/objects/SpatialField.cpp
   scene/objects/Surface.cpp
+  scene/objects/Transform.cpp
   scene/objects/Volume.cpp
   AnariObjectCache.cpp
   ColorMapUtil.cpp

--- a/tsd/src/tsd/core/DataTree.hpp
+++ b/tsd/src/tsd/core/DataTree.hpp
@@ -620,9 +620,7 @@ inline void DataTree::print()
     for (int i = 1; i < level; i++)
       printf("    ");
 
-    if (!node.isLeaf())
-      printf("%s:\n", node.name().c_str());
-    else {
+    {
       printf("%s: ", node.name().c_str());
 
       if (node.holdsObjectIdx()) {

--- a/tsd/src/tsd/core/Forest.hpp
+++ b/tsd/src/tsd/core/Forest.hpp
@@ -671,6 +671,8 @@ inline void forall_children(ForestNodeRef<T> node, FCN &&fcn)
 template <typename T, typename PREDICATE>
 inline ForestNodeRef<T> find_first_child(ForestNodeRef<T> n, PREDICATE &&p)
 {
+  if (n->isLeaf())
+    return {};
   for (auto s = n->next(); s && s != n; s = s->sibling()) {
     if (p(**s))
       return s;

--- a/tsd/src/tsd/core/ObjectPool.hpp
+++ b/tsd/src/tsd/core/ObjectPool.hpp
@@ -51,6 +51,8 @@ struct ObjectPool
   template <typename U>
   void sync_slots(const ObjectPool<U> &o);
 
+  size_t epoch() const;
+
  private:
   template <typename U>
   friend struct ObjectPool;
@@ -58,6 +60,7 @@ struct ObjectPool
   mutable storage_t m_values;
   marker_t m_slots;
   index_pool_t m_freeIndices;
+  size_t m_epoch{0};
 };
 
 template <typename T>
@@ -94,6 +97,7 @@ struct ObjectPoolRef
 
   size_t m_idx{INVALID_INDEX};
   const ObjectPool<T> *m_iv{nullptr};
+  size_t m_epoch{0};
 };
 
 template <typename T>
@@ -217,6 +221,7 @@ inline bool ObjectPool<T>::erase(size_t i)
   m_values[i] = {};
   m_slots[i] = false;
   m_freeIndices.push(i);
+  m_epoch++;
 
   return true;
 }
@@ -227,6 +232,13 @@ inline void ObjectPool<T>::clear()
   m_values.clear();
   m_slots.clear();
   m_freeIndices = {};
+  m_epoch++;
+}
+
+template <typename T>
+inline size_t ObjectPool<T>::epoch() const
+{
+  return m_epoch;
 }
 
 template <typename T>
@@ -252,6 +264,7 @@ inline bool ObjectPool<T>::defragment()
   std::fill(m_slots.begin(), m_slots.end(), true);
   while (!m_freeIndices.empty())
     m_freeIndices.pop();
+  m_epoch++;
 
   return true;
 }
@@ -262,13 +275,14 @@ inline void ObjectPool<T>::sync_slots(const ObjectPool<U> &o)
 {
   m_slots = o.m_slots;
   m_freeIndices = o.m_freeIndices;
+  m_epoch++;
 }
 
 // ObjectPoolRef //
 
 template <typename T>
 inline ObjectPoolRef<T>::ObjectPoolRef(const ObjectPool<T> &iv, size_t idx)
-    : m_iv(&iv), m_idx(idx)
+    : m_iv(&iv), m_idx(idx), m_epoch(iv.epoch())
 {}
 
 template <typename T>
@@ -328,7 +342,8 @@ inline const T *ObjectPoolRef<T>::operator->() const
 template <typename T>
 inline bool ObjectPoolRef<T>::valid() const
 {
-  return m_idx != INVALID_INDEX && m_iv;
+  return m_idx != INVALID_INDEX && m_iv && m_epoch == m_iv->epoch()
+      && m_idx < m_iv->capacity() && !m_iv->slot_empty(m_idx);
 }
 
 template <typename T>
@@ -340,7 +355,7 @@ inline ObjectPoolRef<T>::operator bool() const
 template <typename T>
 inline bool operator==(const ObjectPoolRef<T> &a, const ObjectPoolRef<T> &b)
 {
-  return a.m_iv == b.m_iv && a.m_idx == b.m_idx;
+  return a.m_iv == b.m_iv && a.m_idx == b.m_idx && a.m_epoch == b.m_epoch;
 }
 
 template <typename T>

--- a/tsd/src/tsd/core/ObjectPool.hpp
+++ b/tsd/src/tsd/core/ObjectPool.hpp
@@ -330,13 +330,13 @@ inline const T &ObjectPoolRef<T>::operator*() const
 template <typename T>
 inline T *ObjectPoolRef<T>::operator->()
 {
-  return &storage()[index()];
+  return data();
 }
 
 template <typename T>
 inline const T *ObjectPoolRef<T>::operator->() const
 {
-  return &storage()[index()];
+  return data();
 }
 
 template <typename T>

--- a/tsd/src/tsd/core/TSDTypes.hpp
+++ b/tsd/src/tsd/core/TSDTypes.hpp
@@ -1,0 +1,26 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <anari/anari_cpp/Traits.h>
+#include <anari/anari_cpp.hpp>
+
+namespace tsd::core {
+
+// TSD-specific type constants outside ANARI's reserved ranges
+constexpr ANARIDataType TSD_TRANSFORM = ANARIDataType(10000);
+
+inline bool isTSDTransform(ANARIDataType type)
+{
+  return type == TSD_TRANSFORM;
+}
+
+inline const char *tsdTypeName(ANARIDataType type)
+{
+  if (type == TSD_TRANSFORM)
+    return "TSD_TRANSFORM";
+  return "UNKNOWN_TSD_TYPE";
+}
+
+} // namespace tsd::core

--- a/tsd/src/tsd/core/scene/Animation.cpp
+++ b/tsd/src/tsd/core/scene/Animation.cpp
@@ -218,7 +218,6 @@ void Animation::deserialize(DataNode &node)
         !kindNode || kindNode->getValueAs<std::string>() == "arrays";
 
     auto object = m_scene->getObject(tsNode["object"].getValue());
-
     if (auto *sets = tsNode.child("animationSets"); sets != nullptr) {
       std::vector<Token> parameterNames;
       std::vector<TimeStepArrays> allSteps;

--- a/tsd/src/tsd/core/scene/Layer.cpp
+++ b/tsd/src/tsd/core/scene/Layer.cpp
@@ -25,31 +25,11 @@ LayerNodeData::LayerNodeData(
   setAsObject(type, index, s);
 }
 
-LayerNodeData::LayerNodeData(const math::mat4 &m, const char *n)
-    : LayerNodeData(n)
-{
-  setAsTransform(m);
-}
-
-LayerNodeData::LayerNodeData(const math::mat3 &m, const char *n)
-    : LayerNodeData(n)
-{
-  setAsTransform(m);
-}
-
-LayerNodeData::LayerNodeData(Array *a, const char *n) : LayerNodeData(n)
-{
-  setAsTransformArray(a);
-}
-
 LayerNodeData::LayerNodeData(const LayerNodeData &o)
 {
   m_name = o.m_name;
   m_enabled = o.m_enabled;
   m_value = o.m_value;
-  m_defaultValue = o.m_defaultValue;
-  m_srt = o.m_srt;
-  m_instanceParameters = o.m_instanceParameters;
   m_scene = o.m_scene;
   incObjectUseCount();
 }
@@ -59,9 +39,6 @@ LayerNodeData::LayerNodeData(LayerNodeData &&o)
   m_name = std::move(o.m_name);
   m_enabled = std::move(o.m_enabled);
   m_value = std::move(o.m_value);
-  m_defaultValue = std::move(o.m_defaultValue);
-  m_srt = std::move(o.m_srt);
-  m_instanceParameters = std::move(o.m_instanceParameters);
   m_scene = std::move(o.m_scene);
   o.m_scene = nullptr;
   o.m_value.reset();
@@ -73,9 +50,6 @@ LayerNodeData &LayerNodeData::operator=(const LayerNodeData &o)
   m_name = o.m_name;
   m_enabled = o.m_enabled;
   m_value = o.m_value;
-  m_defaultValue = o.m_defaultValue;
-  m_srt = o.m_srt;
-  m_instanceParameters = o.m_instanceParameters;
   m_scene = o.m_scene;
   incObjectUseCount();
   return *this;
@@ -87,9 +61,6 @@ LayerNodeData &LayerNodeData::operator=(LayerNodeData &&o)
   m_name = std::move(o.m_name);
   m_enabled = std::move(o.m_enabled);
   m_value = std::move(o.m_value);
-  m_defaultValue = std::move(o.m_defaultValue);
-  m_srt = std::move(o.m_srt);
-  m_instanceParameters = std::move(o.m_instanceParameters);
   m_scene = std::move(o.m_scene);
   o.m_scene = nullptr;
   o.m_value.reset();
@@ -101,31 +72,6 @@ LayerNodeData::~LayerNodeData()
   decObjectUseCount();
 }
 
-bool LayerNodeData::hasDefault() const
-{
-  return m_defaultValue;
-}
-
-bool LayerNodeData::isDefaultValue() const
-{
-  return m_value == m_defaultValue;
-}
-
-void LayerNodeData::setToDefaultValue()
-{
-  if (hasDefault()) {
-    m_value = m_defaultValue;
-    if (isTransform())
-      setAsTransform(getTransform()); // ensure srt matrix is up to date
-  }
-}
-
-void LayerNodeData::setCurrentValueAsDefault()
-{
-  if (isTransform())
-    m_defaultValue = m_value;
-}
-
 anari::DataType LayerNodeData::type() const
 {
   return m_value.type();
@@ -133,12 +79,12 @@ anari::DataType LayerNodeData::type() const
 
 bool LayerNodeData::isObject() const
 {
-  return anari::isObject(type());
+  return anari::isObject(type()) || isTSDTransform(type());
 }
 
 bool LayerNodeData::isTransform() const
 {
-  return type() == ANARI_FLOAT32_MAT4;
+  return type() == TSD_TRANSFORM;
 }
 
 bool LayerNodeData::isEmpty() const
@@ -171,67 +117,11 @@ void LayerNodeData::setAsObject(anari::DataType type, size_t index, Scene *s)
   incObjectUseCount();
 }
 
-void LayerNodeData::setAsTransform(const math::mat4 &m)
-{
-  decObjectUseCount();
-  m_value = m;
-  if (!hasDefault())
-    m_defaultValue = m_value;
-
-  auto &sc = m_srt[0];
-  auto &azelrot = m_srt[1];
-  auto &tl = m_srt[2];
-  math::mat4 rot;
-  math::decomposeMatrix(m, sc, rot, tl);
-  azelrot = math::degrees(math::matrixToAzElRoll(rot));
-}
-
-void LayerNodeData::setAsTransform(
-    const math::mat4 &m, const math::mat4 &defaultM)
-{
-  m_defaultValue = defaultM;
-  setAsTransform(m);
-}
-
-void LayerNodeData::setAsTransform(const math::mat3 &srt)
-{
-  decObjectUseCount();
-  m_srt = srt;
-  auto &sc = srt[0];
-  auto &azelrot = srt[1];
-  auto &tl = srt[2];
-
-  auto rot = math::IDENTITY_MAT4;
-  rot = math::mul(rot,
-      math::rotation_matrix(math::rotation_quat(
-          math::float3(0.f, 1.f, 0.f), math::radians(azelrot.x))));
-  rot = math::mul(rot,
-      math::rotation_matrix(math::rotation_quat(
-          math::float3(1.f, 0.f, 0.f), math::radians(azelrot.y))));
-  rot = math::mul(rot,
-      math::rotation_matrix(math::rotation_quat(
-          math::float3(0.f, 0.f, 1.f), math::radians(azelrot.z))));
-
-  m_value = math::mul(
-      math::translation_matrix(tl), math::mul(rot, math::scaling_matrix(sc)));
-  if (!hasDefault())
-    m_defaultValue = m_value;
-}
-
-void LayerNodeData::setAsTransformArray(Array *a)
-{
-  setAsObject(a);
-}
-
 void LayerNodeData::setEmpty()
 {
   decObjectUseCount();
   m_value.reset();
-  m_srt[0] = math::float3(1.f, 1.f, 1.f);
-  m_srt[1] = math::float3(0.f, 0.f, 0.f);
-  m_srt[2] = math::float3(0.f, 0.f, 0.f);
   m_scene = nullptr;
-  clearInstanceParameters();
   m_name.clear();
 }
 
@@ -248,30 +138,6 @@ Object *LayerNodeData::getObject() const
 size_t LayerNodeData::getObjectIndex() const
 {
   return m_value.getAsObjectIndex();
-}
-
-math::mat4 LayerNodeData::getTransform() const
-{
-  return isTransform() ? m_value.getAs<math::mat4>() : math::IDENTITY_MAT4;
-}
-
-math::mat3 LayerNodeData::getTransformSRT() const
-{
-  return isTransform() ? m_srt
-                       : math::mat3{math::float3(1.f, 1.f, 1.f),
-                             math::float3(0.f, 0.f, 0.f),
-                             math::float3(0.f, 0.f, 0.f)};
-}
-
-Array *LayerNodeData::getTransformArray() const
-{
-  auto *obj = getObject();
-  if (obj && obj->type() == ANARI_ARRAY1D) {
-    auto *a = (Array *)obj;
-    if (a->elementType() == ANARI_FLOAT32_MAT4)
-      return a;
-  }
-  return nullptr;
 }
 
 std::string &LayerNodeData::name()
@@ -294,23 +160,15 @@ void LayerNodeData::setValueRaw(const Any &v, Scene *scene)
   setEmpty();
   m_scene = scene;
   m_value = v;
-  setCurrentValueAsDefault();
   incObjectUseCount();
 }
 
-const InstanceParameterMap &LayerNodeData::getInstanceParameters() const
+Transform *LayerNodeData::getTransformObject() const
 {
-  return m_instanceParameters;
-}
-
-void LayerNodeData::setInstanceParameter(const std::string &name, Any v)
-{
-  m_instanceParameters.set(name, v);
-}
-
-void LayerNodeData::clearInstanceParameters()
-{
-  m_instanceParameters.clear();
+  if (type() != TSD_TRANSFORM || !m_scene)
+    return nullptr;
+  return static_cast<Transform *>(
+      m_scene->getObject(type(), m_value.getAsObjectIndex()));
 }
 
 void LayerNodeData::incObjectUseCount()

--- a/tsd/src/tsd/core/scene/Layer.hpp
+++ b/tsd/src/tsd/core/scene/Layer.hpp
@@ -7,13 +7,14 @@
 #include "tsd/core/FlatMap.hpp"
 #include "tsd/core/Forest.hpp"
 #include "tsd/core/TSDMath.hpp"
+#include "tsd/core/TSDTypes.hpp"
 
 namespace tsd::core {
 
 struct Array;
 struct Object;
 struct Scene;
-using InstanceParameterMap = FlatMap<std::string, Any>;
+struct Transform;
 
 struct LayerNodeData
 {
@@ -22,9 +23,6 @@ struct LayerNodeData
   LayerNodeData(Object *o, const char *n = "");
   LayerNodeData(
       anari::DataType type, size_t index, Scene *s, const char *n = "");
-  LayerNodeData(const math::mat4 &m, const char *n = "");
-  LayerNodeData(const math::mat3 &m, const char *n = "");
-  LayerNodeData(Array *a, const char *n = "");
   template <typename T>
   LayerNodeData(ObjectPoolRef<T> obj, const char *n = "");
 
@@ -35,32 +33,22 @@ struct LayerNodeData
 
   ~LayerNodeData();
 
-  bool hasDefault() const;
-  bool isDefaultValue() const;
-  void setToDefaultValue();
-  void setCurrentValueAsDefault();
-
   anari::DataType type() const;
   bool isObject() const;
   bool isTransform() const;
   bool isEmpty() const;
   bool isEnabled() const;
 
-  void setAsObject(Object *o);
   void setAsObject(anari::DataType type, size_t index, Scene *s);
-  void setAsTransform(const math::mat4 &m);
-  void setAsTransform(const math::mat4 &m, const math::mat4 &defaultM);
-  void setAsTransform(const math::mat3 &srt);
-  void setAsTransformArray(Array *a);
+  void setAsObject(Object *o);
+  void setAsTransform(Transform *xfm);
   void setEmpty();
 
   void setEnabled(bool enabled);
 
   Object *getObject() const;
   size_t getObjectIndex() const;
-  math::mat4 getTransform() const;
-  math::mat3 getTransformSRT() const;
-  Array *getTransformArray() const;
+  Transform *getTransformObject() const;
 
   std::string &name();
   const std::string &name() const;
@@ -71,10 +59,6 @@ struct LayerNodeData
   void setValueRaw(const Any &v, Scene *scene = nullptr);
   //////////////////////////////////////////////////////////////////
 
-  const InstanceParameterMap &getInstanceParameters() const;
-  void setInstanceParameter(const std::string &name, Any v);
-  void clearInstanceParameters();
-
  private:
   void incObjectUseCount();
   void decObjectUseCount();
@@ -84,9 +68,6 @@ struct LayerNodeData
   std::string m_name;
   bool m_enabled{true};
   Any m_value;
-  Any m_defaultValue;
-  math::mat3 m_srt; // scale, azelrot, translation
-  InstanceParameterMap m_instanceParameters;
   Scene *m_scene{nullptr};
 };
 

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -577,6 +577,7 @@ void Scene::removeAllLayers()
   }
 
   m_layers.clear();
+  m_numActiveLayers = 0;
 }
 
 LayerNodeRef Scene::insertChildNode(LayerNodeRef parent, const char *name)

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -531,12 +531,10 @@ void Scene::setAllLayersActive()
 std::vector<const Layer *> Scene::getActiveLayers() const
 {
   std::vector<const Layer *> activeLayers;
-  if (numberOfActiveLayers() != numberOfLayers()) {
-    activeLayers.reserve(m_layers.size());
-    for (const auto &ls : m_layers) {
-      if (ls.second.active)
-        activeLayers.push_back(ls.second.ptr.get());
-    }
+  activeLayers.reserve(m_layers.size());
+  for (const auto &ls : m_layers) {
+    if (ls.second.active)
+      activeLayers.push_back(ls.second.ptr.get());
   }
   return activeLayers;
 }

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -21,7 +21,8 @@ std::string objectDBInfo(const ObjectDatabase &db)
   ss << "      fields: " << db.field.size() << '\n';
   ss << "      lights: " << db.light.size() << '\n';
   ss << "     cameras: " << db.camera.size() << '\n';
-  ss << "   renderers: " << db.renderer.size();
+  ss << "   renderers: " << db.renderer.size() << '\n';
+  ss << "  transforms: " << db.transform.size();
   return ss.str();
 }
 
@@ -71,6 +72,7 @@ Scene::~Scene()
   reportObjectUsages(m_db.array);
   reportObjectUsages(m_db.camera);
   reportObjectUsages(m_db.renderer);
+  reportObjectUsages(m_db.transform);
 }
 
 MaterialRef Scene::defaultMaterial()
@@ -163,6 +165,9 @@ Object *Scene::createObject(anari::DataType type, Token subtype)
   case ANARI_CAMERA:
     obj = createObjectImpl(m_db.camera, subtype).data();
     break;
+  case TSD_TRANSFORM:
+    obj = createObjectImpl(m_db.transform, subtype).data();
+    break;
   default:
     logError("[Scene::createObject(type, subtype)] unsupported object type %s",
         anari::toString(type));
@@ -199,6 +204,13 @@ SurfaceRef Scene::createSurface(const char *name, GeometryRef g, MaterialRef m)
   surface->setMaterial(m ? m : defaultMaterial());
   surface->setName(name);
   return surface;
+}
+
+TransformRef Scene::createTransform(const char *name)
+{
+  auto xfm = createObject<Transform>(tokens::transform::transform);
+  xfm->setName(name);
+  return xfm;
 }
 
 Object *Scene::getObject(const Any &a) const
@@ -244,8 +256,9 @@ Object *Scene::getObject(ANARIDataType type, size_t i) const
   case ANARI_ARRAY3D:
     obj = m_db.array.at(i).data();
     break;
-  default:
-    break; // no-op
+  case TSD_TRANSFORM:
+    obj = m_db.transform.at(i).data();
+    break;
   }
 
   return obj;
@@ -289,8 +302,9 @@ size_t Scene::numberOfObjects(anari::DataType type) const
   case ANARI_ARRAY3D:
     numObjects = m_db.array.size();
     break;
-  default:
-    break; // no-op
+  case TSD_TRANSFORM:
+    numObjects = m_db.transform.capacity();
+    break;
   }
 
   return numObjects;
@@ -349,8 +363,9 @@ void Scene::removeObject(const Object *_o)
   case ANARI_ARRAY3D:
     m_db.array.erase(index);
     break;
-  default:
-    break; // no-op
+  case TSD_TRANSFORM:
+    m_db.transform.erase(index);
+    break;
   }
 }
 
@@ -367,6 +382,7 @@ void Scene::removeAllObjects()
   m_db.array.clear();
   m_db.surface.clear();
   m_db.geometry.clear();
+  m_db.transform.clear();
   m_db.material.clear();
   m_db.sampler.clear();
   m_db.volume.clear();
@@ -444,6 +460,7 @@ void Scene::setUpdateDelegate(BaseUpdateDelegate *ud)
   setDelegateOnObjects(m_db.field);
   setDelegateOnObjects(m_db.camera);
   setDelegateOnObjects(m_db.renderer);
+  setDelegateOnObjects(m_db.transform);
 }
 
 const ObjectDatabase &Scene::objectDB() const
@@ -476,7 +493,7 @@ Layer *Scene::addLayer(Token name)
 {
   auto &ls = m_layers[name];
   if (!ls.ptr) {
-    ls.ptr.reset(new Layer({tsd::math::mat4(tsd::math::identity), "root"}));
+    ls.ptr.reset(new Layer(LayerNodeData("root")));
     if (m_updateDelegate)
       m_updateDelegate->signalLayerAdded(ls.ptr.get());
     m_numActiveLayers++;
@@ -591,19 +608,20 @@ LayerNodeRef Scene::insertChildNode(LayerNodeRef parent, const char *name)
 LayerNodeRef Scene::insertChildTransformNode(
     LayerNodeRef parent, mat4 xfm, const char *name)
 {
-  auto *layer = parent->container();
-  auto inst = layer->insert_last_child(parent, xfm);
-  (*inst)->name() = name;
-  signalLayerChange(parent->container());
+  auto transform = createTransform(name);
+  transform->setTransform(xfm);
+  auto inst =
+      insertChildObjectNode(parent, TSD_TRANSFORM, transform->index(), name);
   return inst;
 }
 
 LayerNodeRef Scene::insertChildTransformArrayNode(
     LayerNodeRef parent, Array *a, const char *name)
 {
-  auto inst = parent->insert_last_child({a});
-  (*inst)->name() = name;
-  signalLayerChange(parent->container());
+  auto transform = createTransform(name);
+  transform->setTransformArray(getObject<Array>(a->index()));
+  auto inst =
+      insertChildObjectNode(parent, TSD_TRANSFORM, transform->index(), name);
   return inst;
 }
 
@@ -758,6 +776,7 @@ void Scene::removeUnusedObjects(bool includeRenderers)
   removeUnused(m_db.surface);
   removeUnused(m_db.volume);
   removeUnused(m_db.light);
+  removeUnused(m_db.transform);
   removeUnused(m_db.geometry);
   removeUnused(m_db.material);
   removeUnused(m_db.field);
@@ -780,6 +799,7 @@ void Scene::defragmentObjectStorage()
   defrag |= defragmentations[ANARI_ARRAY] = m_db.array.defragment();
   defrag |= defragmentations[ANARI_SURFACE] = m_db.surface.defragment();
   defrag |= defragmentations[ANARI_GEOMETRY] = m_db.geometry.defragment();
+  defrag |= defragmentations[TSD_TRANSFORM] = m_db.transform.defragment();
   defrag |= defragmentations[ANARI_MATERIAL] = m_db.material.defragment();
   defrag |= defragmentations[ANARI_SAMPLER] = m_db.sampler.defragment();
   defrag |= defragmentations[ANARI_VOLUME] = m_db.volume.defragment();
@@ -833,7 +853,9 @@ void Scene::defragmentObjectStorage()
     case ANARI_ARRAY3D:
       return findIdx(m_db.array, idx);
     default:
-      break; // no-op
+      if (objType == TSD_TRANSFORM)
+        return findIdx(m_db.transform, idx);
+      break;
     }
 
     return INVALID_INDEX;
@@ -902,6 +924,7 @@ void Scene::defragmentObjectStorage()
   updateParameterReferences(m_db.array);
   updateParameterReferences(m_db.surface);
   updateParameterReferences(m_db.geometry);
+  updateParameterReferences(m_db.transform);
   updateParameterReferences(m_db.material);
   updateParameterReferences(m_db.sampler);
   updateParameterReferences(m_db.volume);
@@ -925,6 +948,7 @@ void Scene::defragmentObjectStorage()
   updateObjectHeldIndex(m_db.array);
   updateObjectHeldIndex(m_db.surface);
   updateObjectHeldIndex(m_db.geometry);
+  updateObjectHeldIndex(m_db.transform);
   updateObjectHeldIndex(m_db.material);
   updateObjectHeldIndex(m_db.sampler);
   updateObjectHeldIndex(m_db.volume);

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -62,17 +62,17 @@ Scene::~Scene()
     array.clear();
   };
 
-  reportObjectUsages(m_db.light);
   reportObjectUsages(m_db.surface);
   reportObjectUsages(m_db.volume);
-  reportObjectUsages(m_db.geometry);
-  reportObjectUsages(m_db.material);
-  reportObjectUsages(m_db.sampler);
-  reportObjectUsages(m_db.field);
-  reportObjectUsages(m_db.array);
+  reportObjectUsages(m_db.light);
   reportObjectUsages(m_db.camera);
   reportObjectUsages(m_db.renderer);
   reportObjectUsages(m_db.transform);
+  reportObjectUsages(m_db.geometry);
+  reportObjectUsages(m_db.material);
+  reportObjectUsages(m_db.field);
+  reportObjectUsages(m_db.sampler);
+  reportObjectUsages(m_db.array);
 }
 
 MaterialRef Scene::defaultMaterial()
@@ -379,17 +379,17 @@ void Scene::removeAllObjects()
 
   removeAllLayers();
 
-  m_db.array.clear();
   m_db.surface.clear();
-  m_db.geometry.clear();
-  m_db.transform.clear();
-  m_db.material.clear();
-  m_db.sampler.clear();
   m_db.volume.clear();
-  m_db.field.clear();
   m_db.light.clear();
   m_db.camera.clear();
   m_db.renderer.clear();
+  m_db.transform.clear();
+  m_db.geometry.clear();
+  m_db.material.clear();
+  m_db.field.clear();
+  m_db.sampler.clear();
+  m_db.array.clear();
 }
 
 RendererAppRef Scene::createRenderer(Token device, Token subtype)

--- a/tsd/src/tsd/core/scene/Scene.hpp
+++ b/tsd/src/tsd/core/scene/Scene.hpp
@@ -14,6 +14,7 @@
 #include "tsd/core/scene/objects/Sampler.hpp"
 #include "tsd/core/scene/objects/SpatialField.hpp"
 #include "tsd/core/scene/objects/Surface.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
 #include "tsd/core/scene/objects/Volume.hpp"
 // std
 #include <memory>
@@ -38,6 +39,7 @@ struct ObjectDatabase
   ObjectPool<Array> array;
   ObjectPool<Surface> surface;
   ObjectPool<Geometry> geometry;
+  ObjectPool<Transform> transform;
   ObjectPool<Material> material;
   ObjectPool<Sampler> sampler;
   ObjectPool<Volume> volume;
@@ -108,6 +110,7 @@ struct Scene
       size_t items2 = 0);
   SurfaceRef createSurface(
       const char *name = "", GeometryRef g = {}, MaterialRef m = {});
+  TransformRef createTransform(const char *name = "");
 
   template <typename T>
   ObjectPoolRef<T> getObject(size_t i) const;
@@ -316,6 +319,12 @@ inline CameraRef Scene::createObject(Token subtype)
   return createObjectImpl(m_db.camera, subtype);
 }
 
+template <>
+inline TransformRef Scene::createObject(Token subtype)
+{
+  return createObjectImpl(m_db.transform, subtype);
+}
+
 template <typename T>
 inline ObjectPoolRef<T> Scene::getObject(size_t i) const
 {
@@ -376,6 +385,12 @@ template <>
 inline CameraRef Scene::getObject(size_t i) const
 {
   return m_db.camera.at(i);
+}
+
+template <>
+inline TransformRef Scene::getObject(size_t i) const
+{
+  return m_db.transform.at(i);
 }
 
 template <>

--- a/tsd/src/tsd/core/scene/objects/Transform.cpp
+++ b/tsd/src/tsd/core/scene/objects/Transform.cpp
@@ -1,0 +1,120 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/core/scene/objects/Transform.hpp"
+#include "tsd/core/scene/Scene.hpp"
+
+namespace tsd::core {
+
+Transform::Transform(Token subtype) : Object(TSD_TRANSFORM, subtype)
+{
+  addParameter(tokens::transform::transform).setValue(math::IDENTITY_MAT4);
+}
+
+void Transform::setTransform(const math::mat4 &m)
+{
+  setParameter(tokens::transform::transform, m);
+}
+
+math::mat4 Transform::getTransform() const
+{
+  auto *p = parameter(tokens::transform::transform);
+  if (!p || p->value().type() != ANARI_FLOAT32_MAT4)
+    return math::IDENTITY_MAT4;
+  return p->value().get<math::mat4>();
+}
+
+void Transform::setTransformArray(ArrayRef transforms)
+{
+  if (!transforms.valid())
+    return;
+  setParameterObject(tokens::transform::transform, *transforms);
+}
+
+Array *Transform::getTransformArray() const
+{
+  return parameterValueAsObject<Array>(tokens::transform::transform);
+}
+
+Any Transform::getTransformAsAny() const
+{
+  auto *p = parameter(tokens::transform::transform);
+  if (!p)
+    return Any(math::IDENTITY_MAT4);
+  return p->value();
+}
+
+void Transform::setTransform(const math::mat3 &srt)
+{
+  auto &sc = srt[0];
+  auto &azelrot = srt[1];
+  auto &tl = srt[2];
+
+  auto rot = math::IDENTITY_MAT4;
+  rot = math::mul(rot,
+      math::rotation_matrix(math::rotation_quat(
+          math::float3(0.f, 1.f, 0.f), math::radians(azelrot.x))));
+  rot = math::mul(rot,
+      math::rotation_matrix(math::rotation_quat(
+          math::float3(1.f, 0.f, 0.f), math::radians(azelrot.y))));
+  rot = math::mul(rot,
+      math::rotation_matrix(math::rotation_quat(
+          math::float3(0.f, 0.f, 1.f), math::radians(azelrot.z))));
+
+  auto m = math::mul(
+      math::translation_matrix(tl), math::mul(rot, math::scaling_matrix(sc)));
+
+  setTransform(m);
+}
+
+ObjectPoolRef<Transform> Transform::self() const
+{
+  return scene() ? scene()->getObject<Transform>(index())
+                 : ObjectPoolRef<Transform>{};
+}
+
+anari::Object Transform::makeANARIObject(anari::Device d) const
+{
+  return {};
+}
+
+Transform::InstanceParameterMap Transform::getInstanceParameterMap() const
+{
+  InstanceParameterMap res;
+
+  // Go with a fixed set of possible parameters.
+  if (auto p = parameter(tokens::transform::id)) {
+    res[tokens::transform::id] = p->value();
+  }
+  if (auto p = parameter(tokens::transform::color)) {
+    res[tokens::transform::color] = p->value();
+  }
+  if (auto p = parameter(tokens::transform::attribute0)) {
+    res[tokens::transform::attribute0] = p->value();
+  }
+  if (auto p = parameter(tokens::transform::attribute1)) {
+    res[tokens::transform::attribute1] = p->value();
+  }
+  if (auto p = parameter(tokens::transform::attribute2)) {
+    res[tokens::transform::attribute2] = p->value();
+  }
+  if (auto p = parameter(tokens::transform::attribute3)) {
+    res[tokens::transform::attribute3] = p->value();
+  }
+
+  return res;
+}
+
+} // namespace tsd::core
+
+namespace tsd::core::tokens::transform {
+
+const Token transform = "transform";
+const Token id = "id";
+const Token color = "color";
+const Token attribute0 = "attribute0";
+const Token attribute1 = "attribute1";
+const Token attribute2 = "attribute2";
+const Token attribute3 = "attribute3";
+
+} // namespace tsd::core::tokens::transform

--- a/tsd/src/tsd/core/scene/objects/Transform.hpp
+++ b/tsd/src/tsd/core/scene/objects/Transform.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <anari/anari_cpp/Traits.h>
+#include "tsd/core/TSDTypes.hpp"
+#include "tsd/core/scene/objects/Array.hpp"
+
+namespace tsd::core {
+
+namespace tokens::transform {
+
+extern const Token transform;
+extern const Token id;
+extern const Token color;
+extern const Token attribute0;
+extern const Token attribute1;
+extern const Token attribute2;
+extern const Token attribute3;
+
+} // namespace tokens::transform
+
+struct Transform : public Object
+{
+  using InstanceParameterMap = FlatMap<Token, Any>;
+
+  DECLARE_OBJECT_DEFAULT_LIFETIME(Transform);
+
+  Transform(Token subtype = tokens::transform::transform);
+  virtual ~Transform() = default;
+
+  void setTransform(const math::mat3 &srt);
+  void setTransform(const math::mat4 &m);
+  math::mat4 getTransform() const;
+
+  void setTransformArray(ArrayRef transforms);
+  Array *getTransformArray() const;
+
+  Any getTransformAsAny() const;
+
+  ObjectPoolRef<Transform> self() const;
+
+  anari::Object makeANARIObject(anari::Device d) const override;
+
+  InstanceParameterMap getInstanceParameterMap() const;
+};
+
+using TransformRef = ObjectPoolRef<Transform>;
+
+} // namespace tsd::core
+
+namespace anari {
+ANARI_TYPEFOR_SPECIALIZATION(tsd::core::Transform, tsd::core::TSD_TRANSFORM);
+} // namespace anari

--- a/tsd/src/tsd/io/importers/import_ASSIMP.cpp
+++ b/tsd/src/tsd/io/importers/import_ASSIMP.cpp
@@ -609,7 +609,8 @@ static void populateASSIMPLayer(Scene &scene,
   tsd::math::mat4 mat;
   std::memcpy(&mat, &node->mTransformation, sizeof(mat));
   mat = tsd::math::transpose(mat);
-  auto tr = tsdLayerRef->insert_last_child({mat, node->mName.C_Str()});
+  auto tr = scene.insertChildTransformNode(
+      tsdLayerRef, mat, node->mName.C_Str());
 
   for (unsigned int i = 0; i < node->mNumMeshes; i++) {
     auto mesh = surfaces.at(node->mMeshes[i]);

--- a/tsd/src/tsd/io/importers/import_GLTF.cpp
+++ b/tsd/src/tsd/io/importers/import_GLTF.cpp
@@ -1297,7 +1297,8 @@ static void populateGLTFLayer(Scene &scene,
   }
 
   // Create node in the hierarchy
-  auto nodeRef = parentNode->insert_last_child({transform, node.name.c_str()});
+  auto nodeRef = scene.insertChildTransformNode(
+      parentNode, transform, node.name.c_str());
 
   // Add mesh if present
   if (node.mesh >= 0 && node.mesh < model.meshes.size()) {
@@ -1377,8 +1378,8 @@ void import_GLTF(Scene &scene, const char *filename, LayerNodeRef location)
   }
 
   // Create root transformation node
-  auto rootNode =
-      targetLocation->insert_last_child({IDENTITY_MAT4, fileName.c_str()});
+  auto rootNode = scene.insertChildTransformNode(
+      targetLocation, IDENTITY_MAT4, fileName.c_str());
 
   if (model.defaultScene >= 0 && model.defaultScene < model.scenes.size()) {
     const auto &gltfScene = model.scenes[model.defaultScene];

--- a/tsd/src/tsd/io/procedural/generate_material_orb.cpp
+++ b/tsd/src/tsd/io/procedural/generate_material_orb.cpp
@@ -77,9 +77,8 @@ void generate_material_orb(Scene &scene, LayerNodeRef location)
   if (!location)
     location = scene.defaultLayer()->root();
 
-  auto orb_root = location->insert_last_child(
-      {tsd::math::mat4(tsd::math::identity)});
-  (*orb_root)->name() = "Material Orb";
+  auto orb_root = scene.insertChildTransformNode(
+      location, tsd::math::mat4(tsd::math::identity), "Material Orb");
 
   MaterialRef mat;
 

--- a/tsd/src/tsd/io/serialization/export_SceneToUSD.cpp
+++ b/tsd/src/tsd/io/serialization/export_SceneToUSD.cpp
@@ -796,7 +796,7 @@ void export_SceneToUSD(Scene &scene, const char *filename, int framesPerSecond)
         if (node->isEmpty())
           return true;
         if (node->isTransform()) {
-          auto transform = node->getTransform();
+          auto transform = node->getTransformObject()->getTransform();
           transformStack.pop();
           transformStack.push(math::mul(transformStack.top(), transform));
         }

--- a/tsd/src/tsd/io/serialization/serialization_datatree.cpp
+++ b/tsd/src/tsd/io/serialization/serialization_datatree.cpp
@@ -183,7 +183,7 @@ void nodeToNewObject(Scene &scene, core::DataNode &node)
   const size_t index = self.getAsObjectIndex();
   const Token subtype(node["subtype"].getValueAs<std::string>());
 
-  if (!anari::isObject(type)) {
+  if (!anari::isObject(type) && !core::isTSDTransform(type)) {
     logError("[nodeToObject] parsed invalid object type '%s'",
         anari::toString(type));
     return;
@@ -262,6 +262,9 @@ void nodeToNewObject(Scene &scene, core::DataNode &node)
     if (!rendererDeviceName.empty())
       obj = scene.createRenderer(rendererDeviceName, subtype).get();
   } break;
+  case TSD_TRANSFORM:
+    obj = scene.createObject<Transform>(subtype).data();
+    break;
   default:
     break;
   }
@@ -329,8 +332,6 @@ void layerToNode(Layer &layer, core::DataNode &node)
 
     currentNode->append("name") = tsdNode->name();
     currentNode->append("value") = tsdNode->getValueRaw();
-    if (tsdNode->isTransform())
-      currentNode->append("transformSRT") = tsdNode->getTransformSRT();
     currentNode->append("enabled") = tsdNode->isEnabled();
     currentNode->append("children");
 
@@ -366,10 +367,7 @@ void nodeToLayer(core::DataNode &rootNode, Layer &layer, Scene &scene)
       currentNode = layer.root();
     else {
       currentNode = layer.insert_last_child(currentParentNode, {});
-      if (auto *c = node.child("transformSRT"); c != nullptr)
-        (*currentNode)->setAsTransform(c->getValueAs<math::mat3>());
-      else
-        (*currentNode)->setValueRaw(node["value"].getValue(), &scene);
+      (*currentNode)->setValueRaw(node["value"].getValue(), &scene);
       (*currentNode)->setEnabled(node["enabled"].getValueOr(true));
       (*currentNode)->name() = node["name"].getValueAs<std::string>();
     }
@@ -453,6 +451,7 @@ void save_Scene(Scene &scene, core::DataNode &root, bool forceProxyArrays)
   objectPoolToNode(objectDB, scene.m_db.light, "light");
   objectPoolToNode(objectDB, scene.m_db.camera, "camera");
   objectPoolToNode(objectDB, scene.m_db.renderer, "renderer");
+  objectPoolToNode(objectDB, scene.m_db.transform, "transform");
   objectPoolToNode(objectDB, scene.m_db.array, "array");
 }
 
@@ -501,6 +500,7 @@ void load_Scene(Scene &scene, core::DataNode &root)
   nodeToObjectPool(objectDB, scene, "light");
   nodeToObjectPool(objectDB, scene, "camera");
   nodeToObjectPool(objectDB, scene, "renderer");
+  nodeToObjectPool(objectDB, scene, "transform");
 
   // Layers
 

--- a/tsd/src/tsd/rendering/index/RenderIndex.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.cpp
@@ -227,4 +227,20 @@ void RenderIndex::signalAnimationTimeChanged(float)
   // no-op
 }
 
+void RenderIndex::signalObjectParameterUseCountZero(const Object *o)
+{
+  if (o->useCount(tsd::core::Object::UseKind::LAYER) > 0)
+    return;
+
+  m_cache.releaseHandle(o);
+}
+
+void RenderIndex::signalObjectLayerUseCountZero(const Object *o)
+{
+  if (o->useCount(tsd::core::Object::UseKind::PARAMETER) > 0)
+    return;
+
+  m_cache.releaseHandle(o);
+}
+
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/index/RenderIndex.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.cpp
@@ -212,7 +212,8 @@ void RenderIndex::signalRemoveAllObjects()
   auto w = world();
   anari::unsetAllParameters(d, w);
   anari::commitParameters(d, w);
-  m_cache.clear();
+  // Don't m_cache.clear(); for now objects are still referenced by Layers
+  // and will be clear later on.
 }
 
 void RenderIndex::signalInvalidateCachedObjects()

--- a/tsd/src/tsd/rendering/index/RenderIndex.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.hpp
@@ -57,6 +57,8 @@ struct RenderIndex : public BaseUpdateDelegate
   void signalRemoveAllObjects() override;
   void signalInvalidateCachedObjects() override;
   void signalAnimationTimeChanged(float time) override;
+  void signalObjectParameterUseCountZero(const Object *o) override;
+  void signalObjectLayerUseCountZero(const Object *o) override;
 
  protected:
   virtual void updateWorld() = 0;

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
@@ -23,9 +23,129 @@
 // std
 #include <algorithm>
 #include <anari/anari_cpp.hpp>
+#include <cstring>
 #include <variant>
 
 namespace tsd::rendering {
+
+// Helpers
+
+namespace {
+
+// Transform composition
+
+mat4 composeTransform(const mat4 &a, const mat4 &b)
+{
+  return mul(a, b);
+}
+
+std::vector<mat4> composeTransform(
+    const mat4 &a, const mat4 *begin, const mat4 *end)
+{
+  std::vector<mat4> res;
+  res.reserve(end - begin);
+  for (auto it = begin; it != end; ++it)
+    res.push_back(mul(a, *it));
+  return res;
+}
+
+std::vector<mat4> composeTransform(
+    const mat4 *begin, const mat4 *end, const mat4 &b)
+{
+  std::vector<mat4> res;
+  res.reserve(end - begin);
+  for (auto it = begin; it != end; ++it)
+    res.push_back(mul(*it, b));
+  return res;
+}
+
+std::vector<mat4> composeTransform(
+    const mat4 *beginA, const mat4 *endA, const mat4 *beginB, const mat4 *endB)
+{
+  std::vector<mat4> res;
+  res.reserve((endA - beginA) * (endB - beginB));
+  for (auto itA = beginA; itA != endA; ++itA)
+    for (auto itB = beginB; itB != endB; ++itB)
+      res.push_back(mul(*itA, *itB));
+
+  return res;
+}
+
+// Attribute composition
+
+RenderIndexAllLayers::AttributeValue broadcastValue(
+    const void *src, ANARIDataType type, size_t n)
+{
+  auto elementSize = anari::sizeOf(type);
+  RenderIndexAllLayers::AttributeValue result;
+  result.elementType = type;
+  result.data.resize(elementSize * n);
+  auto *dst = result.data.data();
+  for (size_t i = 0; i < n; ++i)
+    std::memcpy(dst + i * elementSize, src, elementSize);
+  return result;
+}
+
+static RenderIndexAllLayers::AttributeValue repeatBlock(
+    const void *src, size_t srcCount, ANARIDataType type, size_t n)
+{
+  auto es = anari::sizeOf(type);
+  auto blockSize = es * srcCount;
+  RenderIndexAllLayers::AttributeValue result;
+  result.elementType = type;
+  result.data.resize(blockSize * n);
+  auto *dst = result.data.data();
+  for (size_t i = 0; i < n; ++i)
+    std::memcpy(dst + i * blockSize, src, blockSize);
+  return result;
+}
+
+static RenderIndexAllLayers::AttributeValue expandEach(
+    const RenderIndexAllLayers::AttributeValue &src, size_t n)
+{
+  auto es = src.elementSize();
+  auto srcCount = src.count();
+  RenderIndexAllLayers::AttributeValue result;
+  result.elementType = src.elementType;
+  result.data.resize(es * srcCount * n);
+  auto *dst = result.data.data();
+  auto *srcPtr = src.data.data();
+  for (size_t i = 0; i < srcCount; ++i) {
+    for (size_t j = 0; j < n; ++j)
+      std::memcpy(dst + (i * n + j) * es, srcPtr + i * es, es);
+  }
+  return result;
+}
+
+} // namespace
+
+// AttributeValue //////////////////////////////////////////////////////////////
+
+bool RenderIndexAllLayers::AttributeValue::empty() const
+{
+  return data.empty();
+}
+
+size_t RenderIndexAllLayers::AttributeValue::elementSize() const
+{
+  return anari::sizeOf(elementType);
+}
+
+size_t RenderIndexAllLayers::AttributeValue::count() const
+{
+  auto count = elementSize();
+  return count ? data.size() / count : 0;
+}
+
+// Attribute byte-level helpers ////////////////////////////////////////////////
+
+static size_t instanceCount(
+    const RenderIndexAllLayers::TransformCache::Value &v)
+{
+  if (std::holds_alternative<math::mat4>(v))
+    return 1;
+  return std::get<std::vector<math::mat4>>(v).size();
+}
 
 // RenderIndexAllLayers definitions ///////////////////////////////////////////
 
@@ -187,6 +307,8 @@ void RenderIndexAllLayers::signalRemoveAllObjects()
   for (auto &&[_, rootInst] : m_layerRootInstance)
     anari::release(device(), rootInst);
   m_layerRootInstance.clear();
+  m_layerNodeInstanceParams.clear();
+  m_layerAttributeCache.clear();
 
   m_transformLastUpdateTimeStamp = helium::newTimeStamp();
 }
@@ -198,15 +320,11 @@ void RenderIndexAllLayers::updateWorld()
 
   auto effectiveLayers = m_includedLayers;
 
-  bool needTopologyUpdate = false;
-  bool needInstanceUpdate = false;
+  bool needWorldInstanceRebuild = false;
   for (const auto *l : effectiveLayers) {
     if (!m_layerTransformDependency.contains(l)) {
-      needTopologyUpdate = true;
+      needWorldInstanceRebuild = true;
       updateLayerTransformDependency(l);
-    }
-    if (updateLayerTransformCache(l)) {
-      needInstanceUpdate = true;
       RenderToAnariObjectsVisitor visitor(d,
           m_cache,
           m_layerInstanceCache[l],
@@ -215,13 +333,16 @@ void RenderIndexAllLayers::updateWorld()
       const_cast<Layer *>(l)->traverse(l->root(), visitor);
       visitor.finalizeRootObjects();
     }
+
+    bool needInstanceArraysUpdate = updateLayerTransformCache(l);
+    updateLayerAttributeCache(l);
+
+    if (needInstanceArraysUpdate)
+      writeTransformCacheToInstances(l);
   }
   m_transformLastUpdateTimeStamp = helium::newTimeStamp();
 
-  if (needInstanceUpdate)
-    writeTransformCacheToInstances();
-
-  if (needTopologyUpdate) {
+  if (needWorldInstanceRebuild) {
     std::vector<anari::Instance> allInstances;
     for (const auto *l : effectiveLayers) {
       auto *deps = m_layerTransformDependency.at(l);
@@ -256,8 +377,10 @@ void RenderIndexAllLayers::updateLayerTransformDependency(const Layer *l)
   auto xfmCapacity = m_ctx->objectDB().transform.capacity();
 
   std::vector<TransformDependency> orderedTransforms;
+  std::vector<InstanceParameterMap> nodeInstanceParams;
   // Final size equals the number of enabled transform nodes in this layer.
   orderedTransforms.reserve(xfmCapacity);
+  nodeInstanceParams.reserve(xfmCapacity);
 
   auto mutableLayer = const_cast<Layer *>(l);
   size_t currentOrderedIndex = INVALID_INDEX;
@@ -276,7 +399,9 @@ void RenderIndexAllLayers::updateLayerTransformDependency(const Layer *l)
         currentOrderedIndex = orderedTransforms.size();
         orderedTransforms.push_back({n->getObjectIndex(),
             parentOrderedIndex,
-            n->name().size() ? n->name() : n->getObject()->name()});
+            n->name().size() ? n->name() : transformObject->name()});
+        nodeInstanceParams.push_back(
+            transformObject->getInstanceParameterMap());
 
         return true;
       },
@@ -294,6 +419,7 @@ void RenderIndexAllLayers::updateLayerTransformDependency(const Layer *l)
 
   auto xfmCount = orderedTransforms.size();
   m_layerTransformDependency[l] = std::move(orderedTransforms);
+  m_layerNodeInstanceParams[l] = std::move(nodeInstanceParams);
   m_layerTransformCache[l].clear();
   m_layerTransformCache[l].resize(
       xfmCount, {math::IDENTITY_MAT4, helium::newTimeStamp()});
@@ -348,8 +474,6 @@ bool RenderIndexAllLayers::updateLayerTransformCache(const Layer *l)
       continue;
     }
 
-    // FIXME: Handle other properties such as color
-
     const auto *parentCache =
         hasParent ? &(*transformCache)[parentOrderedIndex] : &identityCache;
 
@@ -398,46 +522,136 @@ bool RenderIndexAllLayers::updateLayerTransformCache(const Layer *l)
   return hasUpdate;
 }
 
-void RenderIndexAllLayers::writeTransformCacheToInstances()
+void RenderIndexAllLayers::updateLayerAttributeCache(const Layer *l)
+{
+  auto *orderedTransforms = m_layerTransformDependency.at(l);
+  auto *transformCache = m_layerTransformCache.at(l);
+  auto *nodeParams = m_layerNodeInstanceParams.at(l);
+  auto *attributeCache = m_layerAttributeCache.at(l);
+
+  for (size_t transformOrderedIndex = 0;
+      transformOrderedIndex < orderedTransforms->size();
+      ++transformOrderedIndex) {
+    const auto &t = (*orderedTransforms)[transformOrderedIndex];
+    auto transformObjectIndex = t.transformObjectIndex;
+    if (transformObjectIndex == INVALID_INDEX)
+      continue;
+
+    auto parentOrderedIndex = t.parentOrderedIndex;
+    bool hasParent = parentOrderedIndex != INVALID_INDEX;
+
+    if ((*transformCache)[transformOrderedIndex].timestamp
+            < m_transformLastUpdateTimeStamp
+        && (!hasParent
+            || (*transformCache)[parentOrderedIndex].timestamp
+                < m_transformLastUpdateTimeStamp)) {
+      continue;
+    }
+
+    const auto *parentXfmCache =
+        hasParent ? &(*transformCache)[parentOrderedIndex] : nullptr;
+    auto parentElementCount =
+        hasParent ? instanceCount(parentXfmCache->value) : 1;
+
+    auto thisTransformRef =
+        m_ctx->objectDB().transform.at(transformObjectIndex);
+    auto *thisTransform = thisTransformRef.data();
+
+    auto *thisXfmCache = &(*transformCache)[transformOrderedIndex];
+    auto *thisCache = &(*attributeCache)[transformOrderedIndex];
+    auto thisElementCount = instanceCount(thisXfmCache->value);
+
+    for (auto &&[name, value] : thisTransform->getInstanceParameterMap()) {
+      auto &thisAttributeCache = (*thisCache)[name];
+      if (anari::isArray(value.type())) {
+        auto array = m_ctx->getObject<Array>(value.getAsObjectIndex());
+        thisAttributeCache.elementType = array->elementType();
+        if (!array || !array->data())
+          continue;
+        thisAttributeCache = repeatBlock(array->data(),
+            array->size(),
+            array->elementType(),
+            parentElementCount);
+      } else {
+        thisAttributeCache = broadcastValue(value.data(), value.type(), 1);
+      }
+    }
+
+    if (const auto *parentCache =
+            hasParent ? &(*attributeCache)[parentOrderedIndex] : nullptr) {
+      for (auto &&[name, value] : (*parentCache)) {
+        if (thisCache->contains(name))
+          continue;
+
+        auto &thisAttributeCache = (*thisCache)[name];
+
+        if (value.data.size() > 1) {
+          thisAttributeCache = expandEach(value, thisElementCount);
+        } else if (value.data.size() == 1) {
+          thisAttributeCache = value;
+        } else
+          continue;
+      }
+    }
+  }
+}
+
+void RenderIndexAllLayers::writeTransformCacheToInstances(const Layer *layer)
 {
   auto d = device();
 
-  for (const auto &[layer, transformCache] : m_layerTransformCache) {
-    auto *transformDependency = m_layerTransformDependency.at(layer);
-    auto &instanceCache = m_layerInstanceCache[layer];
-    for (size_t transformIndex = 0; transformIndex < transformCache.size();
-        transformIndex++) {
-      if (!transformDependency
-          || (*transformDependency)[transformIndex].transformObjectIndex
-              == INVALID_INDEX)
-        continue;
+  auto *transformCache = m_layerTransformCache.at(layer);
+  auto *transformDependency = m_layerTransformDependency.at(layer);
+  auto *attrCacheVec = m_layerAttributeCache.at(layer);
+  auto &instanceCache = m_layerInstanceCache[layer];
+  for (size_t transformIndex = 0; transformIndex < transformCache->size();
+      transformIndex++) {
+    if (!transformDependency
+        || (*transformDependency)[transformIndex].transformObjectIndex
+            == INVALID_INDEX)
+      continue;
 
-      const auto &transform = transformCache[transformIndex];
-      auto instance = instanceCache[transformIndex];
-      if (!instance)
-        continue;
+    const auto &transform = (*transformCache)[transformIndex];
+    auto instance = instanceCache[transformIndex];
+    if (!instance)
+      continue;
 
-      if (std::holds_alternative<std::vector<math::mat4>>(transform.value)) {
-        const auto &array = std::get<std::vector<math::mat4>>(transform.value);
-        uint64_t stride = 0;
-        auto *xfms = (math::mat4 *)anariMapParameterArray1D(d,
-            instance,
-            "transform",
-            ANARI_FLOAT32_MAT4,
-            array.size(),
-            &stride);
+    if (std::holds_alternative<std::vector<math::mat4>>(transform.value)) {
+      const auto &array = std::get<std::vector<math::mat4>>(transform.value);
+      uint64_t stride = 0;
+      auto *xfms = (math::mat4 *)anariMapParameterArray1D(
+          d, instance, "transform", ANARI_FLOAT32_MAT4, array.size(), &stride);
 
-        if (stride == sizeof(math::mat4))
-          std::copy(cbegin(array), cend(array), xfms);
+      if (stride == sizeof(math::mat4))
+        std::copy(cbegin(array), cend(array), xfms);
 
-        anariUnmapParameterArray(d, instance, "transform");
-      } else {
-        anari::setParameter(
-            d, instance, "transform", std::get<math::mat4>(transform.value));
-      }
-
-      anari::commitParameters(d, instance);
+      anariUnmapParameterArray(d, instance, "transform");
+    } else {
+      anari::setParameter(
+          d, instance, "transform", std::get<math::mat4>(transform.value));
     }
+
+    // Write resolved instance attributes
+    if (attrCacheVec) {
+      const auto &attrs = (*attrCacheVec)[transformIndex];
+      for (const auto &[name, av] : attrs) {
+        if (av.empty())
+          continue;
+        if (av.count() == 1) {
+          anariSetParameter(
+              d, instance, name.c_str(), av.elementType, av.data.data());
+        } else {
+          uint64_t stride = 0;
+          auto *dst = (uint8_t *)anariMapParameterArray1D(
+              d, instance, name.c_str(), av.elementType, av.count(), &stride);
+          if (stride == av.elementSize())
+            std::memcpy(dst, av.data.data(), av.data.size());
+          anariUnmapParameterArray(d, instance, name.c_str());
+        }
+      }
+    }
+
+    anari::commitParameters(d, instance);
   }
 }
 

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
@@ -1,40 +1,49 @@
 // Copyright 2024-2026 NVIDIA Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tsd/rendering/index/RenderIndexAllLayers.hpp"
-
+#include "RenderIndexAllLayers.hpp"
 #include "RenderToAnariObjectsVisitor.hpp"
+
 // tsd_core
 #include "tsd/core/Logging.hpp"
+#include "tsd/core/ObjectPool.hpp"
+#include "tsd/core/TSDMath.hpp"
+#include "tsd/core/TSDTypes.hpp"
+#include "tsd/core/scene/Layer.hpp"
+#include "tsd/core/scene/Object.hpp"
+#include "tsd/core/scene/objects/Array.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
+
+// anari
+#include <anari/anari_cpp/Traits.h>
+#include <anari/anari_cpp/ext/linalg.h>
+#include <anari/frontend/anari_enums.h>
+#include <helium/utility/TimeStamp.h>
+
 // std
 #include <algorithm>
-#include <iterator>
+#include <anari/anari_cpp.hpp>
+#include <variant>
 
 namespace tsd::rendering {
 
-// Helper functions ///////////////////////////////////////////////////////////
-
-static void releaseInstances(
-    anari::Device d, const std::vector<anari::Instance> &instances)
-{
-  for (auto i : instances)
-    anari::release(d, i);
-}
-
 // RenderIndexAllLayers definitions ///////////////////////////////////////////
 
-RenderIndexAllLayers::RenderIndexAllLayers(Scene &scene,
-    tsd::core::Token deviceName,
-    anari::Device d,
-    bool alwaysGatherAllLights)
-    : RenderIndex(scene, deviceName, d), m_forceAllLights(alwaysGatherAllLights)
+RenderIndexAllLayers::RenderIndexAllLayers(
+    Scene &scene, tsd::core::Token deviceName, anari::Device d)
+    : RenderIndex(scene, deviceName, d)
 {
   m_includedLayers = scene.getActiveLayers();
 }
 
 RenderIndexAllLayers::~RenderIndexAllLayers()
 {
-  releaseAllInstances();
+  for (auto &&[_, instanceCache] : m_layerInstanceCache) {
+    for (auto &instance : instanceCache)
+      anari::release(device(), instance);
+  }
+  for (auto &&[_, rootInst] : m_layerRootInstance)
+    anari::release(device(), rootInst);
 }
 
 bool RenderIndexAllLayers::isFlat() const
@@ -59,177 +68,422 @@ void RenderIndexAllLayers::setIncludedLayers(
 
 void RenderIndexAllLayers::signalArrayUnmapped(const Array *a)
 {
-  RenderIndex::signalArrayUnmapped(a);
-  if (a->elementType() == ANARI_FLOAT32_MAT4)
+  bool hasChanged = false;
+
+  const auto &transforms = m_ctx->objectDB().transform;
+  for (auto txIndex = 0; txIndex < transforms.capacity(); ++txIndex) {
+    if (const auto &tx = transforms.at(txIndex)) {
+      for (auto paramIndex = 0; paramIndex < tx->numParameters();
+          ++paramIndex) {
+        const auto &param = tx->parameterAt(paramIndex);
+        const auto &value = param.value();
+
+        if (value.holdsObject() && m_ctx->getObject(value) == a) {
+          hasChanged |= invalidateTransformAtObjectIndex(tx.index());
+        }
+      }
+    }
+  }
+
+  if (hasChanged) {
     updateWorld();
+  }
+  RenderIndex::signalArrayUnmapped(a);
 }
 
-void RenderIndexAllLayers::signalObjectParameterUseCountZero(const Object *o)
+void RenderIndexAllLayers::signalParameterUpdated(
+    const Object *o, const Parameter *p)
 {
-  if (o->useCount(tsd::core::Object::UseKind::LAYER) > 0)
-    return;
-  m_cache.releaseHandle(o);
-#if 0
-    tsd::core::logDebug(
-        "RenderIndex: Object of type %s and name '%s' has "
-        "parameter use count zero; its ANARI handle may be "
-        "released now.",
-        anari::toString(o->type()),
-        o->name().c_str());
-#endif
+  if (o->type() == TSD_TRANSFORM) {
+    if (invalidateTransformAtObjectIndex(o->index()))
+      updateWorld();
+  }
+
+  RenderIndex::signalParameterUpdated(o, p);
 }
 
 void RenderIndexAllLayers::signalObjectLayerUseCountZero(const Object *o)
 {
-  if (o->useCount(tsd::core::Object::UseKind::PARAMETER) > 0)
-    return;
-  m_cache.releaseHandle(o);
-#if 0
-    tsd::core::logDebug(
-        "RenderIndex: Object of type %s and name '%s' has "
-        "layer use count zero; its ANARI handle may be "
-        "released now.",
-        anari::toString(o->type()),
-        o->name().c_str());
-#endif
+  if (o->type() == TSD_TRANSFORM) {
+    auto objectIndex = o->index();
+    std::vector<const Layer *> layersToClear;
+    // Invalidate all layers holding that very object
+    for (auto &&[layer, transformDependency] : m_layerTransformDependency) {
+      for (const auto &transform : transformDependency) {
+        if (transform.transformObjectIndex == objectIndex) {
+          layersToClear.push_back(layer);
+          break;
+        }
+      }
+    }
+
+    for (auto l : layersToClear) {
+      tagDirtyTopology(l);
+    }
+  }
+
+  updateWorld();
+  RenderIndex::signalObjectLayerUseCountZero(o);
 }
 
 void RenderIndexAllLayers::signalLayerAdded(const Layer *l)
 {
-  syncLayerInstances(l, false, objectMask_all());
+  m_includedLayers.push_back(l);
   updateWorld();
 }
 
 void RenderIndexAllLayers::signalLayerUpdated(const Layer *l)
 {
-  if (m_instanceCache.contains(l)) {
-    syncLayerInstances(l, false, objectMask_all());
-    updateWorld();
-  }
+  tagDirtyTopology(l);
+  updateWorld();
 }
 
 void RenderIndexAllLayers::signalLayerRemoved(const Layer *l)
 {
-  if (m_instanceCache.contains(l)) {
-    releaseInstances(device(), m_instanceCache[l]);
-    m_instanceCache.erase(l);
-    updateWorld();
-  }
+  tagDirtyTopology(l);
+  m_includedLayers.erase(
+      std::remove(m_includedLayers.begin(), m_includedLayers.end(), l),
+      m_includedLayers.end());
+  updateWorld();
 }
 
 void RenderIndexAllLayers::signalActiveLayersChanged()
 {
-  if (!m_customIncludedLayers) {
-    if (m_includedLayers.empty()
-        && m_ctx->numberOfActiveLayers() == m_ctx->numberOfLayers())
-      return;
+  if (!m_customIncludedLayers)
     m_includedLayers = m_ctx->getActiveLayers();
-  }
+
   signalInvalidateCachedObjects();
+
+  RenderIndex::signalActiveLayersChanged();
 }
 
 void RenderIndexAllLayers::signalObjectFilteringChanged()
 {
   if (m_filter || m_filterForceUpdate) {
-    releaseAllInstances();
-    updateWorld();
     m_filterForceUpdate = false;
+    updateWorld();
   }
+
+  RenderIndex::signalObjectFilteringChanged();
+}
+
+void RenderIndexAllLayers::signalAnimationTimeChanged(float)
+{
+  // Transform/value updates are applied through signalParameterUpdated().
 }
 
 void RenderIndexAllLayers::signalRemoveAllObjects()
 {
-  releaseAllInstances();
   RenderIndex::signalRemoveAllObjects();
+  m_includedLayers.clear();
+  m_layerTransformDependency.clear();
+  m_layerTransformCache.clear();
+  for (auto &&[_, instanceCache] : m_layerInstanceCache) {
+    for (auto &instance : instanceCache)
+      anari::release(device(), instance);
+    instanceCache.clear();
+  }
+  m_layerInstanceCache.clear();
+  for (auto &&[_, rootInst] : m_layerRootInstance)
+    anari::release(device(), rootInst);
+  m_layerRootInstance.clear();
+
+  m_transformLastUpdateTimeStamp = helium::newTimeStamp();
 }
 
 void RenderIndexAllLayers::updateWorld()
 {
-#if 0
-  tsd::core::logDebug(
-      "RenderIndexAllLayers: updating world with %zu layers included, "
-      "%zu external instances, and %zu cached layers.",
-      m_includedLayers.size(),
-      m_externalInstances.size(),
-      m_instanceCache.size());
-#endif
-
   auto d = device();
   auto w = world();
 
-  if (m_instanceCache.empty()) {
-    if (!m_includedLayers.empty()) { // only sync specified layers
-      tsd::core::logDebug(
-          "[RenderIndexAllLayers] cache empty, "
-          "repopulating using specific layers");
-      if (m_forceAllLights) {
-        // first just the surfaces/volumes from included layers
-        for (auto &l : m_includedLayers)
-          syncLayerInstances(l, false, objectMask_surfacesAndVolumes());
-        // then all lights from all layers
-        for (auto &l : m_ctx->layers())
-          syncLayerInstances(l.second.ptr.get(), true, objectMask_lights());
-      } else {
-        for (auto &l : m_includedLayers)
-          syncLayerInstances(l, false, objectMask_all());
-      }
-    } else { // sync everything
-      tsd::core::logDebug(
-          "[RenderIndexAllLayers] cache empty, "
-          "repopulating using all layers");
-      for (auto &l : m_ctx->layers())
-        syncLayerInstances(l.second.ptr.get(), false, objectMask_all());
+  auto effectiveLayers = m_includedLayers;
+
+  bool needTopologyUpdate = false;
+  bool needInstanceUpdate = false;
+  for (const auto *l : effectiveLayers) {
+    if (!m_layerTransformDependency.contains(l)) {
+      needTopologyUpdate = true;
+      updateLayerTransformDependency(l);
+    }
+    if (updateLayerTransformCache(l)) {
+      needInstanceUpdate = true;
+      RenderToAnariObjectsVisitor visitor(d,
+          m_cache,
+          m_layerInstanceCache[l],
+          m_layerRootInstance[l],
+          m_filter);
+      const_cast<Layer *>(l)->traverse(l->root(), visitor);
+      visitor.finalizeRootObjects();
     }
   }
+  m_transformLastUpdateTimeStamp = helium::newTimeStamp();
 
-  std::vector<anari::Instance> instances;
-  instances.reserve(2000);
+  if (needInstanceUpdate)
+    writeTransformCacheToInstances();
 
-  for (auto &i : m_instanceCache)
-    std::copy(i.second.begin(), i.second.end(), std::back_inserter(instances));
+  if (needTopologyUpdate) {
+    std::vector<anari::Instance> allInstances;
+    for (const auto *l : effectiveLayers) {
+      auto *deps = m_layerTransformDependency.at(l);
+      auto &instances = m_layerInstanceCache[l];
+      for (size_t i = 0; i < instances.size(); i++) {
+        if ((*deps)[i].transformObjectIndex != INVALID_INDEX && instances[i])
+          allInstances.push_back(instances[i]);
+      }
+      if (auto *rootInst = m_layerRootInstance.at(l); rootInst && *rootInst)
+        allInstances.push_back(*rootInst);
+    }
 
-  std::copy(m_externalInstances.begin(),
-      m_externalInstances.end(),
-      std::back_inserter(instances));
+    if (!allInstances.empty()) {
+      anari::setParameterArray1D(device(),
+          m_world,
+          "instance",
+          allInstances.data(),
+          allInstances.size());
+    } else {
+      anari::unsetParameter(device(), m_world, "instance");
+    }
 
-  if (instances.empty())
-    anari::unsetParameter(d, w, "instance");
-  else {
-    anari::setParameterArray1D(
-        d, w, "instance", instances.data(), instances.size());
+    anari::commitParameters(d, w);
   }
-
-  anari::commitParameters(d, w);
 }
 
-void RenderIndexAllLayers::syncLayerInstances(
-    const Layer *_layer, bool appendExisting, uint8_t mask)
+void RenderIndexAllLayers::updateLayerTransformDependency(const Layer *l)
+{
+  // Dependency/cache/instance vectors are indexed by transform traversal order
+  // (entry index), not by transform object pool index.
+  // We only use pool capacity here as a conservative reserve upper bound.
+  auto xfmCapacity = m_ctx->objectDB().transform.capacity();
+
+  std::vector<TransformDependency> orderedTransforms;
+  // Final size equals the number of enabled transform nodes in this layer.
+  orderedTransforms.reserve(xfmCapacity);
+
+  auto mutableLayer = const_cast<Layer *>(l);
+  size_t currentOrderedIndex = INVALID_INDEX;
+
+  mutableLayer->traverse(
+      mutableLayer->root(),
+      [&](LayerNode &n, int /*level*/) {
+        if (!n->isEnabled())
+          return false; // match RenderToAnariObjectsVisitor subtree pruning
+        if (!n->isTransform())
+          return true;
+
+        auto transformObject = n->getTransformObject();
+
+        const size_t parentOrderedIndex = currentOrderedIndex;
+        currentOrderedIndex = orderedTransforms.size();
+        orderedTransforms.push_back({n->getObjectIndex(),
+            parentOrderedIndex,
+            n->name().size() ? n->name() : n->getObject()->name()});
+
+        return true;
+      },
+      [&](LayerNode &n, int /*level*/) {
+        if (!n->isEnabled())
+          return true;
+        if (!n->isTransform())
+          return true;
+
+        currentOrderedIndex = currentOrderedIndex == INVALID_INDEX
+            ? INVALID_INDEX
+            : orderedTransforms[currentOrderedIndex].parentOrderedIndex;
+        return true;
+      });
+
+  auto xfmCount = orderedTransforms.size();
+  m_layerTransformDependency[l] = std::move(orderedTransforms);
+  m_layerTransformCache[l].clear();
+  m_layerTransformCache[l].resize(
+      xfmCount, {math::IDENTITY_MAT4, helium::newTimeStamp()});
+  m_layerAttributeCache[l].clear();
+  m_layerAttributeCache[l].resize(xfmCount);
+
+  // Release any previously-allocated instances before recreating
+  if (auto *oldInstances = m_layerInstanceCache.at(l)) {
+    for (auto &inst : *oldInstances)
+      anari::release(device(), inst);
+  }
+  m_layerInstanceCache[l].clear();
+  m_layerInstanceCache[l].reserve(orderedTransforms.size());
+  std::generate_n(
+      back_inserter(m_layerInstanceCache[l]), xfmCount, [d = device()]() {
+        return anari::newObject<anari::Instance>(d, "transform");
+      });
+
+  if (auto *oldRoot = m_layerRootInstance.at(l))
+    anari::release(device(), *oldRoot);
+  m_layerRootInstance[l] =
+      anari::newObject<anari::Instance>(device(), "transform");
+}
+
+bool RenderIndexAllLayers::updateLayerTransformCache(const Layer *l)
+{
+  auto *orderedTransforms = m_layerTransformDependency.at(l);
+  auto *transformCache = m_layerTransformCache.at(l);
+
+  const TransformCache identityCache = {math::IDENTITY_MAT4, 0};
+
+  auto thisTs = helium::newTimeStamp();
+
+  bool hasUpdate = false;
+
+  for (size_t transformOrderedIndex = 0;
+      transformOrderedIndex < orderedTransforms->size();
+      ++transformOrderedIndex) {
+    const auto &t = (*orderedTransforms)[transformOrderedIndex];
+    auto transformObjectIndex = t.transformObjectIndex;
+    if (transformObjectIndex == INVALID_INDEX)
+      continue;
+
+    auto parentOrderedIndex = t.parentOrderedIndex;
+    bool hasParent = parentOrderedIndex != INVALID_INDEX;
+
+    if ((*transformCache)[transformOrderedIndex].timestamp
+            < m_transformLastUpdateTimeStamp
+        && (!hasParent
+            || (*transformCache)[parentOrderedIndex].timestamp
+                < m_transformLastUpdateTimeStamp)) {
+      continue;
+    }
+
+    // FIXME: Handle other properties such as color
+
+    const auto *parentCache =
+        hasParent ? &(*transformCache)[parentOrderedIndex] : &identityCache;
+
+    auto thisTransformRef =
+        m_ctx->objectDB().transform.at(transformObjectIndex);
+    auto *thisTransform = thisTransformRef.data();
+    auto thisXfm = thisTransform->getTransformAsAny();
+    auto *thisCache = &(*transformCache)[transformOrderedIndex];
+
+    if (thisXfm.is<math::mat4>()) {
+      const auto xfm = thisXfm.getAs<math::mat4>();
+
+      if (std::holds_alternative<math::mat4>(parentCache->value)) {
+        const auto &parentXfm = std::get<math::mat4>(parentCache->value);
+        thisCache->value = composeTransform(parentXfm, xfm);
+      } else {
+        const auto &parentXfms =
+            std::get<std::vector<math::mat4>>(parentCache->value);
+        thisCache->value =
+            composeTransform(&*cbegin(parentXfms), &*cend(parentXfms), xfm);
+      }
+    } else if (auto xfmArray =
+                   m_ctx->getObject<Array>(thisXfm.getAsObjectIndex());
+        xfmArray && xfmArray->elementType() == ANARI_FLOAT32_MAT4) {
+      const auto xfmsCount = xfmArray->size();
+      const auto *xfms = xfmArray->dataAs<math::mat4>();
+
+      if (std::holds_alternative<math::mat4>(parentCache->value)) {
+        const auto &parentXfm = std::get<math::mat4>(parentCache->value);
+        thisCache->value = composeTransform(parentXfm, xfms, xfms + xfmsCount);
+      } else {
+        const auto &parentXfms =
+            std::get<std::vector<math::mat4>>(parentCache->value);
+        thisCache->value = composeTransform(
+            &*cbegin(parentXfms), &*cend(parentXfms), xfms, xfms + xfmsCount);
+      }
+    } else {
+      logWarning("Unexpected transformation value type, ignoring...\n");
+      thisCache->value = math::IDENTITY_MAT4;
+    }
+
+    hasUpdate = true;
+    thisCache->timestamp = thisTs;
+  }
+
+  return hasUpdate;
+}
+
+void RenderIndexAllLayers::writeTransformCacheToInstances()
 {
   auto d = device();
 
-  std::vector<anari::Instance> instances;
-  instances.reserve(100);
+  for (const auto &[layer, transformCache] : m_layerTransformCache) {
+    auto *transformDependency = m_layerTransformDependency.at(layer);
+    auto &instanceCache = m_layerInstanceCache[layer];
+    for (size_t transformIndex = 0; transformIndex < transformCache.size();
+        transformIndex++) {
+      if (!transformDependency
+          || (*transformDependency)[transformIndex].transformObjectIndex
+              == INVALID_INDEX)
+        continue;
 
-  auto *layer = const_cast<Layer *>(_layer);
+      const auto &transform = transformCache[transformIndex];
+      auto instance = instanceCache[transformIndex];
+      if (!instance)
+        continue;
 
-  RenderToAnariObjectsVisitor visitor(
-      d, m_cache, &instances, mask, m_filter ? &m_filter : nullptr);
-  layer->traverse(layer->root(), visitor);
+      if (std::holds_alternative<std::vector<math::mat4>>(transform.value)) {
+        const auto &array = std::get<std::vector<math::mat4>>(transform.value);
+        uint64_t stride = 0;
+        auto *xfms = (math::mat4 *)anariMapParameterArray1D(d,
+            instance,
+            "transform",
+            ANARI_FLOAT32_MAT4,
+            array.size(),
+            &stride);
 
-  auto &cached = m_instanceCache[layer];
-  if (appendExisting)
-    std::copy(instances.begin(), instances.end(), std::back_inserter(cached));
-  else {
-    releaseInstances(d, cached);
-    cached = instances;
+        if (stride == sizeof(math::mat4))
+          std::copy(cbegin(array), cend(array), xfms);
+
+        anariUnmapParameterArray(d, instance, "transform");
+      } else {
+        anari::setParameter(
+            d, instance, "transform", std::get<math::mat4>(transform.value));
+      }
+
+      anari::commitParameters(d, instance);
+    }
   }
 }
 
-void RenderIndexAllLayers::releaseAllInstances()
+bool RenderIndexAllLayers::invalidateTransformAtObjectIndex(
+    size_t objectIndex, const Layer *layer)
 {
-  for (auto &i : m_instanceCache)
-    releaseInstances(device(), i.second);
-  m_instanceCache.clear();
+  bool didInvalidate = false;
+
+  auto &transformDependency = *m_layerTransformDependency.at(layer);
+  auto &transformCache = *m_layerTransformCache.at(layer);
+  auto &instanceCache = *m_layerInstanceCache.at(layer);
+  for (size_t i = 0; i < transformDependency.size(); ++i) {
+    if (transformDependency[i].transformObjectIndex == objectIndex) {
+      transformCache[i].timestamp = helium::newTimeStamp();
+      didInvalidate = true;
+    }
+  }
+
+  return didInvalidate;
 }
 
+bool RenderIndexAllLayers::invalidateTransformAtObjectIndex(size_t index)
+{
+  bool didInvalidate = false;
+
+  for (auto &&[layer, _] : m_layerTransformDependency) {
+    didInvalidate |= invalidateTransformAtObjectIndex(index, layer);
+  }
+
+  return didInvalidate;
+}
+
+void RenderIndexAllLayers::tagDirtyTopology(const Layer *l)
+{
+  m_layerTransformDependency.erase(l);
+  m_layerTransformCache.erase(l);
+  m_layerNodeInstanceParams.erase(l);
+  m_layerAttributeCache.erase(l);
+  if (auto *instances = m_layerInstanceCache.at(l)) {
+    for (auto &inst : *instances)
+      anari::release(device(), inst);
+  }
+  m_layerInstanceCache.erase(l);
+  if (auto *rootInst = m_layerRootInstance.at(l)) {
+    anari::release(device(), *rootInst);
+    m_layerRootInstance.erase(l);
+  }
+}
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
@@ -36,6 +36,23 @@ struct RenderIndexAllLayers : public RenderIndex
   void signalAnimationTimeChanged(float time) override;
   void signalRemoveAllObjects() override;
 
+  struct TransformCache
+  {
+    using Value = std::variant<math::mat4, std::vector<math::mat4>>;
+    Value value;
+    helium::TimeStamp timestamp{};
+  };
+
+  struct AttributeValue
+  {
+    std::vector<uint8_t> data;
+    ANARIDataType elementType{ANARI_UNKNOWN};
+
+    bool empty() const;
+    size_t elementSize() const;
+    size_t count() const;
+  };
+
  private:
   void updateWorld() override;
 
@@ -44,20 +61,7 @@ struct RenderIndexAllLayers : public RenderIndex
   bool m_customIncludedLayers{false};
   bool m_filterForceUpdate{false};
 
-  void tagDirtyTopology(const Layer *l)
-  {
-    m_layerTransformDependency.erase(l);
-    m_layerTransformCache.erase(l);
-    if (auto *instances = m_layerInstanceCache.at(l)) {
-      for (auto &inst : *instances)
-        anari::release(device(), inst);
-    }
-    m_layerInstanceCache.erase(l);
-    if (auto *rootInst = m_layerRootInstance.at(l)) {
-      anari::release(device(), *rootInst);
-      m_layerRootInstance.erase(l);
-    }
-  }
+  void tagDirtyTopology(const Layer *l);
 
   helium::TimeStamp m_transformLastUpdateTimeStamp{0};
 
@@ -68,23 +72,22 @@ struct RenderIndexAllLayers : public RenderIndex
     std::string transformName;
   };
 
-  struct TransformCache
-  {
-    using Value = std::variant<math::mat4, std::vector<math::mat4>>;
-    Value value;
-    helium::TimeStamp timestamp{};
-  };
+  using AttributeCache = FlatMap<Token, AttributeValue>;
+  using InstanceParameterMap = tsd::core::Transform::InstanceParameterMap;
 
   FlatMap<const Layer *, std::vector<TransformDependency>>
       m_layerTransformDependency;
   FlatMap<const Layer *, std::vector<TransformCache>> m_layerTransformCache;
   FlatMap<const Layer *, std::vector<anari::Instance>> m_layerInstanceCache;
   FlatMap<const Layer *, anari::Instance> m_layerRootInstance;
+  FlatMap<const Layer *, std::vector<InstanceParameterMap>>
+      m_layerNodeInstanceParams;
+  FlatMap<const Layer *, std::vector<AttributeCache>> m_layerAttributeCache;
 
   void updateLayerTransformDependency(const Layer *l);
   bool updateLayerTransformCache(const Layer *l);
-  void writeTransformCacheToInstances();
-  // void patchInstanceTransforms();
+  void updateLayerAttributeCache(const Layer *l);
+  void writeTransformCacheToInstances(const Layer *l);
   bool invalidateTransformAtObjectIndex(size_t index);
   bool invalidateTransformAtObjectIndex(size_t index, const Layer *l);
 };

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
@@ -3,18 +3,20 @@
 
 #pragma once
 
+#include <helium/utility/TimeStamp.h>
+#include "tsd/core/scene/Layer.hpp"
 #include "tsd/rendering/index/RenderIndex.hpp"
 // std
+#include <anari/anari_cpp.hpp>
+#include <variant>
 #include <vector>
 
 namespace tsd::rendering {
 
 struct RenderIndexAllLayers : public RenderIndex
 {
-  RenderIndexAllLayers(Scene &scene,
-      tsd::core::Token deviceName,
-      anari::Device d,
-      bool alwaysGatherAllLights = false);
+  RenderIndexAllLayers(
+      Scene &scene, tsd::core::Token deviceName, anari::Device d);
   ~RenderIndexAllLayers() override;
 
   bool isFlat() const override;
@@ -24,29 +26,67 @@ struct RenderIndexAllLayers : public RenderIndex
   void setIncludedLayers(const std::vector<const Layer *> &layers);
 
   void signalArrayUnmapped(const Array *a) override;
-  void signalObjectParameterUseCountZero(const Object *obj) override;
+  void signalParameterUpdated(const Object *o, const Parameter *p) override;
   void signalObjectLayerUseCountZero(const Object *obj) override;
   void signalLayerAdded(const Layer *l) override;
   void signalLayerUpdated(const Layer *l) override;
   void signalLayerRemoved(const Layer *l) override;
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;
+  void signalAnimationTimeChanged(float time) override;
   void signalRemoveAllObjects() override;
 
  private:
   void updateWorld() override;
-  void syncLayerInstances(
-      const Layer *layer, bool appendExisting, uint8_t mask);
-  void releaseAllInstances();
 
   RenderIndexFilterFcn m_filter;
   std::vector<const Layer *> m_includedLayers;
-  bool m_forceAllLights{false};
   bool m_customIncludedLayers{false};
   bool m_filterForceUpdate{false};
 
-  using InstanceCache = FlatMap<const Layer *, std::vector<anari::Instance>>;
-  InstanceCache m_instanceCache;
+  void tagDirtyTopology(const Layer *l)
+  {
+    m_layerTransformDependency.erase(l);
+    m_layerTransformCache.erase(l);
+    if (auto *instances = m_layerInstanceCache.at(l)) {
+      for (auto &inst : *instances)
+        anari::release(device(), inst);
+    }
+    m_layerInstanceCache.erase(l);
+    if (auto *rootInst = m_layerRootInstance.at(l)) {
+      anari::release(device(), *rootInst);
+      m_layerRootInstance.erase(l);
+    }
+  }
+
+  helium::TimeStamp m_transformLastUpdateTimeStamp{0};
+
+  struct TransformDependency
+  {
+    size_t transformObjectIndex;
+    size_t parentOrderedIndex;
+    std::string transformName;
+  };
+
+  struct TransformCache
+  {
+    using Value = std::variant<math::mat4, std::vector<math::mat4>>;
+    Value value;
+    helium::TimeStamp timestamp{};
+  };
+
+  FlatMap<const Layer *, std::vector<TransformDependency>>
+      m_layerTransformDependency;
+  FlatMap<const Layer *, std::vector<TransformCache>> m_layerTransformCache;
+  FlatMap<const Layer *, std::vector<anari::Instance>> m_layerInstanceCache;
+  FlatMap<const Layer *, anari::Instance> m_layerRootInstance;
+
+  void updateLayerTransformDependency(const Layer *l);
+  bool updateLayerTransformCache(const Layer *l);
+  void writeTransformCacheToInstances();
+  // void patchInstanceTransforms();
+  bool invalidateTransformAtObjectIndex(size_t index);
+  bool invalidateTransformAtObjectIndex(size_t index, const Layer *l);
 };
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/index/RenderToAnariObjectsVisitor.hpp
+++ b/tsd/src/tsd/rendering/index/RenderToAnariObjectsVisitor.hpp
@@ -4,62 +4,37 @@
 #pragma once
 
 // tsd_core
+#include "tsd/core/AnariObjectCache.hpp"
+#include "tsd/core/TSDTypes.hpp"
 #include "tsd/core/scene/Layer.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
 // tsd_rendering
 #include "tsd/rendering/index/RenderIndexFilterFcn.hpp"
 // std
-#include <algorithm>
-#include <cstdint>
-#include <iterator>
+#include <anari/anari_cpp.hpp>
+#include <cassert>
 #include <stack>
+#include <vector>
 
 namespace tsd::rendering {
-
-enum RenderInclusionMask
-{
-  SURFACES = 1 << 0,
-  VOLUMES = 1 << 1,
-  LIGHTS = 1 << 2,
-  ALL = ((1 << 3) - 1)
-};
-
-constexpr uint8_t objectMask_none()
-{
-  return 0;
-}
-
-constexpr uint8_t objectMask_all()
-{
-  return RenderInclusionMask::ALL;
-}
-
-constexpr uint8_t objectMask_surfacesAndVolumes()
-{
-  return RenderInclusionMask::SURFACES | RenderInclusionMask::VOLUMES;
-}
-
-constexpr uint8_t objectMask_lights()
-{
-  return RenderInclusionMask::LIGHTS;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 
 struct RenderToAnariObjectsVisitor : public tsd::core::LayerVisitor
 {
   RenderToAnariObjectsVisitor(anari::Device d,
-      tsd::core::AnariObjectCache &oc,
-      std::vector<anari::Instance> *instances,
-      uint8_t inclusionMask = objectMask_all(),
-      RenderIndexFilterFcn *f = nullptr);
+      tsd::core::AnariObjectCache &cache,
+      std::vector<anari::Instance> &instanceCache,
+      anari::Instance &rootInstance,
+      RenderIndexFilterFcn filter);
   ~RenderToAnariObjectsVisitor();
 
-  bool preChildren(tsd::core::LayerNode &n, int level) override;
-  void postChildren(tsd::core::LayerNode &n, int level) override;
+  bool preChildren(tsd::core::LayerNode &n, int /*level*/) override;
+  void postChildren(tsd::core::LayerNode &n, int /*level*/) override;
+
+  void finalizeRootObjects();
 
  private:
   bool isIncludedAfterFiltering(const tsd::core::LayerNode &n) const;
-  void createInstanceFromTop();
+  bool commitGroupToInstance(anari::Instance instance);
 
   struct GroupedObjects
   {
@@ -70,29 +45,30 @@ struct RenderToAnariObjectsVisitor : public tsd::core::LayerVisitor
 
   anari::Device m_device{nullptr};
   tsd::core::AnariObjectCache *m_cache{nullptr};
-  std::vector<anari::Instance> *m_instances{nullptr};
-  std::stack<tsd::math::mat4> m_xfms;
+  std::vector<anari::Instance> *m_instances;
+  anari::Instance *m_rootInstance{nullptr};
+  RenderIndexFilterFcn m_filter;
   std::stack<GroupedObjects> m_objects;
-  const tsd::core::Array *m_xfmArray{nullptr};
-  uint8_t m_mask{objectMask_none()};
-  RenderIndexFilterFcn *m_filter{nullptr};
+  size_t m_nextTransformOrderedIndex{0};
+  std::stack<size_t> m_transformOrderedIndices;
+  size_t m_expectedTransformCount{0};
 };
 
 // Inlined definitions ////////////////////////////////////////////////////////
 
 inline RenderToAnariObjectsVisitor::RenderToAnariObjectsVisitor(anari::Device d,
-    tsd::core::AnariObjectCache &oc,
-    std::vector<anari::Instance> *instances,
-    uint8_t mask,
-    RenderIndexFilterFcn *f)
+    tsd::core::AnariObjectCache &cache,
+    std::vector<anari::Instance> &instanceCache,
+    anari::Instance &rootInstance,
+    RenderIndexFilterFcn filter)
     : m_device(d),
-      m_cache(&oc),
-      m_instances(instances),
-      m_mask(mask),
-      m_filter(f)
+      m_cache(&cache),
+      m_instances(&instanceCache),
+      m_rootInstance(&rootInstance),
+      m_filter(std::move(filter)),
+      m_expectedTransformCount(instanceCache.size())
 {
   anari::retain(d, d);
-  m_xfms.emplace(tsd::math::identity);
   m_objects.emplace();
 }
 
@@ -102,7 +78,7 @@ inline RenderToAnariObjectsVisitor::~RenderToAnariObjectsVisitor()
 }
 
 inline bool RenderToAnariObjectsVisitor::preChildren(
-    tsd::core::LayerNode &n, int level)
+    tsd::core::LayerNode &n, int /*level*/)
 {
   if (!n->isEnabled())
     return false;
@@ -112,89 +88,58 @@ inline bool RenderToAnariObjectsVisitor::preChildren(
   const bool included = isIncludedAfterFiltering(n);
 
   auto type = n->type();
+
   switch (type) {
-  case ANARI_SURFACE:
-    if (m_mask & RenderInclusionMask::SURFACES) {
-      size_t i = n->getObjectIndex();
-      if (auto h = m_cache->getHandle(type, i, true); h != nullptr && included)
-        current.surfaces.push_back((anari::Surface)h);
-    }
+  case ANARI_SURFACE: {
+    size_t i = n->getObjectIndex();
+    if (auto h = m_cache->getHandle(type, i, true); h != nullptr && included)
+      current.surfaces.push_back((anari::Surface)h);
     break;
-  case ANARI_VOLUME:
-    if (m_mask & RenderInclusionMask::VOLUMES) {
-      size_t i = n->getObjectIndex();
-      if (auto h = m_cache->getHandle(type, i, true); h != nullptr && included)
-        current.volumes.push_back((anari::Volume)h);
-    }
+  }
+  case ANARI_VOLUME: {
+    size_t i = n->getObjectIndex();
+    if (auto h = m_cache->getHandle(type, i, true); h != nullptr && included)
+      current.volumes.push_back((anari::Volume)h);
     break;
-  case ANARI_LIGHT:
-    if (m_mask & RenderInclusionMask::LIGHTS) {
-      size_t i = n->getObjectIndex();
-      if (auto h = m_cache->getHandle(type, i, true); h != nullptr)
-        current.lights.push_back((anari::Light)h);
-    }
+  }
+  case ANARI_LIGHT: {
+    size_t i = n->getObjectIndex();
+    if (auto h = m_cache->getHandle(type, i, true); h != nullptr)
+      current.lights.push_back((anari::Light)h);
     break;
-  case ANARI_FLOAT32_MAT4:
-    m_xfms.push(tsd::math::mul(m_xfms.top(), n->getTransform()));
+  }
+  case core::TSD_TRANSFORM: {
+    assert(m_nextTransformOrderedIndex < m_instances->size());
+    m_transformOrderedIndices.push(m_nextTransformOrderedIndex++);
     m_objects.emplace();
     break;
-  case ANARI_ARRAY1D: {
-    if (auto *a = n->getTransformArray(); a) {
-      m_objects.emplace();
-      m_xfmArray = a;
-    }
   }
-  default:
-    break;
   }
 
   return true;
 }
 
 inline void RenderToAnariObjectsVisitor::postChildren(
-    tsd::core::LayerNode &n, int level)
+    tsd::core::LayerNode &n, int /*level*/)
 {
   if (!n->isEnabled())
     return;
 
-  bool consumeXfmArray = false;
-  switch (n->type()) {
-  case ANARI_ARRAY1D: {
-    if (auto *a = n->getTransformArray(); !a)
-      break;
-    consumeXfmArray = true;
-  }
-  // intentionally fallthrough...
-  case ANARI_FLOAT32_MAT4:
-    createInstanceFromTop();
+  auto nodeType = n->type();
+  switch (nodeType) {
+  case core::TSD_TRANSFORM: {
+    const auto orderedIndex = m_transformOrderedIndices.top();
+    m_transformOrderedIndices.pop();
+    assert(orderedIndex < m_instances->size());
 
-    if (!consumeXfmArray)
-      m_xfms.pop();
-    else {
-      //
-      // NOTE(jda) - custom parameters here is awkward, should be generalized...
-      //
-      //   TODO: Put setting TSD object parameters on an ANARI handle in a
-      //         common spot for here + base Object updates physically the same.
-      //
-      anari::Instance inst = m_instances->back();
-      for (auto &p : n->getInstanceParameters()) {
-        if (!p.second.holdsObject())
-          continue;
-        auto objType = p.second.type();
-        auto objHandle =
-            m_cache->getHandle(objType, p.second.getAsObjectIndex(), true);
-        anari::setParameter(
-            m_device, inst, p.first.c_str(), objType, &objHandle);
-      }
-      anari::commitParameters(m_device, inst);
+    if (!commitGroupToInstance((*m_instances)[orderedIndex])) {
+      anari::release(m_device, (*m_instances)[orderedIndex]);
+      (*m_instances)[orderedIndex] = {};
     }
 
     m_objects.pop();
     break;
-  default:
-    // no-op
-    break;
+  }
   }
 }
 
@@ -205,18 +150,23 @@ inline bool RenderToAnariObjectsVisitor::isIncludedAfterFiltering(
     return true;
 
   auto type = n->type();
-  if (!anari::isObject(type))
+  if (!anari::isObject(type) && !tsd::core::isTSDTransform(type))
     return false;
 
-  return (*m_filter)(n->getObject());
+  return m_filter(n->getObject());
 }
 
-inline void RenderToAnariObjectsVisitor::createInstanceFromTop()
+inline bool RenderToAnariObjectsVisitor::commitGroupToInstance(
+    anari::Instance instance)
 {
   auto &current = m_objects.top();
+
   if (current.surfaces.empty() && current.volumes.empty()
-      && current.lights.empty())
-    return;
+      && current.lights.empty()) {
+    anari::unsetParameter(m_device, instance, "group");
+    anari::commitParameters(m_device, instance);
+    return false;
+  }
 
   auto group = anari::newObject<anari::Group>(m_device);
 
@@ -241,46 +191,24 @@ inline void RenderToAnariObjectsVisitor::createInstanceFromTop()
         m_device, group, "light", current.lights.data(), current.lights.size());
   }
 
-  current.surfaces.clear();
-  current.volumes.clear();
-  current.lights.clear();
-
   anari::commitParameters(m_device, group);
 
-  auto instance = anari::newObject<anari::Instance>(m_device, "transform");
-
-  const auto xfm = m_xfms.top();
-  if (!m_xfmArray)
-    anari::setParameter(m_device, instance, "transform", xfm);
-  else {
-    const auto *xfms_in = m_xfmArray->dataAs<tsd::math::mat4>();
-
-    uint64_t stride = 0;
-    auto *xfms_out = (tsd::math::mat4 *)anariMapParameterArray1D(m_device,
-        instance,
-        "transform",
-        ANARI_FLOAT32_MAT4,
-        m_xfmArray->size(),
-        &stride);
-
-    if (stride == sizeof(tsd::math::mat4)) {
-      std::transform(xfms_in,
-          xfms_in + m_xfmArray->size(),
-          xfms_out,
-          [&](const tsd::math::mat4 &m) { return tsd::math::mul(xfm, m); });
-    } else {
-      throw std::runtime_error("render index -- bad transform array stride");
-    }
-
-    anariUnmapParameterArray(m_device, instance, "transform");
-
-    m_xfmArray = nullptr;
-  }
   anari::setParameter(m_device, instance, "group", group);
   anari::commitParameters(m_device, instance);
-  m_instances->push_back(instance);
 
   anari::release(m_device, group);
+
+  return true;
+}
+
+inline void RenderToAnariObjectsVisitor::finalizeRootObjects()
+{
+  assert(m_transformOrderedIndices.empty());
+  assert(m_nextTransformOrderedIndex == m_expectedTransformCount);
+  if (!commitGroupToInstance(*m_rootInstance)) {
+    anari::release(m_device, *m_rootInstance);
+    *m_rootInstance = {};
+  }
 }
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/scripting/Sol2Helpers.hpp
+++ b/tsd/src/tsd/scripting/Sol2Helpers.hpp
@@ -19,6 +19,7 @@
 #include "tsd/core/scene/objects/Sampler.hpp"
 #include "tsd/core/scene/objects/SpatialField.hpp"
 #include "tsd/core/scene/objects/Surface.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
 #include "tsd/core/scene/objects/Volume.hpp"
 
 #include <functional>
@@ -50,6 +51,7 @@ TSD_SOL2_COMPARISON_OPS(Light)
 TSD_SOL2_COMPARISON_OPS(Material)
 TSD_SOL2_COMPARISON_OPS(Sampler)
 TSD_SOL2_COMPARISON_OPS(Volume)
+TSD_SOL2_COMPARISON_OPS(Transform)
 TSD_SOL2_COMPARISON_OPS(LayerNodeData)
 
 #undef TSD_SOL2_COMPARISON_OPS

--- a/tsd/src/tsd/scripting/bindings/CoreBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/CoreBindings.cpp
@@ -4,14 +4,14 @@
 #include "ArrayHelpers.hpp"
 #include "ObjectMethodBindings.hpp"
 #include "ParameterHelpers.hpp"
-#include "tsd/scripting/LuaBindings.hpp"
-#include "tsd/core/Token.hpp"
 #include "tsd/core/Parameter.hpp"
+#include "tsd/core/Token.hpp"
 #include "tsd/core/scene/Animation.hpp"
 #include "tsd/core/scene/Object.hpp"
 #include "tsd/core/scene/Scene.hpp"
 #include "tsd/core/scene/objects/Array.hpp"
 #include "tsd/core/scene/objects/Sampler.hpp"
+#include "tsd/scripting/LuaBindings.hpp"
 #include "tsd/scripting/Sol2Helpers.hpp"
 
 #include <sol/sol.hpp>
@@ -52,6 +52,10 @@ static core::Object *extractObjectPtr(sol::object luaObj)
     auto ref = luaObj.as<core::SpatialFieldRef>();
     return ref.valid() ? ref.data() : nullptr;
   }
+  if (luaObj.is<core::TransformRef>()) {
+    auto ref = luaObj.as<core::TransformRef>();
+    return ref.valid() ? ref.data() : nullptr;
+  }
   if (luaObj.is<core::ArrayRef>()) {
     auto ref = luaObj.as<core::ArrayRef>();
     return ref.valid() ? ref.data() : nullptr;
@@ -90,7 +94,6 @@ static auto makeCreateBinding()
   };
 }
 
-
 void registerCoreBindings(sol::state &lua)
 {
   sol::table tsd = lua["tsd"];
@@ -107,7 +110,8 @@ void registerCoreBindings(sol::state &lua)
       [](const core::Token &a, const core::Token &b) { return a == b; });
 
   // Read-only from Lua; values are set through Object
-  tsd.new_usertype<core::Parameter>("Parameter",
+  tsd.new_usertype<core::Parameter>(
+      "Parameter",
       sol::no_constructor,
       "name",
       [](const core::Parameter &p) { return p.name().str(); },
@@ -116,24 +120,32 @@ void registerCoreBindings(sol::state &lua)
       "isEnabled",
       &core::Parameter::isEnabled);
 
-  auto objectType = tsd.new_usertype<core::Object>("Object",
-      sol::no_constructor,
-      "index",
-      &core::Object::index);
+  auto objectType = tsd.new_usertype<core::Object>(
+      "Object", sol::no_constructor, "index", &core::Object::index);
 
   registerObjectMethodsOn(
       objectType, [](core::Object &o) -> core::Object * { return &o; });
 
-  tsd.new_usertype<core::Scene>("Scene",
+  tsd.new_usertype<core::Scene>(
+      "Scene",
       sol::constructors<core::Scene()>(),
       // Object creation
-      "createGeometry", makeCreateBinding<core::Geometry>(),
-      "createMaterial", makeCreateBinding<core::Material>(),
-      "createLight", makeCreateBinding<core::Light>(),
-      "createCamera", makeCreateBinding<core::Camera>(),
-      "createSampler", makeCreateBinding<core::Sampler>(),
-      "createVolume", makeCreateBinding<core::Volume>(),
-      "createSpatialField", makeCreateBinding<core::SpatialField>(),
+      "createGeometry",
+      makeCreateBinding<core::Geometry>(),
+      "createMaterial",
+      makeCreateBinding<core::Material>(),
+      "createLight",
+      makeCreateBinding<core::Light>(),
+      "createCamera",
+      makeCreateBinding<core::Camera>(),
+      "createSampler",
+      makeCreateBinding<core::Sampler>(),
+      "createVolume",
+      makeCreateBinding<core::Volume>(),
+      "createSpatialField",
+      makeCreateBinding<core::SpatialField>(),
+      "createTransform",
+      makeCreateBinding<core::Transform>(),
       "createSurface",
       [](core::Scene &s,
           const std::string &name,
@@ -174,9 +186,7 @@ void registerCoreBindings(sol::state &lua)
       "getCamera",
       [](core::Scene &s, size_t i) { return s.getObject<core::Camera>(i); },
       "getSurface",
-      [](core::Scene &s, size_t i) {
-        return s.getObject<core::Surface>(i);
-      },
+      [](core::Scene &s, size_t i) { return s.getObject<core::Surface>(i); },
       "getArray",
       [](core::Scene &s, size_t i) { return s.getObject<core::Array>(i); },
       "getVolume",
@@ -187,6 +197,8 @@ void registerCoreBindings(sol::state &lua)
       [](core::Scene &s, size_t i) {
         return s.getObject<core::SpatialField>(i);
       },
+      "getTransform",
+      [](core::Scene &s, size_t i) { return s.getObject<core::Transform>(i); },
       // Object counts
       "numberOfObjects",
       [](core::Scene &s, ANARIDataType type) -> size_t {
@@ -211,6 +223,8 @@ void registerCoreBindings(sol::state &lua)
       makeForEach([](auto &db) -> auto & { return db.sampler; }),
       "forEachArray",
       makeForEach([](auto &db) -> auto & { return db.array; }),
+      "forEachTransform",
+      makeForEach([](auto &db) -> auto & { return db.transform; }),
       // Layers
       "addLayer",
       [](core::Scene &s, const std::string &name) {
@@ -314,16 +328,13 @@ void registerCoreBindings(sol::state &lua)
       // Node removal
       "removeNode",
       sol::overload(
-          [](core::Scene &s, core::LayerNodeRef obj) {
-            s.removeNode(obj);
-          },
+          [](core::Scene &s, core::LayerNodeRef obj) { s.removeNode(obj); },
           [](core::Scene &s, core::LayerNodeRef obj, bool deleteObjects) {
             s.removeNode(obj, deleteObjects);
           }),
       // Animation
       "addAnimation",
-      sol::overload(
-          [](core::Scene &s) { return s.addAnimation(); },
+      sol::overload([](core::Scene &s) { return s.addAnimation(); },
           [](core::Scene &s, const std::string &name) {
             return s.addAnimation(name.c_str());
           }),
@@ -353,11 +364,11 @@ void registerCoreBindings(sol::state &lua)
       "cleanupScene",
       &core::Scene::cleanupScene);
 
-  tsd.new_usertype<core::Animation>("Animation",
+  tsd.new_usertype<core::Animation>(
+      "Animation",
       sol::no_constructor,
       "name",
-      sol::property(
-          [](const core::Animation &a) { return a.name(); },
+      sol::property([](const core::Animation &a) { return a.name(); },
           [](core::Animation &a, const std::string &n) { a.name() = n; }),
       "info",
       [](const core::Animation &a) { return a.info(); },
@@ -409,6 +420,7 @@ void registerCoreBindings(sol::state &lua)
   tsd["SAMPLER"] = ANARI_SAMPLER;
   tsd["ARRAY"] = ANARI_ARRAY;
   tsd["SPATIAL_FIELD"] = ANARI_SPATIAL_FIELD;
+  tsd["TRANSFORM"] = core::TSD_TRANSFORM;
 }
 
 } // namespace tsd::scripting

--- a/tsd/src/tsd/scripting/bindings/LayerBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/LayerBindings.cpp
@@ -1,10 +1,11 @@
 // Copyright 2026 NVIDIA Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tsd/scripting/LuaBindings.hpp"
+#include <fmt/format.h>
 #include "tsd/core/scene/Layer.hpp"
 #include "tsd/core/scene/objects/Array.hpp"
-#include <fmt/format.h>
+#include "tsd/core/scene/objects/Transform.hpp"
+#include "tsd/scripting/LuaBindings.hpp"
 
 #include <sol/sol.hpp>
 
@@ -14,7 +15,8 @@ void registerLayerBindings(sol::state &lua)
 {
   sol::table tsd = lua["tsd"];
 
-  tsd.new_usertype<core::LayerNodeRef>("LayerNode",
+  tsd.new_usertype<core::LayerNodeRef>(
+      "LayerNode",
       sol::no_constructor,
       "valid",
       &core::LayerNodeRef::valid,
@@ -29,11 +31,17 @@ void registerLayerBindings(sol::state &lua)
         return fmt::format("LayerNode({})", r->value().name());
       },
       "parent",
-      [](core::LayerNodeRef &r) { return r.valid() ? r->parent() : core::LayerNodeRef{}; },
+      [](core::LayerNodeRef &r) {
+        return r.valid() ? r->parent() : core::LayerNodeRef{};
+      },
       "next",
-      [](core::LayerNodeRef &r) { return r.valid() ? r->next() : core::LayerNodeRef{}; },
+      [](core::LayerNodeRef &r) {
+        return r.valid() ? r->next() : core::LayerNodeRef{};
+      },
       "sibling",
-      [](core::LayerNodeRef &r) { return r.valid() ? r->sibling() : core::LayerNodeRef{}; },
+      [](core::LayerNodeRef &r) {
+        return r.valid() ? r->sibling() : core::LayerNodeRef{};
+      },
       "isRoot",
       [](const core::LayerNodeRef &r) { return r.valid() && r->isRoot(); },
       "isLeaf",
@@ -54,9 +62,8 @@ void registerLayerBindings(sol::state &lua)
       [](core::LayerNodeRef &r, const std::string &name) -> core::LayerNodeRef {
         if (!r.valid())
           return {};
-        return find_first_child(r, [&](const core::LayerNodeData &d) {
-          return d.name() == name;
-        });
+        return find_first_child(
+            r, [&](const core::LayerNodeData &d) { return d.name() == name; });
       },
       "name",
       sol::property(
@@ -68,53 +75,69 @@ void registerLayerBindings(sol::state &lua)
               r->value().name() = n;
           }),
       "isObject",
-      [](const core::LayerNodeRef &r) { return r.valid() && r->value().isObject(); },
+      [](const core::LayerNodeRef &r) {
+        return r.valid() && r->value().isObject();
+      },
       "isTransform",
-      [](const core::LayerNodeRef &r) { return r.valid() && r->value().isTransform(); },
+      [](const core::LayerNodeRef &r) {
+        return r.valid() && r->value().isTransform();
+      },
       "isEmpty",
-      [](const core::LayerNodeRef &r) { return !r.valid() || r->value().isEmpty(); },
+      [](const core::LayerNodeRef &r) {
+        return !r.valid() || r->value().isEmpty();
+      },
       "isEnabled",
-      [](const core::LayerNodeRef &r) { return r.valid() && r->value().isEnabled(); },
+      [](const core::LayerNodeRef &r) {
+        return r.valid() && r->value().isEnabled();
+      },
       "setEnabled",
       [](core::LayerNodeRef &r, bool enabled) {
         if (r.valid())
           r->value().setEnabled(enabled);
       },
-      "getTransform",
-      [](const core::LayerNodeRef &r) -> math::mat4 {
-        return r.valid() ? r->value().getTransform() : math::mat4(math::identity);
-      },
-      "getTransformSRT",
-      [](const core::LayerNodeRef &r) -> math::mat3 {
-        return r.valid() ? r->value().getTransformSRT() : math::IDENTITY_MAT3;
-      },
       "setAsTransform",
       sol::overload(
           [](core::LayerNodeRef &r, const math::mat4 &m) {
-            if (r.valid())
-              r->value().setAsTransform(m);
+            if (!r.valid())
+              return;
+            if (auto *xfm = r->value().getTransformObject())
+              xfm->setTransform(m);
           },
           [](core::LayerNodeRef &r, const math::mat3 &srt) {
-            if (r.valid())
-              r->value().setAsTransform(srt);
+            if (!r.valid())
+              return;
+            if (auto *xfm = r->value().getTransformObject())
+              xfm->setTransform(srt);
           }),
       "setAsTransformArray",
       sol::overload(
-          [](core::LayerNodeRef &r, core::Array &a) {
-            if (r.valid())
-              r->value().setAsTransformArray(&a);
+          [](const core::LayerNodeRef &r, core::Array &a) {
+            if (!r.valid())
+              return;
+            auto arr = a.self();
+            if (!arr.valid())
+              return;
+            if (auto *xfm = r->value().getTransformObject())
+              xfm->setTransformArray(arr);
           },
-          [](core::LayerNodeRef &r, core::ArrayRef a) {
-            if (r.valid() && a)
-              r->value().setAsTransformArray(a.data());
+          [](const core::LayerNodeRef &r, core::ArrayRef a) {
+            if (!r.valid() || !a.valid())
+              return;
+            if (auto *xfm = r->value().getTransformObject())
+              xfm->setTransformArray(a);
           }),
       "getTransformArray",
       [](const core::LayerNodeRef &r) -> core::Array * {
-        return r.valid() ? r->value().getTransformArray() : nullptr;
+        if (!r.valid())
+          return nullptr;
+        if (auto *xfm = r->value().getTransformObject())
+          return xfm->getTransformArray();
+        return nullptr;
       });
 
   using Layer = core::Layer;
-  tsd.new_usertype<Layer>("Layer",
+  tsd.new_usertype<Layer>(
+      "Layer",
       sol::no_constructor,
       "root",
       [](Layer &l) { return l.root(); },
@@ -127,7 +150,7 @@ void registerLayerBindings(sol::state &lua)
       "foreach",
       [](Layer &l, sol::function fn) {
         l.traverse(l.root(), [&fn, &l](core::LayerNode &node, int level) {
-            sol::object result = fn(l.at(node.index()), level);
+          sol::object result = fn(l.at(node.index()), level);
           if (result.is<bool>() && !result.as<bool>())
             return false;
           return true;

--- a/tsd/src/tsd/scripting/bindings/ObjectBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/ObjectBindings.cpp
@@ -14,6 +14,7 @@
 #include "tsd/core/scene/objects/Sampler.hpp"
 #include "tsd/core/scene/objects/SpatialField.hpp"
 #include "tsd/core/scene/objects/Surface.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
 #include "tsd/core/scene/objects/Volume.hpp"
 #include "tsd/scripting/LuaBindings.hpp"
 #include "tsd/scripting/Sol2Helpers.hpp"
@@ -678,6 +679,11 @@ void registerObjectBindings(sol::state &lua)
       sol::base_classes,
       sol::bases<core::Object>());
 
+  tsd.new_usertype<core::Transform>("Transform",
+      sol::no_constructor,
+      sol::base_classes,
+      sol::bases<core::Object>());
+
   tsd.new_usertype<core::Surface>(
       "Surface",
       sol::no_constructor,
@@ -763,6 +769,7 @@ void registerObjectBindings(sol::state &lua)
   registerObjectPoolRef<core::Light>(tsd, "Light");
   registerObjectPoolRef<core::Camera>(tsd, "Camera");
   registerObjectPoolRef<core::Sampler>(tsd, "Sampler");
+  registerObjectPoolRef<core::Transform>(tsd, "Transform");
 
   auto surfaceRefType = registerObjectPoolRef<core::Surface>(tsd, "Surface");
   surfaceRefType["geometry"] = +[](core::SurfaceRef &r) -> core::Geometry * {

--- a/tsd/src/tsd/scripting/bindings/ParameterHelpers.cpp
+++ b/tsd/src/tsd/scripting/bindings/ParameterHelpers.cpp
@@ -6,6 +6,7 @@
 #include "tsd/core/Token.hpp"
 #include "tsd/core/scene/Object.hpp"
 #include "tsd/core/scene/Scene.hpp"
+#include "tsd/core/scene/objects/Transform.hpp"
 #include "tsd/scripting/Sol2Helpers.hpp"
 
 #include <fmt/format.h>
@@ -71,6 +72,10 @@ void setParameterFromLua(
     auto ref = value.as<core::SurfaceRef>();
     if (ref.valid())
       obj->setParameterObject(token, *ref.data());
+  } else if (value.is<core::TransformRef>()) {
+    auto ref = value.as<core::TransformRef>();
+    if (ref.valid())
+      obj->setParameterObject(token, *ref.data());
   } else if (value.is<sol::table>()) {
     sol::table t = value.as<sol::table>();
     size_t len = t.size();
@@ -107,7 +112,7 @@ void setParameterFromLua(
         "Unsupported type '{}' for parameter '{}'"
         ": expected bool, number, string, float2/3/4, mat4, ArrayRef, "
         "SamplerRef, GeometryRef, MaterialRef, SpatialFieldRef, "
-        "VolumeRef, LightRef, CameraRef, SurfaceRef, "
+        "VolumeRef, LightRef, CameraRef, SurfaceRef, TransformRef, "
         "or table of 2-4 numbers",
         typeName,
         name));
@@ -180,8 +185,8 @@ sol::object getParameterAsLua(
       return sol::make_object(lua, scene->getObject<core::Camera>(idx));
     case ANARI_SURFACE:
       return sol::make_object(lua, scene->getObject<core::Surface>(idx));
-    default:
-      break;
+    case core::TSD_TRANSFORM:
+      return sol::make_object(lua, scene->getObject<core::Transform>(idx));
     }
   }
 

--- a/tsd/src/tsd/scripting/tsd.lua
+++ b/tsd/src/tsd/scripting/tsd.lua
@@ -62,7 +62,7 @@ local mat4 = {}
 -- Parameter value types accepted by setParameter / returned by getParameter
 ------------------------------------------------------------------------
 
----@alias tsd.ParameterValue boolean|number|string|tsd.float2|tsd.float3|tsd.float4|tsd.mat4|tsd.Array|tsd.Sampler|tsd.Geometry|tsd.Material|tsd.SpatialField|tsd.Volume|tsd.Light|tsd.Camera|tsd.Surface|number[]
+---@alias tsd.ParameterValue boolean|number|string|tsd.float2|tsd.float3|tsd.float4|tsd.mat4|tsd.Array|tsd.Sampler|tsd.Geometry|tsd.Material|tsd.SpatialField|tsd.Volume|tsd.Light|tsd.Camera|tsd.Surface|tsd.Transform|number[]
 
 ------------------------------------------------------------------------
 -- Token (CoreBindings.cpp)
@@ -229,6 +229,11 @@ function SpatialField:valid() end
 ---@return tsd.float2
 function SpatialField:computeValueRange() end
 
+---@class tsd.Transform: tsd.Object
+local Transform = {}
+---@return boolean
+function Transform:valid() end
+
 ---@class tsd.Array: tsd.Object
 local Array = {}
 ---@return boolean
@@ -306,13 +311,6 @@ function LayerNode:isEnabled() end
 
 ---@param enabled boolean
 function LayerNode:setEnabled(enabled) end
-
----@return tsd.mat4
-function LayerNode:getTransform() end
-
---- Get transform as packed SRT (columns: scale, euler-rotation-degrees, translation).
----@return tsd.mat3
-function LayerNode:getTransformSRT() end
 
 ---@overload fun(self: tsd.LayerNode, m: tsd.mat4)
 ---@overload fun(self: tsd.LayerNode, srt: tsd.mat3)
@@ -417,6 +415,11 @@ function Scene:createVolume(subtype, params) end
 ---@return tsd.SpatialField
 function Scene:createSpatialField(subtype, params) end
 
+---@param subtype string
+---@param params? table<string, tsd.ParameterValue>
+---@return tsd.Transform
+function Scene:createTransform(subtype, params) end
+
 ---@param name string
 ---@param geometry tsd.Geometry
 ---@param material tsd.Material
@@ -474,6 +477,10 @@ function Scene:getSampler(index) end
 ---@return tsd.SpatialField
 function Scene:getSpatialField(index) end
 
+---@param index integer
+---@return tsd.Transform
+function Scene:getTransform(index) end
+
 -- Object counts ----------------------------------------------------------
 
 --- Return the number of objects of the given ANARI type.
@@ -518,6 +525,10 @@ function Scene:forEachSampler(fn) end
 --- Iterate over all arrays. Return false from the callback to stop early.
 ---@param fn fun(obj: tsd.Array): boolean?
 function Scene:forEachArray(fn) end
+
+--- Iterate over all transforms. Return false from the callback to stop early.
+---@param fn fun(obj: tsd.Transform): boolean?
+function Scene:forEachTransform(fn) end
 
 -- Layers -----------------------------------------------------------------
 
@@ -736,6 +747,8 @@ tsd.SAMPLER = 0
 tsd.ARRAY = 0
 ---@type integer
 tsd.SPATIAL_FIELD = 0
+---@type integer
+tsd.TRANSFORM = 0
 
 -- Math utility functions (MathBindings.cpp) ------------------------------
 

--- a/tsd/src/tsd/ui/imgui/modals/AppSettingsDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/AppSettingsDialog.cpp
@@ -61,12 +61,18 @@ void AppSettingsDialog::buildUI_applicationSettings()
 
   doUpdate |= ImGui::DragFloat("rounding", &config->rounding, 0.01f, 0.f, 12.f);
 
-  bool useFlat = core->anari.useFlatRenderIndex();
-  if (ImGui::Checkbox("use flat render index", &useFlat))
-    core->anari.setUseFlatRenderIndex(useFlat);
+  auto kind = core->anari.renderIndexKind();
 
+  if (ImGui::RadioButton(
+          "all layers", kind == tsd::app::RenderIndexKind::ALL_LAYERS))
+    core->anari.setRenderIndexKind(tsd::app::RenderIndexKind::ALL_LAYERS);
   if (ImGui::IsItemHovered())
-    ImGui::SetTooltip("Check this option to bypass instancing of objects.");
+    ImGui::SetTooltip("Full render index with instancing support.");
+  ImGui::SameLine();
+  if (ImGui::RadioButton("flat", kind == tsd::app::RenderIndexKind::FLAT))
+    core->anari.setRenderIndexKind(tsd::app::RenderIndexKind::FLAT);
+  if (ImGui::IsItemHovered())
+    ImGui::SetTooltip("Bypass instancing of objects.");
 
   if (doUpdate)
     applySettings();

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -229,7 +229,7 @@ void LayerTree::buildUI_tree()
         nameText = node->name().c_str();
       else {
         switch (node->type()) {
-        case ANARI_FLOAT32_MAT4:
+        case core::TSD_TRANSFORM:
           nameText = "xfm";
           break;
         case ANARI_SURFACE:
@@ -249,7 +249,7 @@ void LayerTree::buildUI_tree()
 
       const char *typeText = "[-]";
       switch (node->type()) {
-      case ANARI_FLOAT32_MAT4:
+      case core::TSD_TRANSFORM:
         typeText = "[T]";
         break;
       case ANARI_SURFACE:
@@ -284,7 +284,7 @@ void LayerTree::buildUI_tree()
               anari::toString(node->type()),
               node->getObjectIndex());
         } else if (node->isTransform())
-          ImGui::SetTooltip("transform: ANARI_FLOAT32_MAT4");
+          ImGui::SetTooltip("transform");
       }
 
       if (ImGui::IsItemClicked() && m_menuNode == TSD_INVALID_INDEX) {

--- a/tsd/src/tsd/ui/imgui/windows/Log.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Log.cpp
@@ -40,6 +40,7 @@ Log::~Log()
 
 void Log::buildUI()
 {
+  std::lock_guard<std::mutex> guard(m_mutex);
   if (ImGui::BeginPopup("Options")) {
     auto core = appCore();
     bool logVerbose = core->logVerbose();
@@ -94,6 +95,7 @@ void Log::buildUI()
 
 void Log::addText(tsd::core::LogLevel level, const std::string &msg)
 {
+  std::lock_guard<std::mutex> guard(m_mutex);
   m_colorIDs.push_back(static_cast<int>(level));
 
   if (appCore() && appCore()->logEchoOutput())
@@ -137,6 +139,7 @@ void Log::showLine(int line_no, bool useFilter)
 
 void Log::clear()
 {
+  std::lock_guard<std::mutex> guard(m_mutex);
   m_buf.clear();
   m_lineOffsets.clear();
   m_lineOffsets.push_back(0);

--- a/tsd/src/tsd/ui/imgui/windows/Log.h
+++ b/tsd/src/tsd/ui/imgui/windows/Log.h
@@ -8,6 +8,7 @@
 #include "tsd/core/Logging.hpp"
 // std
 #include <array>
+#include <mutex>
 
 namespace tsd::ui::imgui {
 
@@ -26,6 +27,7 @@ struct Log : public Window
   // Data //
 
   bool m_isLoggingTarget{false};
+  std::mutex m_mutex;
 
   ImGuiTextBuffer m_buf;
   ImGuiTextFilter m_filter;

--- a/tsd/src/tsd/ui/imgui/windows/ObjectEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/ObjectEditor.cpp
@@ -27,41 +27,32 @@ void ObjectEditor::buildUI()
 
   auto &node = *selectedNode;
 
-  if (auto *selectedObject = node->getObject(); selectedObject) {
+  if (node->isTransform()) {
+    auto *transformObject = node->getTransformObject();
+    if (transformObject->getTransformArray()) {
+      ImGui::Text("Instance transform (%zu instances)",
+          transformObject->getTransformArray()->size());
+    } else {
+      // Decompose SRT from the live matrix so sliders reflect the actual
+      // transform.
+      auto currentMat = transformObject->getTransform();
+      math::float3 sc, azelrot, tl;
+      math::mat4 rot;
+      math::decomposeMatrix(currentMat, sc, rot, tl);
+      azelrot = math::degrees(math::matrixToAzElRoll(rot));
+      math::mat3 srt(sc, azelrot, tl);
+
+      bool doUpdate = false;
+
+      doUpdate |= ImGui::DragFloat3("scale", &sc.x);
+      doUpdate |= ImGui::SliderFloat3("rotation", &azelrot.x, 0.f, 360.f);
+      doUpdate |= ImGui::DragFloat3("translation", &tl.x);
+
+      if (doUpdate)
+        transformObject->setTransform(math::mat3(sc, azelrot, tl));
+    }
+  } else if (auto *selectedObject = node->getObject(); selectedObject) {
     tsd::ui::buildUI_object(*selectedObject, appCore()->tsd.scene, true);
-  } else if (node->isTransform()) {
-    // Setup transform values //
-
-    auto srt = node->getTransformSRT();
-    auto &sc = srt[0];
-    auto &azelrot = srt[1];
-    auto &tl = srt[2];
-
-    // UI widgets //
-
-    bool doUpdate = false;
-
-    ImGui::BeginDisabled(node->isDefaultValue());
-    if (ImGui::Button("reset")) {
-      node->setToDefaultValue();
-      doUpdate = true;
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("set default"))
-      node->setCurrentValueAsDefault();
-    ImGui::EndDisabled();
-
-    doUpdate |= ImGui::DragFloat3("scale", &sc.x);
-    doUpdate |= ImGui::SliderFloat3("rotation", &azelrot.x, 0.f, 360.f);
-    doUpdate |= ImGui::DragFloat3("translation", &tl.x);
-
-    // Handle transform update //
-
-    if (doUpdate) {
-      node->setAsTransform(srt);
-      auto *layer = selectedNode->container();
-      scene->signalLayerChange(layer);
-    }
   } else if (!node->isEmpty()) {
     ImGui::Text("{unhandled '%s' node}", anari::toString(node->type()));
   } else {

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -1319,7 +1319,6 @@ void Viewport::ui_gizmo()
     auto invParent = linalg::inverse(parentWorldTransform);
     localTransform = mul(invParent, worldTransform);
     (*selectedNodeRef)->setAsTransform(localTransform);
-    appCore()->tsd.scene.signalLayerChange(selectedNodeRef->container());
   }
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -92,8 +92,7 @@ void Viewport::buildUI()
   if (m_rIdx) {
     auto kind = appCore()->anari.renderIndexKind();
     if (kind != m_lastIndexKind) {
-      tsd::core::logWarning(
-          "render index setting changed: resetting viewport");
+      tsd::core::logWarning("render index setting changed: resetting viewport");
       m_lastIndexKind = kind;
       auto lib = m_libName;
       setLibrary("");
@@ -1217,10 +1216,12 @@ bool Viewport::canShowGizmo() const
   if (!m_enableGizmo || !m_deviceReadyToUse)
     return false;
 
-  // Check if we have a selected node with a transform
+  // Check if we have a selected node with a scalar transform.
+  // Array transforms (instancing) can't be meaningfully manipulated via gizmo.
   auto selectedNode = appCore()->getFirstSelected();
   if (selectedNode.valid()) {
-    return (*selectedNode)->isTransform();
+    return (*selectedNode)->isTransform()
+        && !(*selectedNode)->getTransformObject()->getTransformArray();
   }
 
   return false;
@@ -1233,8 +1234,11 @@ void Viewport::ui_gizmo()
 
   auto computeWorldTransform = [](tsd::core::LayerNodeRef node) -> math::mat4 {
     auto world = math::IDENTITY_MAT4;
-    for (; node; node = node->parent())
-      world = mul((*node)->getTransform(), world);
+    for (; node; node = node->parent()) {
+      if ((*node)->isTransform()) {
+        world = mul((*node)->getTransformObject()->getTransform(), world);
+      }
+    }
 
     return world;
   };
@@ -1242,7 +1246,8 @@ void Viewport::ui_gizmo()
   auto selectedNodeRef = appCore()->getFirstSelected();
   auto parentNodeRef = selectedNodeRef->parent();
 
-  auto localTransform = (*selectedNodeRef)->getTransform();
+  auto localTransform =
+      (*selectedNodeRef)->getTransformObject()->getTransform();
   auto parentWorldTransform = computeWorldTransform(parentNodeRef);
   auto worldTransform = mul(parentWorldTransform, localTransform);
 
@@ -1323,7 +1328,7 @@ void Viewport::ui_gizmo()
           &worldTransform[0].x)) {
     auto invParent = linalg::inverse(parentWorldTransform);
     localTransform = mul(invParent, worldTransform);
-    (*selectedNodeRef)->setAsTransform(localTransform);
+    (*selectedNodeRef)->getTransformObject()->setTransform(localTransform);
   }
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -89,11 +89,16 @@ void Viewport::buildUI()
     m_anariPass->setEnableIDs(needIDs);
   }
 
-  if (m_rIdx && (m_rIdx->isFlat() != appCore()->anari.useFlatRenderIndex())) {
-    tsd::core::logWarning("instancing setting changed: resetting viewport");
-    auto lib = m_libName;
-    setLibrary(""); // clear old library
-    setLibrary(lib);
+  if (m_rIdx) {
+    auto kind = appCore()->anari.renderIndexKind();
+    if (kind != m_lastIndexKind) {
+      tsd::core::logWarning(
+          "render index setting changed: resetting viewport");
+      m_lastIndexKind = kind;
+      auto lib = m_libName;
+      setLibrary("");
+      setLibrary(lib);
+    }
   }
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -640,6 +640,8 @@ void Viewport::ui_menubar_Renderer()
       ImGui::Indent(INDENT_AMOUNT);
       for (int i = 0; i < m_rendererObjects.size(); i++) {
         auto ro = m_rendererObjects[i];
+        if (!ro)
+          continue;
         const char *rName = ro->subtype().c_str();
         if (ImGui::RadioButton(rName, m_currentRenderer == ro)) {
           m_currentRenderer = ro;
@@ -651,7 +653,7 @@ void Viewport::ui_menubar_Renderer()
 
     ImGui::Separator();
 
-    if (!m_rendererObjects.empty()) {
+    if (m_currentRenderer) {
       ImGui::Text("Parameters:");
       ImGui::Indent(INDENT_AMOUNT);
 
@@ -684,6 +686,12 @@ void Viewport::ui_menubar_Camera()
 {
   if (ImGui::BeginMenu("Camera")) {
     auto &scene = appCore()->tsd.scene;
+
+    if (!m_currentCamera) {
+      ImGui::TextDisabled("No camera available");
+      ImGui::EndMenu();
+      return;
+    }
 
     ImGui::Text("Manipulator:");
     {

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -87,6 +87,8 @@ struct Viewport : public Window
   bool m_deviceReadyToUse{false};
   std::string m_libName;
   tsd::rendering::RenderIndex *m_rIdx{nullptr};
+  tsd::app::RenderIndexKind m_lastIndexKind{
+      tsd::app::RenderIndexKind::ALL_LAYERS};
 
   tsd::math::float2 m_previousMouse{-1.f, -1.f};
   bool m_mouseRotating{false};


### PR DESCRIPTION
-  Introduce a first-class Transform object (TSDTypes.hpp, Transform.cpp/.hpp) that replaces inline transform parameter handling scattered across Layer and RenderIndex
  - Implement instance attribute composition in RenderIndexAllLayers — transforms, transfer functions, and clipping now compose hierarchically through the instance tree instead of being flat overrides
  - Add Lua bindings for the new transform and layer APIs (CoreBindings, LayerBindings, ObjectBindings, tsd.lua)
  - Fix Forest::find_first_child returning false matches on leaf nodes
  - Fix Any copy using objectSize instead of sizeof for size-typed values
  - Fix Scene object pool destruction order (pools destroyed before dependent state)
  - Minor UX improvements: RenderIndex exposed as radio buttons, scene returns all layers when none selected, viewport skips redundant layer update signals, layer count reset on scene reset