### PR TITLE
Add missing Image2D::textureObject() implementation

### DIFF
--- a/devices/rtx/device/sampler/Image2D.cpp
+++ b/devices/rtx/device/sampler/Image2D.cpp
@@ -99,6 +99,11 @@ int Image2D::numChannels() const
   return numANARIChannels(format);
 }
 
+cudaTextureObject_t Image2D::textureObject() const
+{
+  return m_texture;
+}
+
 SamplerGPUData Image2D::gpuData() const
 {
   SamplerGPUData retval = Sampler::gpuData();


### PR DESCRIPTION
The method was declared in Image2D.h but never defined, causing undefined reference linker errors when the symbol is pulled in (e.g. when building as a dependency with certain link configurations).

Mirrors the existing Image3D::textureObject() implementation.