### PR TITLE
Add MultiDeviceSceneRenderPass::getFrame() accessor

### DIFF
--- a/tsd/src/tsd/rendering/pipeline/passes/MultiDeviceSceneRenderPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/MultiDeviceSceneRenderPass.cpp
@@ -77,6 +77,11 @@ void MultiDeviceSceneRenderPass::setRunAsync(bool on)
   m_runAsync = on;
 }
 
+anari::Frame MultiDeviceSceneRenderPass::getFrame(size_t i) const
+{
+  return i < m_frames.size() ? m_frames[i] : nullptr;
+}
+
 void MultiDeviceSceneRenderPass::foreach_frame(
     const std::function<void(anari::Device, anari::Frame)> &func) const
 {

--- a/tsd/src/tsd/rendering/pipeline/passes/MultiDeviceSceneRenderPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/MultiDeviceSceneRenderPass.h
@@ -27,6 +27,8 @@ struct MultiDeviceSceneRenderPass : public RenderPass
   // default' true' -- if 'false', then anari::wait() on each pass
   void setRunAsync(bool on);
 
+  anari::Frame getFrame(size_t i = 0) const;
+
  private:
   void foreach_frame(
       const std::function<void(anari::Device, anari::Frame)> &func) const;


### PR DESCRIPTION
Expose per-device frame handles so that applications using multi-device rendering can query frame properties (duration, samples) and set per-frame parameters (denoise, AOV channels) on the actual rendering frames.

Mirrors the existing AnariSceneRenderPass::getFrame() API.