### PR TITLE
Fix SIGSEGV in TransformsToAnariVisitor with active filter

### DIFF
--- a/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
+++ b/tsd/src/tsd/rendering/index/RenderIndexAllLayers.cpp
@@ -241,7 +241,8 @@ void RenderIndexAllLayers::syncLayerTransforms(const Layer *_layer)
   auto d = device();
 
   auto *layer = const_cast<Layer *>(_layer);
-  TransformsToAnariVisitor visitor(d, m_instanceCache[layer].data());
+  TransformsToAnariVisitor visitor(
+      d, m_instanceCache[layer].data(), m_filter ? &m_filter : nullptr);
   layer->traverse(layer->root(), visitor);
 }
 

--- a/tsd/src/tsd/rendering/index/TransformsToAnariVisitor.hpp
+++ b/tsd/src/tsd/rendering/index/TransformsToAnariVisitor.hpp
@@ -21,25 +21,30 @@ namespace tsd::rendering {
 
 struct TransformsToAnariVisitor : public tsd::core::LayerVisitor
 {
-  TransformsToAnariVisitor(anari::Device d, anari::Instance *instances);
+  TransformsToAnariVisitor(anari::Device d,
+      anari::Instance *instances,
+      RenderIndexFilterFcn *filter = nullptr);
   ~TransformsToAnariVisitor();
 
   bool preChildren(tsd::core::LayerNode &n, int level) override;
   void postChildren(tsd::core::LayerNode &n, int level) override;
 
  private:
+  bool isIncludedAfterFiltering(const tsd::core::LayerNode &n) const;
+
   anari::Device m_device{nullptr};
   anari::Instance *m_currentInstance;
   std::stack<tsd::math::mat4> m_xfms;
   std::stack<bool> m_hasObjects;
   const tsd::core::Array *m_xfmArray{nullptr};
+  RenderIndexFilterFcn *m_filter{nullptr};
 };
 
 // Inlined definitions ////////////////////////////////////////////////////////
 
 inline TransformsToAnariVisitor::TransformsToAnariVisitor(
-    anari::Device d, anari::Instance *instances)
-    : m_device(d), m_currentInstance(instances)
+    anari::Device d, anari::Instance *instances, RenderIndexFilterFcn *filter)
+    : m_device(d), m_currentInstance(instances), m_filter(filter)
 {
   anari::retain(d, d);
   m_xfms.emplace(tsd::math::identity);
@@ -61,6 +66,9 @@ inline bool TransformsToAnariVisitor::preChildren(
   switch (type) {
   case ANARI_SURFACE:
   case ANARI_VOLUME:
+    if (isIncludedAfterFiltering(n))
+      m_hasObjects.top() = true;
+    break;
   case ANARI_LIGHT: {
     m_hasObjects.top() = true;
     break;
@@ -137,6 +145,19 @@ inline void TransformsToAnariVisitor::postChildren(
     // no-op
     break;
   }
+}
+
+inline bool TransformsToAnariVisitor::isIncludedAfterFiltering(
+    const tsd::core::LayerNode &n) const
+{
+  if (!m_filter)
+    return true;
+
+  auto type = n->type();
+  if (!anari::isObject(type))
+    return false;
+
+  return (*m_filter)(n->getObject());
 }
 
 } // namespace tsd::rendering


### PR DESCRIPTION
When a RenderIndexFilterFcn is active (e.g. for multi-device data partitioning by dataRank), RenderToAnariObjectsVisitor correctly skips filtered-out objects and creates fewer instances. However, TransformsToAnariVisitor was not filter-aware, it unconditionally set m_hasObjects for every SURFACE/VOLUME node, then advanced a raw instance pointer (*m_currentInstance++) in postChildren for each transform with objects below it.

Fix: accept an optional RenderIndexFilterFcn in TransformsToAnariVisitor and check isIncludedAfterFiltering() for SURFACE/VOLUME nodes (lights remain always-included, matching RenderToAnariObjectsVisitor). Pass the filter from RenderIndexAllLayers::syncLayerTransforms().