### PR TITLE
Tsd io roundtrip

### DIFF
--- a/tsd/src/tsd/core/Forest.hpp
+++ b/tsd/src/tsd/core/Forest.hpp
@@ -149,6 +149,7 @@ struct Forest
   Forest &operator=(Forest &&) = delete;
 
   void reserve(size_t size);
+  void reset();
 
   // ForestNode access //
 
@@ -166,6 +167,8 @@ struct Forest
 
   NodeRef insert_first_child(NodeRef n, T &&v);
   NodeRef insert_last_child(NodeRef n, T &&v);
+  NodeRef emplace_detached(T &&v);
+  void adopt_last_child(NodeRef parent, NodeRef child);
 
   void erase(NodeRef n);
   void erase_subtree(NodeRef n);
@@ -173,6 +176,9 @@ struct Forest
   void move_subtree(NodeRef source, NodeRef newParent);
 
   void clear();
+  void insert_empty_slot();
+  void rebuild_free_list();
+  bool slot_empty(size_t i) const;
 
   // Queries //
 
@@ -608,6 +614,54 @@ template <typename T>
 inline void Forest<T>::clear()
 {
   erase_subtree(m_root);
+}
+
+template <typename T>
+inline void Forest<T>::reset()
+{
+  m_nodes.clear();
+  m_root = {};
+}
+
+template <typename T>
+inline typename Forest<T>::NodeRef Forest<T>::emplace_detached(T &&v)
+{
+  auto n = make_ForestNode(std::forward<T>(v));
+  if (!m_root)
+    m_root = n;
+  return n;
+}
+
+template <typename T>
+inline void Forest<T>::adopt_last_child(
+    Forest<T>::NodeRef parent, Forest<T>::NodeRef child)
+{
+  child->m_parent = parent;
+  child->m_prev = parent->m_children_end;
+  child->m_next = parent->self();
+  if (parent->isLeaf())
+    parent->m_children_begin = child;
+  else
+    parent->m_children_end->m_next = child;
+  parent->m_children_end = child;
+}
+
+template <typename T>
+inline void Forest<T>::insert_empty_slot()
+{
+  m_nodes.insert_empty_slot();
+}
+
+template <typename T>
+inline void Forest<T>::rebuild_free_list()
+{
+  m_nodes.rebuild_free_list();
+}
+
+template <typename T>
+inline bool Forest<T>::slot_empty(size_t i) const
+{
+  return m_nodes.slot_empty(i);
 }
 
 template <typename T>

--- a/tsd/src/tsd/core/ObjectPool.hpp
+++ b/tsd/src/tsd/core/ObjectPool.hpp
@@ -55,6 +55,8 @@ struct ObjectPool
 
   void clear();
   void reserve(size_t size);
+  void insert_empty_slot();
+  void rebuild_free_list();
 
   bool defragment();
 
@@ -253,6 +255,22 @@ inline void ObjectPool<T>::reserve(size_t size)
 {
   m_values.reserve(size);
   m_slots.reserve(size);
+}
+
+template <typename T>
+inline void ObjectPool<T>::insert_empty_slot()
+{
+  m_values.emplace_back();
+  m_slots.push_back(false);
+}
+
+template <typename T>
+inline void ObjectPool<T>::rebuild_free_list()
+{
+  m_freeIndices = {};
+  for (size_t i = m_values.size(); i-- > 0;)
+    if (!m_slots[i])
+      m_freeIndices.push(i);
 }
 
 template <typename T>

--- a/tsd/src/tsd/io/serialization/serialization_datatree.cpp
+++ b/tsd/src/tsd/io/serialization/serialization_datatree.cpp
@@ -472,18 +472,19 @@ void save_Scene(Scene &scene,
   auto objectPoolToNode = [&](core::DataNode &objPoolRoot,
                               const auto &objPool,
                               const char *poolName) {
-    if (objPool.empty())
+    if (objPool.capacity() == 0)
       return;
 
-    tsd::core::logStatus(
-        "    ...serializing %zu %s objects", size_t(objPool.size()), poolName);
+    tsd::core::logStatus("    ...serializing %zu %s objects (%zu slots)",
+        size_t(objPool.size()),
+        poolName,
+        size_t(objPool.capacity()));
 
     auto &childNode = objPoolRoot[poolName];
     foreach_item_const(objPool, [&](const auto *obj) {
-      if (!obj)
-        return;
       auto &m = childNode.append();
-      objectToNode(*obj, m, forceProxyArrays);
+      if (obj)
+        objectToNode(*obj, m, forceProxyArrays);
     });
   };
 
@@ -531,22 +532,31 @@ void load_Scene(Scene &scene,
   tsd::core::logStatus("  ...converting objects");
 
   auto &objectDB = root["objectDB"];
-  auto nodeToObjectPool =
-      [](core::DataNode &node, Scene &scene, const char *childNodeName) {
-        auto &objectsNode = node[childNodeName];
-        objectsNode.foreach_child([&](auto &n) { nodeToNewObject(scene, n); });
-      };
+  auto nodeToObjectPool = [](core::DataNode &node,
+                              Scene &scene,
+                              const char *childNodeName,
+                              anari::DataType poolType) {
+    auto &objectsNode = node[childNodeName];
+    objectsNode.foreach_child([&](auto &n) {
+      if (!n.child("self"))
+        scene.insertEmptySlot(poolType);
+      else
+        nodeToNewObject(scene, n);
+    });
+  };
 
-  nodeToObjectPool(objectDB, scene, "array");
-  nodeToObjectPool(objectDB, scene, "sampler");
-  nodeToObjectPool(objectDB, scene, "material");
-  nodeToObjectPool(objectDB, scene, "geometry");
-  nodeToObjectPool(objectDB, scene, "surface");
-  nodeToObjectPool(objectDB, scene, "spatialfield");
-  nodeToObjectPool(objectDB, scene, "volume");
-  nodeToObjectPool(objectDB, scene, "light");
-  nodeToObjectPool(objectDB, scene, "camera");
-  nodeToObjectPool(objectDB, scene, "renderer");
+  nodeToObjectPool(objectDB, scene, "array", ANARI_ARRAY);
+  nodeToObjectPool(objectDB, scene, "sampler", ANARI_SAMPLER);
+  nodeToObjectPool(objectDB, scene, "material", ANARI_MATERIAL);
+  nodeToObjectPool(objectDB, scene, "geometry", ANARI_GEOMETRY);
+  nodeToObjectPool(objectDB, scene, "surface", ANARI_SURFACE);
+  nodeToObjectPool(objectDB, scene, "spatialfield", ANARI_SPATIAL_FIELD);
+  nodeToObjectPool(objectDB, scene, "volume", ANARI_VOLUME);
+  nodeToObjectPool(objectDB, scene, "light", ANARI_LIGHT);
+  nodeToObjectPool(objectDB, scene, "camera", ANARI_CAMERA);
+  nodeToObjectPool(objectDB, scene, "renderer", ANARI_RENDERER);
+
+  scene.rebuildFreeLists();
 
   // Layers
 
@@ -594,11 +604,9 @@ void load_Scene(Scene &scene,
 
             auto paramName =
                 Token(bNode["paramName"].getValueAs<std::string>().c_str());
-            auto dataType =
-                (ANARIDataType)bNode["dataType"].getValueAs<int>();
-            auto interp =
-                (tsd::animation::InterpolationRule)bNode["interp"]
-                    .getValueAs<int>();
+            auto dataType = (ANARIDataType)bNode["dataType"].getValueAs<int>();
+            auto interp = (tsd::animation::InterpolationRule)bNode["interp"]
+                              .getValueAs<int>();
 
             const float *tbPtr = nullptr;
             size_t tbCount = 0;

--- a/tsd/src/tsd/io/serialization/serialization_datatree.cpp
+++ b/tsd/src/tsd/io/serialization/serialization_datatree.cpp
@@ -307,76 +307,114 @@ void nodeToCameraPose(core::DataNode &node, rendering::CameraPose &pose)
 
 void layerToNode(const Layer &layer, core::DataNode &node)
 {
-  std::stack<core::DataNode *> nodes;
-  core::DataNode *currentParentNode = nullptr;
-  core::DataNode *currentNode = &node;
-  int currentLevel = -1;
-  layer.traverse_const(layer.root(), [&](const LayerNode &tsdNode, int level) {
-    if (currentLevel < level) {
-      nodes.push(currentNode);
-      currentParentNode = currentNode;
-    } else if (currentLevel > level) {
-      for (int i = 0; i < currentLevel - level; i++)
-        nodes.pop();
-      currentParentNode = nodes.top();
-    }
+  auto &slotsNode = node["slots"];
+  for (size_t i = 0; i < layer.capacity(); i++) {
+    auto &slotNode = slotsNode.append();
+    if (layer.slot_empty(i))
+      continue;
 
-    currentLevel = level;
-
-    if (level == 0)
-      currentNode = &node;
-    else
-      currentNode = &currentParentNode->child("children")->append();
-
-    currentNode->append("name") = tsdNode->name();
-    currentNode->append("value") = tsdNode->getValueRaw();
-    if (tsdNode->isTransform())
-      currentNode->append("transformSRT") = tsdNode->getTransformSRT();
-    currentNode->append("enabled") = tsdNode->isEnabled();
-    currentNode->append("children");
-
-    return true;
-  });
+    auto nref = layer.at(i);
+    const auto &nd = nref->value();
+    slotNode["index"] = i;
+    slotNode["name"] = nd.name();
+    slotNode["value"] = nd.getValueRaw();
+    if (nd.isTransform())
+      slotNode["transformSRT"] = nd.getTransformSRT();
+    slotNode["enabled"] = nd.isEnabled();
+    if (auto p = nref->parent(); p)
+      slotNode["parentIndex"] = p->index();
+  }
 }
 
 void nodeToLayer(core::DataNode &rootNode, Layer &layer, Scene &scene)
 {
-  layer.clear();
+  // Support legacy format (has "children" key on root)
+  if (rootNode.child("children")) {
+    layer.clear();
 
-  std::stack<LayerNodeRef> tsdNodes;
-  LayerNodeRef currentParentNode;
-  LayerNodeRef currentNode = layer.root();
-  int currentLevel = -1;
-  rootNode.traverse([&](core::DataNode &node, int level) {
-    if (level & 0x1 || !node.child("children"))
+    std::stack<LayerNodeRef> tsdNodes;
+    LayerNodeRef currentParentNode;
+    LayerNodeRef currentNode = layer.root();
+    int currentLevel = -1;
+    rootNode.traverse([&](core::DataNode &node, int level) {
+      if (level & 0x1 || !node.child("children"))
+        return true;
+
+      level /= 2;
+      if (currentLevel < level) {
+        tsdNodes.push(currentNode);
+        currentParentNode = currentNode;
+      } else if (currentLevel > level) {
+        for (int i = 0; i < currentLevel - level; i++)
+          tsdNodes.pop();
+        currentParentNode = tsdNodes.top();
+      }
+
+      currentLevel = level;
+
+      if (level == 0)
+        currentNode = layer.root();
+      else {
+        currentNode = currentParentNode->insert_last_child({&layer});
+        if (auto *c = node.child("transformSRT"); c != nullptr)
+          (*currentNode)->setAsTransform(c->getValueAs<math::mat3>());
+        else
+          (*currentNode)->setValueRaw(node["value"].getValue());
+        (*currentNode)->setEnabled(node["enabled"].getValueOr(true));
+        (*currentNode)->name() = node["name"].getValueAs<std::string>();
+      }
+
       return true;
+    });
+    return;
+  }
 
-    level /= 2;
-    if (currentLevel < level) {
-      tsdNodes.push(currentNode);
-      currentParentNode = currentNode;
-    } else if (currentLevel > level) {
-      for (int i = 0; i < currentLevel - level; i++)
-        tsdNodes.pop();
-      currentParentNode = tsdNodes.top();
+  // New index-preserving format
+  layer.reset();
+
+  auto *slotsNode = rootNode.child("slots");
+  if (!slotsNode)
+    return;
+
+  // Pass 1: allocate slots in order, collect parent indices
+  std::vector<size_t> parentIndices;
+  slotsNode->foreach_child([&](core::DataNode &slotNode) {
+    if (!slotNode.child("index")) {
+      layer.insert_empty_slot();
+      parentIndices.push_back(INVALID_INDEX);
+      return;
     }
 
-    currentLevel = level;
+    size_t storedIndex = slotNode["index"].getValueAs<size_t>();
+    LayerNodeData nd(&layer);
+    if (auto *c = slotNode.child("transformSRT"); c != nullptr)
+      nd.setAsTransform(c->getValueAs<math::mat3>());
+    else
+      nd.setValueRaw(slotNode["value"].getValue());
+    nd.setEnabled(slotNode["enabled"].getValueOr(true));
+    nd.name() = slotNode["name"].getValueAs<std::string>();
 
-    if (level == 0)
-      currentNode = layer.root();
-    else {
-      currentNode = currentParentNode->insert_last_child({&layer});
-      if (auto *c = node.child("transformSRT"); c != nullptr)
-        (*currentNode)->setAsTransform(c->getValueAs<math::mat3>());
-      else
-        (*currentNode)->setValueRaw(node["value"].getValue());
-      (*currentNode)->setEnabled(node["enabled"].getValueOr(true));
-      (*currentNode)->name() = node["name"].getValueAs<std::string>();
+    auto nref = layer.emplace_detached(std::move(nd));
+    if (nref->index() != storedIndex) {
+      logError("[nodeToLayer] node index mismatch: got %zu, expected %zu",
+          nref->index(),
+          storedIndex);
     }
 
-    return true;
+    if (auto *c = slotNode.child("parentIndex"); c != nullptr)
+      parentIndices.push_back(c->getValueAs<size_t>());
+    else
+      parentIndices.push_back(INVALID_INDEX);
   });
+
+  // Pass 2: wire parent-child relationships in pool-index order
+  for (size_t i = 0; i < layer.capacity(); i++) {
+    if (layer.slot_empty(i) || parentIndices[i] == INVALID_INDEX)
+      continue;
+    layer.adopt_last_child(layer.at(parentIndices[i]), layer.at(i));
+  }
+
+  layer.rebuild_free_list();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tsd/src/tsd/scene/Layer.cpp
+++ b/tsd/src/tsd/scene/Layer.cpp
@@ -63,6 +63,36 @@ void Layer::clear()
   m_tree.clear();
 }
 
+void Layer::reset()
+{
+  m_tree.reset();
+}
+
+LayerNodeRef Layer::emplace_detached(LayerNodeData &&v)
+{
+  return m_tree.emplace_detached(std::move(v));
+}
+
+void Layer::adopt_last_child(LayerNodeRef parent, LayerNodeRef child)
+{
+  m_tree.adopt_last_child(parent, child);
+}
+
+void Layer::insert_empty_slot()
+{
+  m_tree.insert_empty_slot();
+}
+
+void Layer::rebuild_free_list()
+{
+  m_tree.rebuild_free_list();
+}
+
+bool Layer::slot_empty(size_t i) const
+{
+  return m_tree.slot_empty(i);
+}
+
 bool Layer::isAncestorOf(
     LayerNodeRef potentialAncestor, LayerNodeRef node) const
 {

--- a/tsd/src/tsd/scene/Layer.hpp
+++ b/tsd/src/tsd/scene/Layer.hpp
@@ -47,6 +47,12 @@ struct Layer final
   LayerNodeRef at(size_t i) const;
   void erase(LayerNodeRef obj);
   void clear();
+  void reset();
+  LayerNodeRef emplace_detached(LayerNodeData &&v);
+  void adopt_last_child(LayerNodeRef parent, LayerNodeRef child);
+  void insert_empty_slot();
+  void rebuild_free_list();
+  bool slot_empty(size_t i) const;
 
   bool isAncestorOf(LayerNodeRef potentialAncestor, LayerNodeRef node) const;
 

--- a/tsd/src/tsd/scene/Scene.cpp
+++ b/tsd/src/tsd/scene/Scene.cpp
@@ -416,6 +416,61 @@ void Scene::removeObject(const Object *_o)
   }
 }
 
+void Scene::insertEmptySlot(anari::DataType type)
+{
+  switch (type) {
+  case ANARI_SURFACE:
+    m_db.surface.insert_empty_slot();
+    break;
+  case ANARI_GEOMETRY:
+    m_db.geometry.insert_empty_slot();
+    break;
+  case ANARI_MATERIAL:
+    m_db.material.insert_empty_slot();
+    break;
+  case ANARI_SAMPLER:
+    m_db.sampler.insert_empty_slot();
+    break;
+  case ANARI_VOLUME:
+    m_db.volume.insert_empty_slot();
+    break;
+  case ANARI_SPATIAL_FIELD:
+    m_db.field.insert_empty_slot();
+    break;
+  case ANARI_LIGHT:
+    m_db.light.insert_empty_slot();
+    break;
+  case ANARI_CAMERA:
+    m_db.camera.insert_empty_slot();
+    break;
+  case ANARI_RENDERER:
+    m_db.renderer.insert_empty_slot();
+    break;
+  case ANARI_ARRAY:
+  case ANARI_ARRAY1D:
+  case ANARI_ARRAY2D:
+  case ANARI_ARRAY3D:
+    m_db.array.insert_empty_slot();
+    break;
+  default:
+    break;
+  }
+}
+
+void Scene::rebuildFreeLists()
+{
+  m_db.array.rebuild_free_list();
+  m_db.surface.rebuild_free_list();
+  m_db.geometry.rebuild_free_list();
+  m_db.material.rebuild_free_list();
+  m_db.sampler.rebuild_free_list();
+  m_db.volume.rebuild_free_list();
+  m_db.field.rebuild_free_list();
+  m_db.light.rebuild_free_list();
+  m_db.camera.rebuild_free_list();
+  m_db.renderer.rebuild_free_list();
+}
+
 void Scene::removeAllObjects()
 {
   if (m_updateDelegate)

--- a/tsd/src/tsd/scene/Scene.hpp
+++ b/tsd/src/tsd/scene/Scene.hpp
@@ -137,6 +137,8 @@ struct Scene
   void removeObject(const Object *o);
   void removeObject(const Any &o);
   void removeAllObjects();
+  void insertEmptySlot(anari::DataType type);
+  void rebuildFreeLists();
 
   // Renderers (specially handled per-device) //
 


### PR DESCRIPTION
Fix ObjectPool ordering on reload, both for scene databases and for layer nodes.

This should help correctly remapping animation to their target transforms and objects.

Bottom-line this is about:
- always saving empty layer nodes/object
- traversing the data tree nodes on reload, inserting empty layer nodes/object on empty data tree nodes, rewiring the hierarchy in case of a layer, and then rebuilding the free lists from those empty layer/objects.