### PR TITLE
Add signal layer transform updated

### DIFF
--- a/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
+++ b/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
@@ -44,12 +44,14 @@ void InstancingControls::buildUI()
 
 void InstancingControls::createScene()
 {
-  auto &scene = appCore()->tsd.scene;
-  auto *layer = scene.defaultLayer();
-
   // Clear out previous scene //
 
+  auto &scene = appCore()->tsd.scene;
   scene.removeAllObjects();
+
+  // Then only get the default layer //
+
+  auto *layer = scene.defaultLayer();
 
   // Default (global) material //
 

--- a/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
+++ b/tsd/apps/interactive/demos/arrayInstancing/InstancingControls.cpp
@@ -79,7 +79,7 @@ void InstancingControls::createScene()
 
   // Finally update instancing in RenderIndexes //
 
-  scene.signalLayerChange(layer);
+  scene.signalLayerStructureChanged(layer);
 }
 
 void InstancingControls::generateSpheres()

--- a/tsd/apps/interactive/network/client/NetworkUpdateDelegate.cpp
+++ b/tsd/apps/interactive/network/client/NetworkUpdateDelegate.cpp
@@ -14,8 +14,8 @@
 
 #include "../RenderSession.hpp"
 
-#define CHECK_READY_OR_RETURN() \
-  if (!isReady(__func__)) \
+#define CHECK_READY_OR_RETURN()                                                \
+  if (!isReady(__func__))                                                      \
     return;
 
 namespace tsd::network {
@@ -117,7 +117,17 @@ void NetworkUpdateDelegate::signalLayerAdded(const tsd::core::Layer *l)
   m_channel->send(MessageType::SERVER_UPDATE_LAYER, std::move(msg));
 }
 
-void NetworkUpdateDelegate::signalLayerUpdated(const tsd::core::Layer *l)
+void NetworkUpdateDelegate::signalLayerStructureUpdated(
+    const tsd::core::Layer *l)
+{
+  CHECK_READY_OR_RETURN();
+  auto msg = tsd::network::messages::TransferLayer(
+      m_scene, const_cast<tsd::core::Layer *>(l));
+  m_channel->send(MessageType::SERVER_UPDATE_LAYER, std::move(msg));
+}
+
+void NetworkUpdateDelegate::signalLayerTransformUpdated(
+    const tsd::core::Layer *l)
 {
   CHECK_READY_OR_RETURN();
   auto msg = tsd::network::messages::TransferLayer(

--- a/tsd/apps/interactive/network/client/NetworkUpdateDelegate.hpp
+++ b/tsd/apps/interactive/network/client/NetworkUpdateDelegate.hpp
@@ -36,7 +36,8 @@ struct NetworkUpdateDelegate : public tsd::core::BaseUpdateDelegate
   void signalObjectRemoved(const tsd::core::Object *) override;
   void signalRemoveAllObjects() override;
   void signalLayerAdded(const tsd::core::Layer *) override;
-  void signalLayerUpdated(const tsd::core::Layer *) override;
+  void signalLayerStructureUpdated(const tsd::core::Layer *) override;
+  void signalLayerTransformUpdated(const tsd::core::Layer *) override;
   void signalLayerRemoved(const tsd::core::Layer *) override;
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;

--- a/tsd/src/anari_tsd/World.cpp
+++ b/tsd/src/anari_tsd/World.cpp
@@ -134,7 +134,7 @@ void World::updateLayer()
       zi->insert_last_child(obj->tsdObject());
   }
 
-  deviceState()->scene.signalLayerChange(l);
+  deviceState()->scene.signalLayerStructureChanged(l);
 }
 
 } // namespace tsd_device

--- a/tsd/src/tsd/core/scene/Animation.cpp
+++ b/tsd/src/tsd/core/scene/Animation.cpp
@@ -116,7 +116,7 @@ void Animation::update(float time)
     const size_t idx =
         calculateIndexForTime(time, ts.transformFrames.size(), false);
     (*ts.transformNode)->setAsTransform(ts.transformFrames[idx]);
-    m_scene->signalLayerChange(ts.transformNode->container());
+    m_scene->signalLayerTransformChanged(ts.transformNode->container());
     updateInfoString(time, false);
     return;
   }

--- a/tsd/src/tsd/core/scene/Scene.cpp
+++ b/tsd/src/tsd/core/scene/Scene.cpp
@@ -594,7 +594,7 @@ LayerNodeRef Scene::insertChildTransformNode(
   auto *layer = parent->container();
   auto inst = layer->insert_last_child(parent, xfm);
   (*inst)->name() = name;
-  signalLayerChange(parent->container());
+  signalLayerStructureChanged(parent->container());
   return inst;
 }
 
@@ -603,7 +603,7 @@ LayerNodeRef Scene::insertChildTransformArrayNode(
 {
   auto inst = parent->insert_last_child({a});
   (*inst)->name() = name;
-  signalLayerChange(parent->container());
+  signalLayerStructureChanged(parent->container());
   return inst;
 }
 
@@ -612,7 +612,7 @@ LayerNodeRef Scene::insertChildObjectNode(
 {
   auto inst = parent->insert_last_child({type, idx, this});
   (*inst)->name() = name;
-  signalLayerChange(parent->container());
+  signalLayerStructureChanged(parent->container());
   return inst;
 }
 
@@ -637,13 +637,19 @@ void Scene::removeNode(LayerNodeRef obj, bool deleteReferencedObjects)
   }
 
   layer->erase(obj);
-  signalLayerChange(layer);
+  signalLayerStructureChanged(layer);
 }
 
-void Scene::signalLayerChange(const Layer *l)
+void Scene::signalLayerStructureChanged(const Layer *l)
 {
   if (m_updateDelegate)
-    m_updateDelegate->signalLayerUpdated(l);
+    m_updateDelegate->signalLayerStructureUpdated(l);
+}
+
+void Scene::signalLayerTransformChanged(const Layer *l)
+{
+  if (m_updateDelegate)
+    m_updateDelegate->signalLayerTransformUpdated(l);
 }
 
 void Scene::signalActiveLayersChanged()

--- a/tsd/src/tsd/core/scene/Scene.hpp
+++ b/tsd/src/tsd/core/scene/Scene.hpp
@@ -189,7 +189,8 @@ struct Scene
 
   // Indicate changes occurred //
 
-  void signalLayerChange(const Layer *l);
+  void signalLayerStructureChanged(const Layer *l);
+  void signalLayerTransformChanged(const Layer *l);
   void signalActiveLayersChanged();
   void signalObjectParameterUseCountZero(const Object *obj);
   void signalObjectLayerUseCountZero(const Object *obj);

--- a/tsd/src/tsd/core/scene/UpdateDelegate.cpp
+++ b/tsd/src/tsd/core/scene/UpdateDelegate.cpp
@@ -114,10 +114,16 @@ void MultiUpdateDelegate::signalLayerAdded(const Layer *l)
     d->signalLayerAdded(l);
 }
 
-void MultiUpdateDelegate::signalLayerUpdated(const Layer *l)
+void MultiUpdateDelegate::signalLayerStructureUpdated(const Layer *l)
 {
   for (auto &d : m_delegates)
-    d->signalLayerUpdated(l);
+    d->signalLayerStructureUpdated(l);
+}
+
+void MultiUpdateDelegate::signalLayerTransformUpdated(const Layer *l)
+{
+  for (auto &d : m_delegates)
+    d->signalLayerTransformUpdated(l);
 }
 
 void MultiUpdateDelegate::signalLayerRemoved(const Layer *l)

--- a/tsd/src/tsd/core/scene/UpdateDelegate.hpp
+++ b/tsd/src/tsd/core/scene/UpdateDelegate.hpp
@@ -32,7 +32,8 @@ struct BaseUpdateDelegate
   virtual void signalObjectRemoved(const Object *o) = 0;
   virtual void signalRemoveAllObjects() = 0;
   virtual void signalLayerAdded(const Layer *l) = 0;
-  virtual void signalLayerUpdated(const Layer *l) = 0;
+  virtual void signalLayerStructureUpdated(const Layer *l) = 0;
+  virtual void signalLayerTransformUpdated(const Layer *l) = 0;
   virtual void signalLayerRemoved(const Layer *l) = 0;
   virtual void signalActiveLayersChanged() = 0;
   virtual void signalObjectFilteringChanged() = 0;
@@ -65,7 +66,8 @@ struct EmptyUpdateDelegate : public BaseUpdateDelegate
   void signalObjectRemoved(const Object *) override {}
   void signalRemoveAllObjects() override {}
   void signalLayerAdded(const Layer *) override {}
-  void signalLayerUpdated(const Layer *) override {}
+  void signalLayerStructureUpdated(const Layer *) override {}
+  void signalLayerTransformUpdated(const Layer *) override {}
   void signalLayerRemoved(const Layer *) override {}
   void signalActiveLayersChanged() override {}
   void signalObjectFilteringChanged() override {}
@@ -103,7 +105,8 @@ struct MultiUpdateDelegate : public BaseUpdateDelegate
   void signalObjectRemoved(const Object *o) override;
   void signalRemoveAllObjects() override;
   void signalLayerAdded(const Layer *) override;
-  void signalLayerUpdated(const Layer *) override;
+  void signalLayerStructureUpdated(const Layer *) override;
+  void signalLayerTransformUpdated(const Layer *) override;
   void signalLayerRemoved(const Layer *) override;
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;

--- a/tsd/src/tsd/io/importers/import_GLTF.cpp
+++ b/tsd/src/tsd/io/importers/import_GLTF.cpp
@@ -577,8 +577,7 @@ static std::vector<MaterialRef> importGLTFMaterials(
                 {0, 0, 0, 1}));
         material->setParameterObject("clearcoatRoughness", *sampler);
       } else {
-        material->setParameter(
-            "clearcoatRoughness", clearcoatRoughnessFactor);
+        material->setParameter("clearcoatRoughness", clearcoatRoughnessFactor);
       }
 
       // Clearcoat normal texture
@@ -772,8 +771,8 @@ static std::vector<MaterialRef> importGLTFMaterials(
                 {0, 0, 0, 0},
                 {0, 0, 0, 0},
                 {0, 0, 0, 1}));
-        sampler->setParameter("outOffset",
-            float4(iridescenceThicknessMinimum, 0.0f, 0.0f, 0.0f));
+        sampler->setParameter(
+            "outOffset", float4(iridescenceThicknessMinimum, 0.0f, 0.0f, 0.0f));
         material->setParameterObject("iridescenceThickness", *sampler);
       } else {
         material->setParameter("iridescenceThickness",
@@ -1395,7 +1394,7 @@ void import_GLTF(Scene &scene, const char *filename, LayerNodeRef location)
     logWarning("[import_GLTF] no scenes found in glTF file");
   }
 
-  scene.signalLayerChange(targetLocation->container());
+  scene.signalLayerStructureChanged(targetLocation->container());
 }
 
 } // namespace tsd::io

--- a/tsd/src/tsd/io/serialization/serialization_datatree.cpp
+++ b/tsd/src/tsd/io/serialization/serialization_datatree.cpp
@@ -514,7 +514,7 @@ void load_Scene(Scene &scene, core::DataNode &root)
     bool active = true;
     nLayer["isActive"].getValue(ANARI_BOOL, &active);
     scene.setLayerActive(layerName, active);
-    scene.signalLayerChange(&tLayer);
+    scene.signalLayerStructureChanged(&tLayer);
   });
 
   scene.m_numActiveLayers = 0;

--- a/tsd/src/tsd/network/messages/TransferLayer.cpp
+++ b/tsd/src/tsd/network/messages/TransferLayer.cpp
@@ -49,7 +49,7 @@ void TransferLayer::execute()
         layerName.c_str());
   }
   tsd::io::nodeToLayer(root["l"], *layer, *m_scene);
-  m_scene->signalLayerChange(layer);
+  m_scene->signalLayerStructureChanged(layer);
 }
 
 } // namespace tsd::network::messages

--- a/tsd/src/tsd/rendering/index/RenderIndex.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.cpp
@@ -180,7 +180,12 @@ void RenderIndex::signalLayerAdded(const Layer *)
   // no-op
 }
 
-void RenderIndex::signalLayerUpdated(const Layer *)
+void RenderIndex::signalLayerStructureUpdated(const Layer *)
+{
+  // no-op
+}
+
+void RenderIndex::signalLayerTransformUpdated(const Layer *)
 {
   // no-op
 }

--- a/tsd/src/tsd/rendering/index/RenderIndex.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndex.hpp
@@ -49,7 +49,8 @@ struct RenderIndex : public BaseUpdateDelegate
   void signalArrayMapped(const Array *a) override;
   void signalArrayUnmapped(const Array *a) override;
   void signalLayerAdded(const Layer *l) override;
-  void signalLayerUpdated(const Layer *l) override;
+  void signalLayerStructureUpdated(const Layer *l) override;
+  void signalLayerTransformUpdated(const Layer *l) override;
   void signalLayerRemoved(const Layer *l) override;
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
@@ -6,6 +6,7 @@
 #include "RenderToAnariObjectsVisitor.hpp"
 // tsd_core
 #include "tsd/core/Logging.hpp"
+#include "tsd/rendering/index/TransformsToAnariVisitor.hpp"
 // std
 #include <algorithm>
 #include <iterator>
@@ -111,7 +112,7 @@ void RenderIndexAllLayers::signalLayerStructureUpdated(const Layer *l)
 void RenderIndexAllLayers::signalLayerTransformUpdated(const Layer *l)
 {
   if (m_instanceCache.contains(l)) {
-    syncLayerInstances(l, false, objectMask_all());
+    syncLayerTransforms(l);
     updateWorld();
   }
 }
@@ -231,6 +232,17 @@ void RenderIndexAllLayers::syncLayerInstances(
     releaseInstances(d, cached);
     cached = instances;
   }
+
+  syncLayerTransforms(layer);
+}
+
+void RenderIndexAllLayers::syncLayerTransforms(const Layer *_layer)
+{
+  auto d = device();
+
+  auto *layer = const_cast<Layer *>(_layer);
+  TransformsToAnariVisitor visitor(d, m_instanceCache[layer].data());
+  layer->traverse(layer->root(), visitor);
 }
 
 void RenderIndexAllLayers::releaseAllInstances()

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
@@ -100,7 +100,15 @@ void RenderIndexAllLayers::signalLayerAdded(const Layer *l)
   updateWorld();
 }
 
-void RenderIndexAllLayers::signalLayerUpdated(const Layer *l)
+void RenderIndexAllLayers::signalLayerStructureUpdated(const Layer *l)
+{
+  if (m_instanceCache.contains(l)) {
+    syncLayerInstances(l, false, objectMask_all());
+    updateWorld();
+  }
+}
+
+void RenderIndexAllLayers::signalLayerTransformUpdated(const Layer *l)
 {
   if (m_instanceCache.contains(l)) {
     syncLayerInstances(l, false, objectMask_all());

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
@@ -38,6 +38,7 @@ struct RenderIndexAllLayers : public RenderIndex
   void updateWorld() override;
   void syncLayerInstances(
       const Layer *layer, bool appendExisting, uint8_t mask);
+  void syncLayerTransforms(const Layer *layer);
   void releaseAllInstances();
 
   RenderIndexFilterFcn m_filter;

--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.hpp
@@ -27,7 +27,8 @@ struct RenderIndexAllLayers : public RenderIndex
   void signalObjectParameterUseCountZero(const Object *obj) override;
   void signalObjectLayerUseCountZero(const Object *obj) override;
   void signalLayerAdded(const Layer *l) override;
-  void signalLayerUpdated(const Layer *l) override;
+  void signalLayerStructureUpdated(const Layer *l) override;
+  void signalLayerTransformUpdated(const Layer *l) override;
   void signalLayerRemoved(const Layer *l) override;
   void signalActiveLayersChanged() override;
   void signalObjectFilteringChanged() override;

--- a/tsd/src/tsd/rendering/index/RenderToAnariObjectsVisitor.hpp
+++ b/tsd/src/tsd/rendering/index/RenderToAnariObjectsVisitor.hpp
@@ -9,6 +9,7 @@
 #include "tsd/rendering/index/RenderIndexFilterFcn.hpp"
 // std
 #include <algorithm>
+#include <anari/anari_cpp.hpp>
 #include <cstdint>
 #include <iterator>
 #include <stack>
@@ -59,7 +60,7 @@ struct RenderToAnariObjectsVisitor : public tsd::core::LayerVisitor
 
  private:
   bool isIncludedAfterFiltering(const tsd::core::LayerNode &n) const;
-  void createInstanceFromTop();
+  anari::Instance createInstanceFromTop();
 
   struct GroupedObjects
   {
@@ -71,9 +72,7 @@ struct RenderToAnariObjectsVisitor : public tsd::core::LayerVisitor
   anari::Device m_device{nullptr};
   tsd::core::AnariObjectCache *m_cache{nullptr};
   std::vector<anari::Instance> *m_instances{nullptr};
-  std::stack<tsd::math::mat4> m_xfms;
   std::stack<GroupedObjects> m_objects;
-  const tsd::core::Array *m_xfmArray{nullptr};
   uint8_t m_mask{objectMask_none()};
   RenderIndexFilterFcn *m_filter{nullptr};
 };
@@ -92,7 +91,6 @@ inline RenderToAnariObjectsVisitor::RenderToAnariObjectsVisitor(anari::Device d,
       m_filter(f)
 {
   anari::retain(d, d);
-  m_xfms.emplace(tsd::math::identity);
   m_objects.emplace();
 }
 
@@ -135,14 +133,11 @@ inline bool RenderToAnariObjectsVisitor::preChildren(
     }
     break;
   case ANARI_FLOAT32_MAT4:
-    m_xfms.push(tsd::math::mul(m_xfms.top(), n->getTransform()));
     m_objects.emplace();
     break;
   case ANARI_ARRAY1D: {
-    if (auto *a = n->getTransformArray(); a) {
+    if (auto *a = n->getTransformArray(); a)
       m_objects.emplace();
-      m_xfmArray = a;
-    }
   }
   default:
     break;
@@ -157,27 +152,14 @@ inline void RenderToAnariObjectsVisitor::postChildren(
   if (!n->isEnabled())
     return;
 
-  bool consumeXfmArray = false;
   switch (n->type()) {
   case ANARI_ARRAY1D: {
     if (auto *a = n->getTransformArray(); !a)
       break;
-    consumeXfmArray = true;
   }
   // intentionally fallthrough...
-  case ANARI_FLOAT32_MAT4:
-    createInstanceFromTop();
-
-    if (!consumeXfmArray)
-      m_xfms.pop();
-    else {
-      //
-      // NOTE(jda) - custom parameters here is awkward, should be generalized...
-      //
-      //   TODO: Put setting TSD object parameters on an ANARI handle in a
-      //         common spot for here + base Object updates physically the same.
-      //
-      anari::Instance inst = m_instances->back();
+  case ANARI_FLOAT32_MAT4: {
+    if (auto inst = createInstanceFromTop()) {
       for (auto &p : n->getInstanceParameters()) {
         if (!p.second.holdsObject())
           continue;
@@ -189,9 +171,9 @@ inline void RenderToAnariObjectsVisitor::postChildren(
       }
       anari::commitParameters(m_device, inst);
     }
-
     m_objects.pop();
     break;
+  }
   default:
     // no-op
     break;
@@ -211,12 +193,12 @@ inline bool RenderToAnariObjectsVisitor::isIncludedAfterFiltering(
   return (*m_filter)(n->getObject());
 }
 
-inline void RenderToAnariObjectsVisitor::createInstanceFromTop()
+inline anari::Instance RenderToAnariObjectsVisitor::createInstanceFromTop()
 {
   auto &current = m_objects.top();
   if (current.surfaces.empty() && current.volumes.empty()
       && current.lights.empty())
-    return;
+    return {};
 
   auto group = anari::newObject<anari::Group>(m_device);
 
@@ -248,39 +230,13 @@ inline void RenderToAnariObjectsVisitor::createInstanceFromTop()
   anari::commitParameters(m_device, group);
 
   auto instance = anari::newObject<anari::Instance>(m_device, "transform");
-
-  const auto xfm = m_xfms.top();
-  if (!m_xfmArray)
-    anari::setParameter(m_device, instance, "transform", xfm);
-  else {
-    const auto *xfms_in = m_xfmArray->dataAs<tsd::math::mat4>();
-
-    uint64_t stride = 0;
-    auto *xfms_out = (tsd::math::mat4 *)anariMapParameterArray1D(m_device,
-        instance,
-        "transform",
-        ANARI_FLOAT32_MAT4,
-        m_xfmArray->size(),
-        &stride);
-
-    if (stride == sizeof(tsd::math::mat4)) {
-      std::transform(xfms_in,
-          xfms_in + m_xfmArray->size(),
-          xfms_out,
-          [&](const tsd::math::mat4 &m) { return tsd::math::mul(xfm, m); });
-    } else {
-      throw std::runtime_error("render index -- bad transform array stride");
-    }
-
-    anariUnmapParameterArray(m_device, instance, "transform");
-
-    m_xfmArray = nullptr;
-  }
   anari::setParameter(m_device, instance, "group", group);
   anari::commitParameters(m_device, instance);
   m_instances->push_back(instance);
 
   anari::release(m_device, group);
+
+  return instance;
 }
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/index/TransformsToAnariVisitor.hpp
+++ b/tsd/src/tsd/rendering/index/TransformsToAnariVisitor.hpp
@@ -1,0 +1,142 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// tsd_core
+#include <anari/anari_cpp/ext/linalg.h>
+#include "tsd/core/scene/Layer.hpp"
+// tsd_rendering
+#include "tsd/rendering/index/RenderIndexFilterFcn.hpp"
+// std
+#include <algorithm>
+#include <anari/anari_cpp.hpp>
+#include <cstdint>
+#include <iterator>
+#include <stack>
+
+namespace tsd::rendering {
+
+///////////////////////////////////////////////////////////////////////////////
+
+struct TransformsToAnariVisitor : public tsd::core::LayerVisitor
+{
+  TransformsToAnariVisitor(anari::Device d, anari::Instance *instances);
+  ~TransformsToAnariVisitor();
+
+  bool preChildren(tsd::core::LayerNode &n, int level) override;
+  void postChildren(tsd::core::LayerNode &n, int level) override;
+
+ private:
+  anari::Device m_device{nullptr};
+  anari::Instance *m_currentInstance;
+  std::stack<tsd::math::mat4> m_xfms;
+  std::stack<bool> m_hasObjects;
+  const tsd::core::Array *m_xfmArray{nullptr};
+};
+
+// Inlined definitions ////////////////////////////////////////////////////////
+
+inline TransformsToAnariVisitor::TransformsToAnariVisitor(
+    anari::Device d, anari::Instance *instances)
+    : m_device(d), m_currentInstance(instances)
+{
+  anari::retain(d, d);
+  m_xfms.emplace(tsd::math::identity);
+  m_hasObjects.emplace(false);
+}
+
+inline TransformsToAnariVisitor::~TransformsToAnariVisitor()
+{
+  anari::release(m_device, m_device);
+}
+
+inline bool TransformsToAnariVisitor::preChildren(
+    tsd::core::LayerNode &n, int level)
+{
+  if (!n->isEnabled())
+    return false;
+
+  auto type = n->type();
+  switch (type) {
+  case ANARI_SURFACE:
+  case ANARI_VOLUME:
+  case ANARI_LIGHT: {
+    m_hasObjects.top() = true;
+    break;
+  }
+  case ANARI_FLOAT32_MAT4:
+    m_xfms.push(tsd::math::mul(m_xfms.top(), n->getTransform()));
+    m_hasObjects.emplace(false);
+    break;
+  case ANARI_ARRAY1D: {
+    if (auto *a = n->getTransformArray(); a) {
+      m_xfmArray = a;
+      m_hasObjects.emplace(false);
+    }
+  }
+  default:
+    break;
+  }
+
+  return true;
+}
+
+inline void TransformsToAnariVisitor::postChildren(
+    tsd::core::LayerNode &n, int level)
+{
+  if (!n->isEnabled())
+    return;
+
+  switch (n->type()) {
+  case ANARI_FLOAT32_MAT4: {
+    if (m_hasObjects.top()) {
+      anari::Instance instance = *m_currentInstance++;
+      anari::setParameter(m_device, instance, "transform", m_xfms.top());
+      anari::commitParameters(m_device, instance);
+    }
+    m_hasObjects.pop();
+    m_xfms.pop();
+    break;
+  }
+  case ANARI_ARRAY1D: {
+    if (auto *a = n->getTransformArray(); !a)
+      break;
+
+    if (m_hasObjects.top()) {
+      anari::Instance instance = *m_currentInstance++;
+      const auto *xfms_in = m_xfmArray->dataAs<tsd::math::mat4>();
+
+      uint64_t stride = 0;
+      auto *xfms_out = (tsd::math::mat4 *)anariMapParameterArray1D(m_device,
+          instance,
+          "transform",
+          ANARI_FLOAT32_MAT4,
+          m_xfmArray->size(),
+          &stride);
+
+      if (stride == sizeof(tsd::math::mat4)) {
+        std::transform(xfms_in,
+            xfms_in + m_xfmArray->size(),
+            xfms_out,
+            [&xfm = m_xfms.top()](
+                const tsd::math::mat4 &m) { return tsd::math::mul(xfm, m); });
+      } else {
+        throw std::runtime_error("render index -- bad transform array stride");
+      }
+
+      anariUnmapParameterArray(m_device, instance, "transform");
+
+      m_xfmArray = nullptr;
+      anari::commitParameters(m_device, instance);
+    }
+    m_hasObjects.pop();
+    break;
+  }
+  default:
+    // no-op
+    break;
+  }
+}
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/scripting/bindings/CoreBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/CoreBindings.cpp
@@ -4,14 +4,14 @@
 #include "ArrayHelpers.hpp"
 #include "ObjectMethodBindings.hpp"
 #include "ParameterHelpers.hpp"
-#include "tsd/scripting/LuaBindings.hpp"
-#include "tsd/core/Token.hpp"
 #include "tsd/core/Parameter.hpp"
+#include "tsd/core/Token.hpp"
 #include "tsd/core/scene/Animation.hpp"
 #include "tsd/core/scene/Object.hpp"
 #include "tsd/core/scene/Scene.hpp"
 #include "tsd/core/scene/objects/Array.hpp"
 #include "tsd/core/scene/objects/Sampler.hpp"
+#include "tsd/scripting/LuaBindings.hpp"
 #include "tsd/scripting/Sol2Helpers.hpp"
 
 #include <sol/sol.hpp>
@@ -90,7 +90,6 @@ static auto makeCreateBinding()
   };
 }
 
-
 void registerCoreBindings(sol::state &lua)
 {
   sol::table tsd = lua["tsd"];
@@ -107,7 +106,8 @@ void registerCoreBindings(sol::state &lua)
       [](const core::Token &a, const core::Token &b) { return a == b; });
 
   // Read-only from Lua; values are set through Object
-  tsd.new_usertype<core::Parameter>("Parameter",
+  tsd.new_usertype<core::Parameter>(
+      "Parameter",
       sol::no_constructor,
       "name",
       [](const core::Parameter &p) { return p.name().str(); },
@@ -116,24 +116,30 @@ void registerCoreBindings(sol::state &lua)
       "isEnabled",
       &core::Parameter::isEnabled);
 
-  auto objectType = tsd.new_usertype<core::Object>("Object",
-      sol::no_constructor,
-      "index",
-      &core::Object::index);
+  auto objectType = tsd.new_usertype<core::Object>(
+      "Object", sol::no_constructor, "index", &core::Object::index);
 
   registerObjectMethodsOn(
       objectType, [](core::Object &o) -> core::Object * { return &o; });
 
-  tsd.new_usertype<core::Scene>("Scene",
+  tsd.new_usertype<core::Scene>(
+      "Scene",
       sol::constructors<core::Scene()>(),
       // Object creation
-      "createGeometry", makeCreateBinding<core::Geometry>(),
-      "createMaterial", makeCreateBinding<core::Material>(),
-      "createLight", makeCreateBinding<core::Light>(),
-      "createCamera", makeCreateBinding<core::Camera>(),
-      "createSampler", makeCreateBinding<core::Sampler>(),
-      "createVolume", makeCreateBinding<core::Volume>(),
-      "createSpatialField", makeCreateBinding<core::SpatialField>(),
+      "createGeometry",
+      makeCreateBinding<core::Geometry>(),
+      "createMaterial",
+      makeCreateBinding<core::Material>(),
+      "createLight",
+      makeCreateBinding<core::Light>(),
+      "createCamera",
+      makeCreateBinding<core::Camera>(),
+      "createSampler",
+      makeCreateBinding<core::Sampler>(),
+      "createVolume",
+      makeCreateBinding<core::Volume>(),
+      "createSpatialField",
+      makeCreateBinding<core::SpatialField>(),
       "createSurface",
       [](core::Scene &s,
           const std::string &name,
@@ -174,9 +180,7 @@ void registerCoreBindings(sol::state &lua)
       "getCamera",
       [](core::Scene &s, size_t i) { return s.getObject<core::Camera>(i); },
       "getSurface",
-      [](core::Scene &s, size_t i) {
-        return s.getObject<core::Surface>(i);
-      },
+      [](core::Scene &s, size_t i) { return s.getObject<core::Surface>(i); },
       "getArray",
       [](core::Scene &s, size_t i) { return s.getObject<core::Array>(i); },
       "getVolume",
@@ -305,25 +309,27 @@ void registerCoreBindings(sol::state &lua)
       },
       "numberOfActiveLayers",
       &core::Scene::numberOfActiveLayers,
-      // Signal layer change (needed after modifying transforms)
-      "signalLayerChange",
+      // Signal layer changes
+      "signalLayerStructureChanged",
       [](core::Scene &s, core::Layer *l) {
         if (l)
-          s.signalLayerChange(l);
+          s.signalLayerStructureChanged(l);
+      },
+      "signalLayerTransformChanged",
+      [](core::Scene &s, core::Layer *l) {
+        if (l)
+          s.signalLayerTransformChanged(l);
       },
       // Node removal
       "removeNode",
       sol::overload(
-          [](core::Scene &s, core::LayerNodeRef obj) {
-            s.removeNode(obj);
-          },
+          [](core::Scene &s, core::LayerNodeRef obj) { s.removeNode(obj); },
           [](core::Scene &s, core::LayerNodeRef obj, bool deleteObjects) {
             s.removeNode(obj, deleteObjects);
           }),
       // Animation
       "addAnimation",
-      sol::overload(
-          [](core::Scene &s) { return s.addAnimation(); },
+      sol::overload([](core::Scene &s) { return s.addAnimation(); },
           [](core::Scene &s, const std::string &name) {
             return s.addAnimation(name.c_str());
           }),
@@ -353,11 +359,11 @@ void registerCoreBindings(sol::state &lua)
       "cleanupScene",
       &core::Scene::cleanupScene);
 
-  tsd.new_usertype<core::Animation>("Animation",
+  tsd.new_usertype<core::Animation>(
+      "Animation",
       sol::no_constructor,
       "name",
-      sol::property(
-          [](const core::Animation &a) { return a.name(); },
+      sol::property([](const core::Animation &a) { return a.name(); },
           [](core::Animation &a, const std::string &n) { a.name() = n; }),
       "info",
       [](const core::Animation &a) { return a.info(); },
@@ -395,7 +401,18 @@ void registerCoreBindings(sol::state &lua)
             for (size_t i = 1; i <= arrays.size(); i++)
               stepVec.emplace_back(arrays[i].get<core::ArrayRef>());
             a.setAsTimeSteps(*o, paramVec, stepVec);
-          }));
+          }),
+      "setAsTransformSteps",
+      [](core::Animation &a, core::LayerNodeRef node, sol::table frames) {
+        if (!node.valid())
+          throw std::runtime_error(
+              "setAsTransformSteps: node must be a valid LayerNode");
+        std::vector<math::mat4> mats;
+        mats.reserve(frames.size());
+        for (size_t i = 1; i <= frames.size(); i++)
+          mats.push_back(frames[i].get<math::mat4>());
+        a.setAsTransformSteps(node, std::move(mats));
+      });
 
   tsd["createScene"] = []() { return std::make_unique<core::Scene>(); };
 

--- a/tsd/src/tsd/scripting/bindings/IOBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/IOBindings.cpp
@@ -222,6 +222,14 @@ void registerIOBindings(sol::state &lua)
         TSD_LUA_IMPORT_WRAP(tsd::io::import_E57XYZ(s, f.c_str(), loc), f);
       });
 
+  io["importENSIGHT"] = sol::overload(
+      [](core::Scene &s, const std::string &f) {
+        TSD_LUA_IMPORT_WRAP(tsd::io::import_ENSIGHT(s, f.c_str()), f);
+      },
+      [](core::Scene &s, const std::string &f, core::LayerNodeRef loc) {
+        TSD_LUA_IMPORT_WRAP(tsd::io::import_ENSIGHT(s, f.c_str(), loc), f);
+      });
+
   io["importHSMESH"] = sol::overload(
       [](core::Scene &s, const std::string &f) {
         TSD_LUA_IMPORT_WRAP(tsd::io::import_HSMESH(s, f.c_str()), f);

--- a/tsd/src/tsd/scripting/tsd.lua
+++ b/tsd/src/tsd/scripting/tsd.lua
@@ -206,9 +206,11 @@ function Sampler:valid() end
 local Surface = {}
 ---@return boolean
 function Surface:valid() end
+
 --- Get the geometry attached to this surface.
 ---@return tsd.Geometry?
 function Surface:geometry() end
+
 --- Get the material attached to this surface.
 ---@return tsd.Material?
 function Surface:material() end
@@ -217,6 +219,7 @@ function Surface:material() end
 local Volume = {}
 ---@return boolean
 function Volume:valid() end
+
 --- Get the spatial field attached to this volume.
 ---@return tsd.SpatialField?
 function Volume:spatialField() end
@@ -225,6 +228,7 @@ function Volume:spatialField() end
 local SpatialField = {}
 ---@return boolean
 function SpatialField:valid() end
+
 --- Compute the value range of this spatial field.
 ---@return tsd.float2
 function SpatialField:computeValueRange() end
@@ -233,22 +237,29 @@ function SpatialField:computeValueRange() end
 local Array = {}
 ---@return boolean
 function Array:valid() end
+
 ---@return integer
 function Array:elementType() end
+
 ---@return integer
 function Array:size() end
+
 ---@return integer
 function Array:elementSize() end
+
 ---@return boolean
 function Array:isEmpty() end
+
 ---@param d integer
 ---@return integer
 function Array:dim(d) end
+
 --- Set array data from a Lua table.
 --- For 2D/3D arrays, supports either a flat/linear table or a shape-matching nested table.
 --- Vector elements support `tsd.float2/3/4(...)` values or numeric tables.
 ---@param data table
 function Array:setData(data) end
+
 --- Get array data as a flat/linear Lua table.
 ---@return table
 function Array:getData() end
@@ -556,9 +567,13 @@ function Scene:setOnlyLayerActive(name) end
 ---@return integer
 function Scene:numberOfActiveLayers() end
 
---- Signal that a layer has changed (needed after modifying transforms).
+--- Signal that a layer structure has changed
 ---@param layer tsd.Layer
-function Scene:signalLayerChange(layer) end
+function Scene:signalLayerStructureChanged(layer) end
+
+--- Signal that a layer has changed transforms
+---@param layer tsd.Layer
+function Scene:signalLayerTransformChanged(layer) end
 
 -- Node insertion ---------------------------------------------------------
 
@@ -829,6 +844,7 @@ function tsd.radians(degrees) end
 ---@param radians number
 ---@return number
 function tsd.degrees(radians) end
+
 ------------------------------------------------------------------------
 -- Sub-tables
 ------------------------------------------------------------------------

--- a/tsd/src/tsd/ui/imgui/modals/ImportFileDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/ImportFileDialog.cpp
@@ -107,7 +107,7 @@ void ImportFileDialog::buildUI()
       tsd::io::ImportFile file{
           static_cast<tsd::io::ImporterType>(m_selectedFileType), m_filename};
       tsd::io::import_file(scene, file, importRoot);
-      scene.signalLayerChange(layer);
+      scene.signalLayerStructureChanged(layer);
     };
 
     m_app->showTaskModal(doLoad, "Please Wait: Importing Data...");

--- a/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
@@ -356,7 +356,8 @@ void BaseViewport::ui_gizmo()
     auto invParent = linalg::inverse(parentWorldTransform);
     localTransform = mul(invParent, worldTransform);
     (*selectedNodeRef)->setAsTransform(localTransform);
-    appCore()->tsd.scene.signalLayerChange(selectedNodeRef->container());
+    appCore()->tsd.scene.signalLayerTransformChanged(
+        selectedNodeRef->container());
   }
 }
 

--- a/tsd/src/tsd/ui/imgui/windows/IsosurfaceEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/IsosurfaceEditor.cpp
@@ -118,7 +118,7 @@ void IsosurfaceEditor::addIsosurfaceGeometryFromSelected()
   auto n = layer->insert_last_child(layer->root(), {s});
 
   appCore()->setSelected(n);
-  scene.signalLayerChange(layer);
+  scene.signalLayerStructureChanged(layer);
 }
 
 } // namespace tsd::ui::imgui

--- a/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/LayerTree.cpp
@@ -443,7 +443,7 @@ void LayerTree::buildUI_tree()
       ImGuiIO &io = ImGui::GetIO();
       copyNodesTo(dragAndDropTarget, droppedNodes, !io.KeyCtrl);
 
-      appCore()->tsd.scene.signalLayerChange(&layer);
+      appCore()->tsd.scene.signalLayerStructureChanged(&layer);
     }
   }
 }
@@ -546,7 +546,7 @@ void LayerTree::buildUI_handleSelection()
           appCore()->setSelected(newNodes);
         }
 
-        scene.signalLayerChange(&layer);
+        scene.signalLayerStructureChanged(&layer);
       }
     }
   }
@@ -591,7 +591,7 @@ void LayerTree::buildUI_objectSceneMenu()
     bool enabled = (*menuNode)->isEnabled();
     if (nodeSelected && ImGui::Checkbox("visible", &enabled)) {
       (*menuNode)->setEnabled(enabled);
-      scene.signalLayerChange(&layer);
+      scene.signalLayerStructureChanged(&layer);
     }
 
     if (nodeSelected && ImGui::MenuItem("show all")) {
@@ -599,7 +599,7 @@ void LayerTree::buildUI_objectSceneMenu()
         n->setEnabled(true);
         return true;
       });
-      scene.signalLayerChange(&layer);
+      scene.signalLayerStructureChanged(&layer);
     }
 
     if (nodeSelected && ImGui::MenuItem("hide all")) {
@@ -607,7 +607,7 @@ void LayerTree::buildUI_objectSceneMenu()
         n->setEnabled(false);
         return true;
       });
-      scene.signalLayerChange(&layer);
+      scene.signalLayerStructureChanged(&layer);
     }
 
     if (nodeSelected)

--- a/tsd/src/tsd/ui/imgui/windows/ObjectEditor.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/ObjectEditor.cpp
@@ -60,7 +60,7 @@ void ObjectEditor::buildUI()
     if (doUpdate) {
       node->setAsTransform(srt);
       auto *layer = selectedNode->container();
-      scene->signalLayerChange(layer);
+      scene->signalLayerTransformChanged(layer);
     }
   } else if (!node->isEmpty()) {
     ImGui::Text("{unhandled '%s' node}", anari::toString(node->type()));


### PR DESCRIPTION
This PR introduces a split of signalLayerUpdated into:
- signalLayerStructureUpdated (for scenegraph topological changes)
- signalLayerTransformUpdated (for transform node updates)

This helps splitting the RenderIndex behavior and split the work into two phases:
- ANARI Objects construction, including Instances
- Instances transform update only, for smoother animations

Also exposes the Ensight importer to Lua