### PR TITLE
Fix Lua loading of a tsd state

### DIFF
--- a/tsd/src/tsd/scripting/bindings/IOBindings.cpp
+++ b/tsd/src/tsd/scripting/bindings/IOBindings.cpp
@@ -425,7 +425,11 @@ void registerIOBindings(sol::state &lua)
   io["loadScene"] = [](core::Scene &s, const std::string &filename) {
     core::DataTree tree;
     tree.load(filename.c_str());
-    tsd::io::load_Scene(s, tree.root());
+    auto &root = tree.root();
+    if (auto *c = root.child("context"); c != nullptr)
+      tsd::io::load_Scene(s, *c);
+    else
+      tsd::io::load_Scene(s, root);
   };
 }
 


### PR DESCRIPTION
Scene is under "context" when saved from tsdViewer.