### PR TITLE
ImagePasses cleanup + general tonemapping passes

### DIFF
--- a/tsd/apps/tools/tsdRender.cpp
+++ b/tsd/apps/tools/tsdRender.cpp
@@ -249,7 +249,6 @@ static void setupImagePipeline()
     aovPass->setAOVType(g_ctx->offline.aov.aovType);
     aovPass->setDepthRange(
         g_ctx->offline.aov.depthMin, g_ctx->offline.aov.depthMax);
-    aovPass->setEdgeThreshold(g_ctx->offline.aov.edgeThreshold);
     aovPass->setEdgeInvert(g_ctx->offline.aov.edgeInvert);
 
     // Enable necessary frame channels
@@ -301,7 +300,7 @@ static void renderFrames()
       }
     }
     if (hasCameraAnimation)
-      break;;
+      break;
   }
 
   if (hasCameraAnimation) {

--- a/tsd/src/tsd/app/Context.cpp
+++ b/tsd/src/tsd/app/Context.cpp
@@ -578,7 +578,6 @@ void OfflineRenderSequenceConfig::saveSettings(tsd::core::DataNode &root)
   aovRoot["aovType"] = static_cast<int>(aov.aovType);
   aovRoot["depthMin"] = aov.depthMin;
   aovRoot["depthMax"] = aov.depthMax;
-  aovRoot["edgeThreshold"] = aov.edgeThreshold;
   aovRoot["edgeInvert"] = aov.edgeInvert;
 }
 
@@ -623,7 +622,6 @@ void OfflineRenderSequenceConfig::loadSettings(tsd::core::DataNode &root)
   aov.aovType = static_cast<tsd::rendering::AOVType>(aovTypeInt);
   aovRoot["depthMin"].getValue(ANARI_FLOAT32, &aov.depthMin);
   aovRoot["depthMax"].getValue(ANARI_FLOAT32, &aov.depthMax);
-  aovRoot["edgeThreshold"].getValue(ANARI_FLOAT32, &aov.edgeThreshold);
   aovRoot["edgeInvert"].getValue(ANARI_BOOL, &aov.edgeInvert);
 }
 

--- a/tsd/src/tsd/app/Context.h
+++ b/tsd/src/tsd/app/Context.h
@@ -107,7 +107,6 @@ struct OfflineRenderSequenceConfig
     tsd::rendering::AOVType aovType{tsd::rendering::AOVType::NONE};
     float depthMin{0.f};
     float depthMax{1.f};
-    float edgeThreshold{0.5f};
     bool edgeInvert{false};
   } aov;
 

--- a/tsd/src/tsd/app/renderAnimationSequence.cpp
+++ b/tsd/src/tsd/app/renderAnimationSequence.cpp
@@ -108,7 +108,6 @@ void renderAnimationSequence(Context &ctx,
     auto *aovPass = pipeline.emplace_back<tsd::rendering::VisualizeAOVPass>();
     aovPass->setAOVType(config.aov.aovType);
     aovPass->setDepthRange(config.aov.depthMin, config.aov.depthMax);
-    aovPass->setEdgeThreshold(config.aov.edgeThreshold);
     aovPass->setEdgeInvert(config.aov.edgeInvert);
 
     if (config.aov.aovType == tsd::rendering::AOVType::ALBEDO)

--- a/tsd/src/tsd/rendering/CMakeLists.txt
+++ b/tsd/src/tsd/rendering/CMakeLists.txt
@@ -40,6 +40,7 @@ if (TSD_USE_CUDA)
   set_source_files_properties(
     pipeline/passes/AnariAxesRenderPass.cpp
     pipeline/passes/AnariSceneRenderPass.cpp
+    pipeline/passes/ClearBuffersPass.cpp
     pipeline/passes/ImagePass.cpp
     pipeline/passes/OutlineRenderPass.cpp
     pipeline/passes/VisualizeAOVPass.cpp

--- a/tsd/src/tsd/rendering/CMakeLists.txt
+++ b/tsd/src/tsd/rendering/CMakeLists.txt
@@ -12,15 +12,18 @@ PRIVATE
   index/RenderIndexAllLayers.cpp
   pipeline/passes/AnariAxesRenderPass.cpp
   pipeline/passes/AnariSceneRenderPass.cpp
+  pipeline/passes/AutoExposurePass.cpp
   pipeline/passes/ClearBuffersPass.cpp
   pipeline/passes/CopyFromColorBufferPass.cpp
   pipeline/passes/CopyToColorBufferPass.cpp
   pipeline/passes/CopyToSDLTexturePass.cpp
   pipeline/passes/MultiDeviceSceneRenderPass.cpp
   pipeline/passes/OutlineRenderPass.cpp
+  pipeline/passes/OutputTransformPass.cpp
   pipeline/passes/PickPass.cpp
   pipeline/passes/ImagePass.cpp
   pipeline/passes/SaveToFilePass.cpp
+  pipeline/passes/ToneMapPass.cpp
   pipeline/passes/VisualizeAOVPass.cpp
   pipeline/ImagePipeline.cpp
   view/ManipulatorToAnari.cpp
@@ -40,9 +43,12 @@ if (TSD_USE_CUDA)
   set_source_files_properties(
     pipeline/passes/AnariAxesRenderPass.cpp
     pipeline/passes/AnariSceneRenderPass.cpp
+    pipeline/passes/AutoExposurePass.cpp
     pipeline/passes/ClearBuffersPass.cpp
     pipeline/passes/ImagePass.cpp
     pipeline/passes/OutlineRenderPass.cpp
+    pipeline/passes/OutputTransformPass.cpp
+    pipeline/passes/ToneMapPass.cpp
     pipeline/passes/VisualizeAOVPass.cpp
     PROPERTIES
       COMPILE_OPTIONS "--extended-lambda;--expt-relaxed-constexpr;-Xcudafe=--diag_suppress=20012;-Wno-deprecated-gpu-targets"

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -38,6 +38,7 @@ void ImagePipeline::setDimensions(uint32_t width, uint32_t height)
   cleanup();
   const size_t totalSize = size_t(width) * size_t(height);
   m_buffers.color = detail::allocate<uint32_t>(totalSize);
+  m_buffers.hdrColor = detail::allocate<float>(totalSize * 4);
   m_buffers.depth = detail::allocate<float>(totalSize);
   m_buffers.instanceId = detail::allocate<uint32_t>(totalSize);
   m_buffers.objectId = detail::allocate<uint32_t>(totalSize);
@@ -51,6 +52,7 @@ void ImagePipeline::setDimensions(uint32_t width, uint32_t height)
 void ImagePipeline::render()
 {
   int stageId = 0;
+  m_buffers.exposure = 0.f;
   m_passTimings.clear();
   for (auto &p : m_passes) {
     if (!p->isEnabled())
@@ -92,6 +94,7 @@ void ImagePipeline::clear()
 void ImagePipeline::cleanup()
 {
   detail::free(m_buffers.color);
+  detail::free(m_buffers.hdrColor);
   detail::free(m_buffers.depth);
   detail::free(m_buffers.objectId);
   detail::free(m_buffers.primitiveId);

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -51,28 +51,27 @@ void ImagePipeline::setDimensions(uint32_t width, uint32_t height)
 void ImagePipeline::render()
 {
   int stageId = 0;
-#define PRINT_LATENCIES 0
+  m_passTimings.clear();
   for (auto &p : m_passes) {
     if (!p->isEnabled())
       continue;
-#if PRINT_LATENCIES
     auto start = std::chrono::steady_clock::now();
-#endif
     p->render(m_buffers, stageId++);
-#if PRINT_LATENCIES
     auto end = std::chrono::steady_clock::now();
-    auto time = std::chrono::duration<float>(end - start).count();
-    printf("[%i] %fms\t", stageId - 1, time * 1000);
-#endif
+    auto time = std::chrono::duration<float, std::milli>(end - start).count();
+    m_passTimings.push_back({p->name(), time});
   }
-#if PRINT_LATENCIES
-  printf("\n");
-#endif
 }
 
 const uint32_t *ImagePipeline::getColorBuffer() const
 {
   return m_buffers.color;
+}
+
+const std::vector<ImagePipeline::PassTiming> &ImagePipeline::getPassTimings()
+    const
+{
+  return m_passTimings;
 }
 
 size_t ImagePipeline::size() const

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -16,8 +16,7 @@ ImagePipeline::ImagePipeline()
 #endif
 }
 
-ImagePipeline::ImagePipeline(int width, int height)
-    : ImagePipeline()
+ImagePipeline::ImagePipeline(int width, int height) : ImagePipeline()
 {
   setDimensions(width, height);
 }
@@ -99,6 +98,11 @@ void ImagePipeline::cleanup()
   detail::free(m_buffers.instanceId);
   detail::free(m_buffers.albedo);
   detail::free(m_buffers.normal);
+
+  // nullify all buffers, retaining the associated CUDA streams.
+  auto stream = m_buffers.stream;
+  m_buffers = {};
+  m_buffers.stream = stream;
 }
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -23,7 +23,7 @@ ImagePipeline::ImagePipeline(int width, int height)
 
 ImagePipeline::~ImagePipeline()
 {
-  void cleanup();
+  cleanup();
 #ifdef ENABLE_CUDA
   cudaStreamDestroy(m_buffers.stream);
 #endif

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -17,6 +17,7 @@ ImagePipeline::ImagePipeline()
 }
 
 ImagePipeline::ImagePipeline(int width, int height)
+    : ImagePipeline()
 {
   setDimensions(width, height);
 }

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.cpp
@@ -94,6 +94,8 @@ void ImagePipeline::cleanup()
   detail::free(m_buffers.color);
   detail::free(m_buffers.depth);
   detail::free(m_buffers.objectId);
+  detail::free(m_buffers.primitiveId);
+  detail::free(m_buffers.instanceId);
   detail::free(m_buffers.albedo);
   detail::free(m_buffers.normal);
 }

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.h
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.h
@@ -35,6 +35,12 @@ namespace tsd::rendering {
  */
 struct ImagePipeline final
 {
+  struct PassTiming
+  {
+    const char *name{nullptr};
+    float milliseconds{0.f};
+  };
+
   ImagePipeline();
   ImagePipeline(int width, int height);
   ~ImagePipeline();
@@ -43,6 +49,7 @@ struct ImagePipeline final
   void render();
 
   const uint32_t *getColorBuffer() const;
+  const std::vector<PassTiming> &getPassTimings() const;
 
   size_t size() const;
   bool empty() const;
@@ -55,6 +62,7 @@ struct ImagePipeline final
   void cleanup();
 
   std::vector<std::unique_ptr<ImagePass>> m_passes;
+  std::vector<PassTiming> m_passTimings;
   ImageBuffers m_buffers;
   tsd::math::uint2 m_size{0, 0};
 };

--- a/tsd/src/tsd/rendering/pipeline/passes/AnariAxesRenderPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/AnariAxesRenderPass.h
@@ -22,6 +22,7 @@ struct AnariAxesRenderPass : public ImagePass
 {
   AnariAxesRenderPass(anari::Device d, const anari::Extensions &e);
   ~AnariAxesRenderPass() override;
+  const char *name() const override { return "Axes Overlay"; }
 
   void setView(const tsd::math::float3 &dir, const tsd::math::float3 &up);
 

--- a/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
@@ -14,14 +14,6 @@ namespace tsd::rendering {
 
 // Thrust kernels /////////////////////////////////////////////////////////////
 
-DEVICE_FCN_INLINE uint32_t shadePixel(uint32_t c_in)
-{
-  auto c_in_f = helium::cvt_color_to_float4(c_in);
-  auto c_h = tsd::math::float4(1.f, 0.5f, 0.f, 1.f);
-  auto c_out = tsd::math::lerp(c_in_f, c_h, 0.8f);
-  return helium::cvt_color_to_uint32(c_out);
-};
-
 void compositeFrame(ImageBuffers &b_out,
     const ImageBuffers &b_in,
     tsd::math::uint2 size,

--- a/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
@@ -291,6 +291,7 @@ void AnariSceneRenderPass::updateSize()
 
   const size_t totalSize = size_t(size.x) * size_t(size.y);
   m_buffers.color = detail::allocate<uint32_t>(totalSize);
+  m_buffers.hdrColor = detail::allocate<float>(totalSize * 4);
   m_buffers.depth = detail::allocate<float>(totalSize);
   m_buffers.objectId = detail::allocate<uint32_t>(totalSize);
   m_buffers.primitiveId = detail::allocate<uint32_t>(totalSize);
@@ -345,6 +346,7 @@ void AnariSceneRenderPass::copyFrameData()
   const size_t totalSize = size.x * size.y;
   if (totalSize > 0 && size.x == color.width && size.y == color.height) {
     if (color.pixelType == ANARI_FLOAT32_VEC4) {
+      detail::copy(m_buffers.hdrColor, (float *)color.data, totalSize * 4);
       detail::convertFloatColorBuffer_(m_buffers.stream,
           (const float *)color.data,
           (uint8_t *)m_buffers.color,
@@ -406,6 +408,8 @@ void AnariSceneRenderPass::composite(ImageBuffers &b, int stageId)
 
   if (firstPass) {
     detail::copy(b.color, m_buffers.color, totalSize);
+    if (m_format == ANARI_FLOAT32_VEC4)
+      detail::copy(b.hdrColor, m_buffers.hdrColor, totalSize * 4);
     detail::copy(b.depth, m_buffers.depth, totalSize);
     detail::copy(b.objectId, m_buffers.objectId, totalSize);
     if (m_enablePrimitiveId)
@@ -424,6 +428,7 @@ void AnariSceneRenderPass::composite(ImageBuffers &b, int stageId)
 void AnariSceneRenderPass::cleanup()
 {
   detail::free(m_buffers.color);
+  detail::free(m_buffers.hdrColor);
   detail::free(m_buffers.depth);
   detail::free(m_buffers.objectId);
   detail::free(m_buffers.primitiveId);

--- a/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.h
@@ -22,6 +22,7 @@ struct AnariSceneRenderPass : public ImagePass
 {
   AnariSceneRenderPass(anari::Device d);
   ~AnariSceneRenderPass() override;
+  const char *name() const override { return "ANARI Scene"; }
 
   void setCamera(anari::Camera c);
   void setRenderer(anari::Renderer r);

--- a/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
@@ -1,0 +1,92 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "AutoExposurePass.h"
+// std
+#include <algorithm>
+#include <cmath>
+
+#include "detail/parallel_reduce.h"
+
+namespace tsd::rendering {
+
+namespace {
+
+constexpr uint32_t SAMPLE_COUNT = 16384;
+constexpr float MIN_LUMINANCE = 1e-4f;
+constexpr float MIN_EXPOSURE = -20.f;
+constexpr float MAX_EXPOSURE = 20.f;
+constexpr float MID_GRAY = 0.18f;
+
+float computeSumLogLuminance(
+    const ImageBuffers &b, uint32_t numSamples, uint32_t stride)
+{
+  // very approximate and suboptimal, going only through a handleful of samples.
+  // Good enough for now.
+  // Might have to be revisited to be exhautive and still high performance.
+  // https://gpuopen.com/fidelityfx-spd/ ?
+  const float *hdrColor = b.hdrColor;
+  return detail::parallel_reduce(
+      b.stream,
+      0u,
+      numSamples,
+      0.f,
+      [=] DEVICE_FCN(uint32_t j) {
+        const uint32_t idx = j * stride * 4;
+        const float lum = std::max(0.2126f * hdrColor[idx + 0]
+                + 0.7152f * hdrColor[idx + 1] + 0.0722f * hdrColor[idx + 2],
+            MIN_LUMINANCE);
+        return std::log2(lum);
+      },
+      [] DEVICE_FCN(float a, float b) { return a + b; });
+}
+
+} // namespace
+
+AutoExposurePass::AutoExposurePass() = default;
+
+AutoExposurePass::~AutoExposurePass() = default;
+
+void AutoExposurePass::setHDREnabled(bool enabled)
+{
+  if (enabled && !m_hdrEnabled)
+    m_hasExposure = false;
+  m_hdrEnabled = enabled;
+}
+
+float AutoExposurePass::currentExposure() const
+{
+  return m_currentExposure;
+}
+
+void AutoExposurePass::render(ImageBuffers &b, int stageId)
+{
+  if (stageId == 0 || !m_hdrEnabled)
+    return;
+
+  const auto size = getDimensions();
+  const uint32_t totalPixels = size.x * size.y;
+  if (totalPixels == 0 || !b.hdrColor)
+    return;
+
+  const uint32_t stride = std::max(1u, totalPixels / SAMPLE_COUNT);
+  const uint32_t numSamples = (totalPixels + stride - 1) / stride;
+  if (numSamples == 0)
+    return;
+
+  const float sumLogLum = computeSumLogLuminance(b, numSamples, stride);
+  const float avgLum = std::exp2(sumLogLum / float(numSamples));
+  const float targetExposure =
+      std::clamp(std::log2(MID_GRAY / avgLum), MIN_EXPOSURE, MAX_EXPOSURE);
+
+  if (!m_hasExposure) {
+    m_currentExposure = targetExposure;
+    m_hasExposure = true;
+  } else {
+    m_currentExposure += (targetExposure - m_currentExposure) * m_response;
+  }
+
+  b.exposure = m_currentExposure;
+}
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
@@ -26,19 +26,20 @@ float computeSumLogLuminance(
   // Might have to be revisited to be exhautive and still high performance.
   // https://gpuopen.com/fidelityfx-spd/ ?
   const float *hdrColor = b.hdrColor;
+  const float minLum = MIN_LUMINANCE;
   return detail::parallel_reduce(
       b.stream,
       0u,
       numSamples,
       0.f,
-      [=] DEVICE_FCN(uint32_t j) {
+      [=] HOST_DEVICE_FCN(uint32_t j) -> float {
         const uint32_t idx = j * stride * 4;
         const float lum = std::max(0.2126f * hdrColor[idx + 0]
                 + 0.7152f * hdrColor[idx + 1] + 0.0722f * hdrColor[idx + 2],
-            MIN_LUMINANCE);
+            minLum);
         return std::log2(lum);
       },
-      [] DEVICE_FCN(float a, float b) { return a + b; });
+      [] HOST_DEVICE_FCN(float a, float b) -> float { return a + b; });
 }
 
 } // namespace

--- a/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.cpp
@@ -21,9 +21,9 @@ constexpr float MID_GRAY = 0.18f;
 float computeSumLogLuminance(
     const ImageBuffers &b, uint32_t numSamples, uint32_t stride)
 {
-  // very approximate and suboptimal, going only through a handleful of samples.
+  // very approximate and suboptimal, going only through a handful of samples.
   // Good enough for now.
-  // Might have to be revisited to be exhautive and still high performance.
+  // Might have to be revisited to be exhaustive and still high performance.
   // https://gpuopen.com/fidelityfx-spd/ ?
   const float *hdrColor = b.hdrColor;
   const float minLum = MIN_LUMINANCE;

--- a/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/AutoExposurePass.h
@@ -1,0 +1,28 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ImagePass.h"
+
+namespace tsd::rendering {
+
+struct AutoExposurePass : public ImagePass
+{
+  AutoExposurePass();
+  ~AutoExposurePass() override;
+  const char *name() const override { return "Auto Exposure"; }
+
+  void setHDREnabled(bool enabled);
+  float currentExposure() const;
+
+ private:
+  void render(ImageBuffers &b, int stageId) override;
+
+  bool m_hdrEnabled{false};
+  bool m_hasExposure{false};
+  float m_currentExposure{0.f};
+  float m_response{0.15f};
+};
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/ClearBuffersPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/ClearBuffersPass.cpp
@@ -3,10 +3,14 @@
 
 #include "ClearBuffersPass.h"
 // std
-#include <algorithm>
 #include <limits>
 
-#include "detail/parallel_for.h"
+#ifdef ENABLE_CUDA
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#else
+#include <algorithm>
+#endif
 
 namespace tsd::rendering {
 
@@ -21,22 +25,25 @@ void ClearBuffersPass::setClearColor(const tsd::math::float4 &color)
 void ClearBuffersPass::render(ImageBuffers &b, int /*stageId*/)
 {
   const auto size = getDimensions();
-  const size_t totalSize = size_t(size.x) * size_t(size.y);
+  const uint32_t totalPixels = uint32_t(size.x) * uint32_t(size.y);
   const auto c = helium::cvt_color_to_uint32(m_clearColor);
-#if ENABLE_CUDA
-  thrust::fill(b.color, b.color + totalSize, c);
-  thrust::fill(b.hdrColor, b.hdrColor + totalSize * 4, 0.f);
-  thrust::fill(b.depth, b.depth + totalSize, tsd::core::math::inf);
-  thrust::fill(b.objectId, b.objectId + totalSize, ~0u);
-  thrust::fill(b.primitiveId, b.primitiveId + totalSize, ~0u);
-  thrust::fill(b.instanceId, b.instanceId + totalSize, ~0u);
+  const float inf = std::numeric_limits<float>::infinity();
+
+#ifdef ENABLE_CUDA
+  auto policy = thrust::cuda::par.on(b.stream);
+  thrust::fill(policy, b.color, b.color + totalPixels, c);
+  thrust::fill(policy, b.hdrColor, b.hdrColor + totalPixels * 4, 0.f);
+  thrust::fill(policy, b.depth, b.depth + totalPixels, inf);
+  thrust::fill(policy, b.objectId, b.objectId + totalPixels, ~0u);
+  thrust::fill(policy, b.primitiveId, b.primitiveId + totalPixels, ~0u);
+  thrust::fill(policy, b.instanceId, b.instanceId + totalPixels, ~0u);
 #else
-  std::fill(b.color, b.color + totalSize, c);
-  std::fill(b.hdrColor, b.hdrColor + totalSize * 4, 0.f);
-  std::fill(b.depth, b.depth + totalSize, tsd::core::math::inf);
-  std::fill(b.objectId, b.objectId + totalSize, ~0u);
-  std::fill(b.primitiveId, b.primitiveId + totalSize, ~0u);
-  std::fill(b.instanceId, b.instanceId + totalSize, ~0u);
+  std::fill(b.color, b.color + totalPixels, c);
+  std::fill(b.hdrColor, b.hdrColor + totalPixels * 4, 0.f);
+  std::fill(b.depth, b.depth + totalPixels, inf);
+  std::fill(b.objectId, b.objectId + totalPixels, ~0u);
+  std::fill(b.primitiveId, b.primitiveId + totalPixels, ~0u);
+  std::fill(b.instanceId, b.instanceId + totalPixels, ~0u);
 #endif
 }
 

--- a/tsd/src/tsd/rendering/pipeline/passes/ClearBuffersPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/ClearBuffersPass.cpp
@@ -25,12 +25,18 @@ void ClearBuffersPass::render(ImageBuffers &b, int /*stageId*/)
   const auto c = helium::cvt_color_to_uint32(m_clearColor);
 #if ENABLE_CUDA
   thrust::fill(b.color, b.color + totalSize, c);
+  thrust::fill(b.hdrColor, b.hdrColor + totalSize * 4, 0.f);
   thrust::fill(b.depth, b.depth + totalSize, tsd::core::math::inf);
   thrust::fill(b.objectId, b.objectId + totalSize, ~0u);
+  thrust::fill(b.primitiveId, b.primitiveId + totalSize, ~0u);
+  thrust::fill(b.instanceId, b.instanceId + totalSize, ~0u);
 #else
   std::fill(b.color, b.color + totalSize, c);
+  std::fill(b.hdrColor, b.hdrColor + totalSize * 4, 0.f);
   std::fill(b.depth, b.depth + totalSize, tsd::core::math::inf);
   std::fill(b.objectId, b.objectId + totalSize, ~0u);
+  std::fill(b.primitiveId, b.primitiveId + totalSize, ~0u);
+  std::fill(b.instanceId, b.instanceId + totalSize, ~0u);
 #endif
 }
 

--- a/tsd/src/tsd/rendering/pipeline/passes/CopyFromColorBufferPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/CopyFromColorBufferPass.cpp
@@ -4,8 +4,6 @@
 #include "CopyFromColorBufferPass.hpp"
 // tsd_core
 #include "tsd/core/Logging.hpp"
-// std
-#include <cstring>
 
 namespace tsd::rendering {
 
@@ -39,7 +37,7 @@ void CopyFromColorBufferPass::render(ImageBuffers &b, int /*stageId*/)
   }
 
   m_externalBuffer->resize(totalPixels * 4); // RGBA8
-  std::memcpy(m_externalBuffer->data(), b.color, totalPixels * 4);
+  detail::memcpy_(m_externalBuffer->data(), b.color, totalPixels * 4);
 }
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/CopyToColorBufferPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/CopyToColorBufferPass.cpp
@@ -4,8 +4,6 @@
 #include "CopyToColorBufferPass.hpp"
 // tsd_core
 #include "tsd/core/Logging.hpp"
-// std
-#include <cstring>
 
 namespace tsd::rendering {
 
@@ -39,7 +37,7 @@ void CopyToColorBufferPass::render(ImageBuffers &b, int /*stageId*/)
     return;
   }
 
-  std::memcpy(b.color, m_externalBuffer->data(), totalPixels * 4);
+  detail::memcpy_(b.color, m_externalBuffer->data(), totalPixels * 4);
 }
 
 } // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/CopyToSDLTexturePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/CopyToSDLTexturePass.h
@@ -18,6 +18,7 @@ struct CopyToSDLTexturePass : public ImagePass
 {
   CopyToSDLTexturePass(SDL_Renderer *renderer);
   ~CopyToSDLTexturePass() override;
+  const char *name() const override { return "Copy To SDL"; }
 
   SDL_Texture *getTexture() const;
 

--- a/tsd/src/tsd/rendering/pipeline/passes/ImagePass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/ImagePass.cpp
@@ -28,6 +28,11 @@ bool ImagePass::isEnabled() const
   return m_enabled;
 }
 
+const char *ImagePass::name() const
+{
+  return "ImagePass";
+}
+
 void ImagePass::updateSize()
 {
   // no-up

--- a/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
@@ -23,6 +23,8 @@ namespace tsd::rendering {
 struct ImageBuffers
 {
   uint32_t *color{nullptr};
+  float *hdrColor{nullptr};
+  float exposure{0.f};
   float *depth{nullptr};
   uint32_t *objectId{nullptr};
   uint32_t *primitiveId{nullptr};

--- a/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
@@ -50,6 +50,7 @@ struct ImagePass
 
   void setEnabled(bool enabled);
   bool isEnabled() const;
+  virtual const char *name() const;
 
   tsd::math::uint2 getDimensions() const;
 

--- a/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/ImagePass.h
@@ -12,8 +12,8 @@ namespace tsd::rendering {
 
 /*
  * POD struct holding pointers to all per-pixel output buffers (color, depth,
- * object/primitive/instance IDs, albedo, normals) shared across pipeline
- * passes.
+ * object/primitive/instance IDs, albedo, normals, hdrColor and
+ * exposure setting) shared across pipeline passes.
  *
  * Example:
  *   ImageBuffers b;

--- a/tsd/src/tsd/rendering/pipeline/passes/OutlineRenderPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/OutlineRenderPass.h
@@ -19,6 +19,7 @@ struct OutlineRenderPass : public ImagePass
 {
   OutlineRenderPass();
   ~OutlineRenderPass() override;
+  const char *name() const override { return "Outline"; }
 
   void setOutlineId(uint32_t id);
 

--- a/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.cpp
@@ -4,6 +4,7 @@
 #include "OutputTransformPass.h"
 // std
 #include <cmath>
+#include <limits>
 
 #include "detail/parallel_for.h"
 
@@ -33,7 +34,7 @@ void OutputTransformPass::setColorFormat(anari::DataType format)
 
 void OutputTransformPass::setGamma(float gamma)
 {
-  m_gamma = gamma;
+  m_gamma = std::max(gamma, 1e-6f);
 }
 
 void applyOutputTransform(ImageBuffers &b,

--- a/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.cpp
@@ -1,0 +1,77 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "OutputTransformPass.h"
+// std
+#include <cmath>
+
+#include "detail/parallel_for.h"
+
+namespace tsd::rendering {
+
+namespace {
+
+DEVICE_FCN_INLINE tsd::math::float3 linearToGamma(
+    tsd::math::float3 c, float invGamma)
+{
+  c.x = std::pow(std::clamp(c.x, 0.f, 1.f), invGamma);
+  c.y = std::pow(std::clamp(c.y, 0.f, 1.f), invGamma);
+  c.z = std::pow(std::clamp(c.z, 0.f, 1.f), invGamma);
+  return c;
+}
+
+} // namespace
+
+OutputTransformPass::OutputTransformPass() = default;
+
+OutputTransformPass::~OutputTransformPass() = default;
+
+void OutputTransformPass::setColorFormat(anari::DataType format)
+{
+  m_colorFormat = format;
+}
+
+void OutputTransformPass::setGamma(float gamma)
+{
+  m_gamma = gamma;
+}
+
+void applyOutputTransform(ImageBuffers &b,
+    uint32_t totalPixels,
+    float invGamma,
+    anari::DataType colorFormat)
+{
+  detail::parallel_for(b.stream, 0u, totalPixels, [=] DEVICE_FCN(uint32_t i) {
+    tsd::math::float4 c(0.f);
+
+    if (colorFormat == ANARI_FLOAT32_VEC4) {
+      const uint32_t idx = i * 4;
+      c.x = b.hdrColor[idx + 0];
+      c.y = b.hdrColor[idx + 1];
+      c.z = b.hdrColor[idx + 2];
+      c.w = b.hdrColor[idx + 3];
+    } else {
+      c = helium::cvt_color_to_float4(b.color[i]);
+    }
+
+    const auto encoded =
+        linearToGamma(tsd::math::float3(c.x, c.y, c.z), invGamma);
+    b.color[i] =
+        helium::cvt_color_to_uint32({encoded.x, encoded.y, encoded.z, c.w});
+  });
+}
+
+void OutputTransformPass::render(ImageBuffers &b, int stageId)
+{
+  if (stageId == 0 || m_colorFormat == ANARI_UFIXED8_RGBA_SRGB)
+    return;
+
+  const auto size = getDimensions();
+  const uint32_t totalPixels = size.x * size.y;
+  if (totalPixels == 0 || !b.color)
+    return;
+
+  applyOutputTransform(b, totalPixels, 1.f / m_gamma, m_colorFormat);
+}
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/OutputTransformPass.h
@@ -1,0 +1,32 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ImagePass.h"
+// anari
+#include <anari/frontend/anari_enums.h>
+
+namespace tsd::rendering {
+
+struct OutputTransformPass : public ImagePass
+{
+  OutputTransformPass();
+  ~OutputTransformPass() override;
+  const char *name() const override
+  {
+    return "Output Transform";
+  }
+
+  void setColorFormat(anari::DataType format);
+  void setGamma(float gamma);
+
+ protected:
+  void render(ImageBuffers &b, int stageId) override;
+
+ private:
+  anari::DataType m_colorFormat{ANARI_UFIXED8_RGBA_SRGB};
+  float m_gamma{2.2f};
+};
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/PickPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/PickPass.h
@@ -25,6 +25,7 @@ struct PickPass : public ImagePass
 
   PickPass();
   ~PickPass() override;
+  const char *name() const override { return "Pick"; }
 
   void setPickOperation(PickOpFunc &&f);
 

--- a/tsd/src/tsd/rendering/pipeline/passes/SaveToFilePass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/SaveToFilePass.cpp
@@ -47,16 +47,16 @@ void SaveToFilePass::render(ImageBuffers &b, int /*stageId*/)
     return;
   }
 
-  // Use STB's built-in vertical flip functionality for simplicity
   stbi_flip_vertically_on_write(1);
 
-  // Write PNG file (4 components = RGBA, stride = width * 4 bytes)
   int result = stbi_write_png(m_filename.c_str(),
       static_cast<int>(size.x),
       static_cast<int>(size.y),
       4, // RGBA
       b.color,
       static_cast<int>(size.x) * 4);
+
+  stbi_flip_vertically_on_write(0);
 
   if (result) {
     tsd::core::logStatus(

--- a/tsd/src/tsd/rendering/pipeline/passes/SaveToFilePass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/SaveToFilePass.h
@@ -22,6 +22,7 @@ struct SaveToFilePass : public ImagePass
 {
   SaveToFilePass();
   ~SaveToFilePass() override;
+  const char *name() const override { return "Save To File"; }
 
   void setFilename(const std::string &filename);
   const std::string &getFilename() const;

--- a/tsd/src/tsd/rendering/pipeline/passes/ToneMapPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/ToneMapPass.cpp
@@ -1,0 +1,212 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ToneMapPass.h"
+// std
+#include <cmath>
+
+#include "detail/parallel_for.h"
+
+namespace tsd::rendering {
+
+// Tonemapping operators ///////////////////////////////////////////////////////
+
+DEVICE_FCN_INLINE tsd::math::float3 max0(tsd::math::float3 c)
+{
+  return {std::max(c.x, 0.f), std::max(c.y, 0.f), std::max(c.z, 0.f)};
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 tonemapReinhard(tsd::math::float3 c)
+{
+  return c / (c + 1.f);
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 tonemapACES(tsd::math::float3 c)
+{
+  // Narkowicz 2015, "ACES Filmic Tone Mapping Curve"
+  const float a = 2.51f;
+  const float b = 0.03f;
+  const float cc = 2.43f;
+  const float d = 0.59f;
+  const float e = 0.14f;
+  return (c * (a * c + b)) / (c * (cc * c + d) + e);
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 hablePartial(tsd::math::float3 x)
+{
+  const float A = 0.15f;
+  const float B = 0.50f;
+  const float C = 0.10f;
+  const float D = 0.20f;
+  const float E = 0.02f;
+  const float F = 0.30f;
+  return ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F;
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 tonemapHable(tsd::math::float3 c)
+{
+  const float W = 11.2f;
+  auto whiteScale =
+      tsd::math::float3(1.f) / hablePartial(tsd::math::float3(W));
+  return hablePartial(c * 2.f) * whiteScale;
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 tonemapKhronosPbrNeutral(
+    tsd::math::float3 c)
+{
+  // https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral
+  const float startCompression = 0.8f - 0.04f;
+  const float desaturation = 0.15f;
+
+  float x = std::min(c.x, std::min(c.y, c.z));
+  float offset = x < 0.08f ? x - 6.25f * x * x : 0.04f;
+  c.x -= offset;
+  c.y -= offset;
+  c.z -= offset;
+
+  float peak = std::max(c.x, std::max(c.y, c.z));
+  if (peak < startCompression)
+    return c;
+
+  const float d2 = 1.f - startCompression;
+  float newPeak = 1.f - d2 * d2 / (peak + d2 - startCompression);
+  float scale = newPeak / peak;
+  c.x *= scale;
+  c.y *= scale;
+  c.z *= scale;
+
+  float g = 1.f - 1.f / (desaturation * (peak - newPeak) + 1.f);
+  c.x = c.x + (newPeak - c.x) * g;
+  c.y = c.y + (newPeak - c.y) * g;
+  c.z = c.z + (newPeak - c.z) * g;
+  return c;
+}
+
+DEVICE_FCN_INLINE tsd::math::float3 tonemapAgX(tsd::math::float3 c)
+{
+  // AgX base contrast (Troy Sobotka)
+  // Inset: linear sRGB -> AgX log-encoding space
+  tsd::math::float3 agx;
+  agx.x = 0.842479062253094f * c.x + 0.0784335999999992f * c.y
+      + 0.0792237451477643f * c.z;
+  agx.y = 0.0423282422610123f * c.x + 0.878468636469772f * c.y
+      + 0.0791661274605434f * c.z;
+  agx.z = 0.0423756549057051f * c.x + 0.0784336000000001f * c.y
+      + 0.879142973793104f * c.z;
+
+  // Log2 encoding
+  const float minEv = -12.47393f;
+  const float maxEv = 4.026069f;
+  const float range = maxEv - minEv;
+  agx.x =
+      std::clamp((std::log2(std::max(agx.x, 1e-10f)) - minEv) / range, 0.f, 1.f);
+  agx.y =
+      std::clamp((std::log2(std::max(agx.y, 1e-10f)) - minEv) / range, 0.f, 1.f);
+  agx.z =
+      std::clamp((std::log2(std::max(agx.z, 1e-10f)) - minEv) / range, 0.f, 1.f);
+
+  // 6th order polynomial approximation of AgX sigmoid
+  auto x2 = agx * agx;
+  auto x4 = x2 * x2;
+  agx = 15.5f * x4 * x2 - 40.14f * x4 * agx + 31.96f * x4
+      - 6.868f * x2 * agx + 0.4298f * x2 + 0.1191f * agx - 0.00232f;
+
+  // Outset: AgX -> linear sRGB
+  return {std::clamp(1.19687900512017f * agx.x - 0.0980208811401368f * agx.y
+              - 0.0990434085532547f * agx.z,
+              0.f, 1.f),
+      std::clamp(-0.0528968517574562f * agx.x + 1.15190312990417f * agx.y
+              - 0.0989611768448433f * agx.z,
+              0.f, 1.f),
+      std::clamp(-0.0529716355144438f * agx.x - 0.0980434800157286f * agx.y
+              + 1.15107367305587f * agx.z,
+              0.f, 1.f)};
+}
+
+// ToneMapPass definitions /////////////////////////////////////////////////////
+
+ToneMapPass::ToneMapPass() = default;
+
+ToneMapPass::~ToneMapPass() = default;
+
+void ToneMapPass::setOperator(ToneMapOperator op)
+{
+  m_operator = op;
+}
+
+void ToneMapPass::setAutoExposureEnabled(bool enabled)
+{
+  m_autoExposureEnabled = enabled;
+}
+
+void ToneMapPass::setExposure(float exposure)
+{
+  m_exposure = exposure;
+}
+
+void ToneMapPass::setHDREnabled(bool enabled)
+{
+  m_hdrEnabled = enabled;
+}
+
+namespace {
+
+void applyToneMap(ImageBuffers &b,
+    uint32_t totalPixels,
+    float exposureScale,
+    ToneMapOperator op)
+{
+  detail::parallel_for(
+      b.stream, 0u, totalPixels, [=] DEVICE_FCN(uint32_t i) {
+        const uint32_t idx = i * 4;
+        tsd::math::float3 c(
+            b.hdrColor[idx + 0], b.hdrColor[idx + 1], b.hdrColor[idx + 2]);
+        const float alpha = b.hdrColor[idx + 3];
+
+        c = c * exposureScale;
+
+        switch (op) {
+        case ToneMapOperator::NONE:
+          break;
+        case ToneMapOperator::REINHARD:
+          c = tonemapReinhard(max0(c));
+          break;
+        case ToneMapOperator::ACES:
+          c = tonemapACES(max0(c));
+          break;
+        case ToneMapOperator::HABLE:
+          c = tonemapHable(max0(c));
+          break;
+        case ToneMapOperator::KHRONOS_PBR_NEUTRAL:
+          c = tonemapKhronosPbrNeutral(max0(c));
+          break;
+        case ToneMapOperator::AGX:
+          c = tonemapAgX(max0(c));
+          break;
+        }
+
+        b.hdrColor[idx + 0] = c.x;
+        b.hdrColor[idx + 1] = c.y;
+        b.hdrColor[idx + 2] = c.z;
+        b.hdrColor[idx + 3] = alpha;
+      });
+}
+
+} // namespace
+
+void ToneMapPass::render(ImageBuffers &b, int stageId)
+{
+  if (stageId == 0 || !m_hdrEnabled)
+    return;
+
+  const auto size = getDimensions();
+  const uint32_t totalPixels = size.x * size.y;
+  if (totalPixels == 0 || !b.hdrColor)
+    return;
+
+  const float exposure =
+      (m_autoExposureEnabled ? b.exposure : 0.f) + m_exposure;
+  applyToneMap(b, totalPixels, std::exp2(exposure), m_operator);
+}
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/ToneMapPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/ToneMapPass.h
@@ -1,0 +1,44 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ImagePass.h"
+
+namespace tsd::rendering {
+
+enum class ToneMapOperator
+{
+  NONE,
+  REINHARD,
+  ACES,
+  HABLE,
+  KHRONOS_PBR_NEUTRAL,
+  AGX
+};
+
+struct ToneMapPass : public ImagePass
+{
+  ToneMapPass();
+  ~ToneMapPass() override;
+  const char *name() const override
+  {
+    return "Tone Map";
+  }
+
+  void setOperator(ToneMapOperator op);
+  void setAutoExposureEnabled(bool enabled);
+  void setExposure(float exposure);
+  void setHDREnabled(bool enabled);
+
+ protected:
+  void render(ImageBuffers &b, int stageId) override;
+
+ private:
+  ToneMapOperator m_operator{ToneMapOperator::ACES};
+  bool m_autoExposureEnabled{false};
+  float m_exposure{0.f};
+  bool m_hdrEnabled{false};
+};
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
@@ -91,8 +91,7 @@ void computeNormalImage(ImageBuffers &b, tsd::math::uint2 size)
       });
 }
 
-void computeEdgesImage(
-    ImageBuffers &b, float threshold, bool invert, tsd::math::uint2 size)
+void computeEdgesImage(ImageBuffers &b, bool invert, tsd::math::uint2 size)
 {
   detail::parallel_for(
       b.stream, 0u, uint32_t(size.x * size.y), [=] DEVICE_FCN(uint32_t i) {
@@ -164,11 +163,6 @@ void VisualizeAOVPass::setDepthRange(float minDepth, float maxDepth)
   m_maxDepth = maxDepth;
 }
 
-void VisualizeAOVPass::setEdgeThreshold(float threshold)
-{
-  m_edgeThreshold = threshold;
-}
-
 void VisualizeAOVPass::setEdgeInvert(bool invert)
 {
   m_edgeInvert = invert;
@@ -192,7 +186,7 @@ void VisualizeAOVPass::render(ImageBuffers &b, int stageId)
     computeNormalImage(b, size);
     break;
   case AOVType::EDGES:
-    computeEdgesImage(b, m_edgeThreshold, m_edgeInvert, size);
+    computeEdgesImage(b, m_edgeInvert, size);
     break;
   case AOVType::OBJECT_ID:
     computeObjectIdImage(b, size);

--- a/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.cpp
@@ -62,7 +62,7 @@ void computeDepthImage(
 {
   detail::parallel_for(
       b.stream, 0u, uint32_t(size.x * size.y), [=] DEVICE_FCN(uint32_t i) {
-        const float depth = b.depth[i];
+        const float depth = b.depth ? b.depth[i] : 0.f;
         const float range = maxDepth - minDepth;
         const float v = range > 0.f
             ? std::clamp((depth - minDepth) / range, 0.f, 1.f)

--- a/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.h
@@ -32,6 +32,7 @@ struct VisualizeAOVPass : public ImagePass
 {
   VisualizeAOVPass();
   ~VisualizeAOVPass() override;
+  const char *name() const override { return "Visualize AOV"; }
 
   void setAOVType(AOVType type);
   void setDepthRange(float minDepth, float maxDepth);

--- a/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/VisualizeAOVPass.h
@@ -32,11 +32,13 @@ struct VisualizeAOVPass : public ImagePass
 {
   VisualizeAOVPass();
   ~VisualizeAOVPass() override;
-  const char *name() const override { return "Visualize AOV"; }
+  const char *name() const override
+  {
+    return "Visualize AOV";
+  }
 
   void setAOVType(AOVType type);
   void setDepthRange(float minDepth, float maxDepth);
-  void setEdgeThreshold(float threshold);
   void setEdgeInvert(bool invert);
 
  private:
@@ -45,7 +47,6 @@ struct VisualizeAOVPass : public ImagePass
   AOVType m_aovType{AOVType::NONE};
   float m_minDepth{0.f};
   float m_maxDepth{1.f};
-  float m_edgeThreshold{0.5f};
   bool m_edgeInvert{false};
 };
 

--- a/tsd/src/tsd/rendering/pipeline/passes/detail/parallel_for.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/detail/parallel_for.h
@@ -10,13 +10,16 @@
 #include <thrust/iterator/counting_iterator.h>
 #define DEVICE_FCN __device__
 #define DEVICE_FCN_INLINE __forceinline__ __device__
+#define HOST_DEVICE_FCN __host__ __device__
 #elif defined(ENABLE_TBB)
 #include <tbb/parallel_for.h>
 #define DEVICE_FCN
 #define DEVICE_FCN_INLINE inline
+#define HOST_DEVICE_FCN
 #else
 #define DEVICE_FCN
 #define DEVICE_FCN_INLINE inline
+#define HOST_DEVICE_FCN
 #endif
 
 #include "ComputeStream.h"

--- a/tsd/src/tsd/rendering/pipeline/passes/detail/parallel_reduce.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/detail/parallel_reduce.h
@@ -1,0 +1,50 @@
+// Copyright 2024-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "parallel_for.h"
+
+#ifdef ENABLE_CUDA
+#include <thrust/transform_reduce.h>
+#elif defined(ENABLE_TBB)
+#include <tbb/parallel_reduce.h>
+#include <tbb/blocked_range.h>
+#endif
+
+namespace tsd::rendering::detail {
+
+template <typename T, typename TRANSFORM_FCN, typename REDUCE_FCN>
+inline T parallel_reduce(ComputeStream stream,
+    uint32_t start,
+    uint32_t end,
+    T init,
+    TRANSFORM_FCN &&transform,
+    REDUCE_FCN &&reduce)
+{
+#ifdef ENABLE_CUDA
+  return thrust::transform_reduce(thrust::cuda::par.on(stream),
+      thrust::make_counting_iterator(start),
+      thrust::make_counting_iterator(end),
+      transform,
+      init,
+      reduce);
+#elif defined(ENABLE_TBB)
+  return tbb::parallel_reduce(
+      tbb::blocked_range<uint32_t>(start, end),
+      init,
+      [&](const tbb::blocked_range<uint32_t> &r, T partial) {
+        for (auto i = r.begin(); i < r.end(); i++)
+          partial = reduce(partial, transform(i));
+        return partial;
+      },
+      reduce);
+#else
+  T result = init;
+  for (auto i = start; i < end; i++)
+    result = reduce(result, transform(i));
+  return result;
+#endif
+}
+
+} // namespace tsd::rendering::detail

--- a/tsd/src/tsd/ui/imgui/modals/AppSettingsDialog.cpp
+++ b/tsd/src/tsd/ui/imgui/modals/AppSettingsDialog.cpp
@@ -310,8 +310,6 @@ void AppSettingsDialog::buildUI_offlineRenderSettings()
 
   ImGui::BeginDisabled(
       ctx->offline.aov.aovType != tsd::rendering::AOVType::EDGES);
-  ImGui::DragFloat(
-      "edge threshold", &ctx->offline.aov.edgeThreshold, 0.01f, 0.f, 1.f);
   ImGui::Checkbox("invert edges", &ctx->offline.aov.edgeInvert);
   ImGui::EndDisabled();
 

--- a/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
@@ -109,6 +109,11 @@ void BaseViewport::imagePipeline_render()
   m_pipeline.render();
 }
 
+const tsd::rendering::ImagePipeline &BaseViewport::imagePipeline() const
+{
+  return m_pipeline;
+}
+
 void BaseViewport::imagePipeline_teardown()
 {
   m_pipeline.clear();

--- a/tsd/src/tsd/ui/imgui/windows/BaseViewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/BaseViewport.h
@@ -44,6 +44,7 @@ struct BaseViewport : public Window
   void imagePipeline_setDimensions(uint32_t width, uint32_t height);
   void imagePipeline_render();
   void imagePipeline_teardown();
+  const tsd::rendering::ImagePipeline &imagePipeline() const;
 
   void camera_update(bool force = false);
   void camera_setCurrent(tsd::scene::CameraAppRef c);

--- a/tsd/src/tsd/ui/imgui/windows/CameraPoses.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/CameraPoses.cpp
@@ -497,7 +497,6 @@ void CameraPoses::renderInterpolatedPath()
               pipeline->emplace_back<tsd::rendering::VisualizeAOVPass>();
           aovPass->setAOVType(config.aov.aovType);
           aovPass->setDepthRange(config.aov.depthMin, config.aov.depthMax);
-          aovPass->setEdgeThreshold(config.aov.edgeThreshold);
           aovPass->setEdgeInvert(config.aov.edgeInvert);
 
           // Enable necessary frame channels

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -478,9 +478,13 @@ void Viewport::teardownDevice()
   BaseViewport::imagePipeline_teardown();
 
   m_anariPass = nullptr;
+  m_pickPass = nullptr;
+  m_visualizeAOVPass = nullptr;
   m_autoExposurePass = nullptr;
-  m_outlinePass = nullptr;
+  m_toneMapPass = nullptr;
   m_outputTransformPass = nullptr;
+  m_outlinePass = nullptr;
+  m_axesPass = nullptr;
   m_outputPass = nullptr;
   m_saveToFilePass = nullptr;
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -904,6 +904,14 @@ void Viewport::ui_overlay()
     ImGui::Text("   ANARI: %.2fms", m_latestAnariFL);
     ImGui::Text("   (min): %.2fms", m_minFL);
     ImGui::Text("   (max): %.2fms", m_maxFL);
+
+    const auto &passTimings = m_pipeline.getPassTimings();
+    if (!passTimings.empty()) {
+      ImGui::Separator();
+      ImGui::Text("passes:");
+      for (const auto &timing : passTimings)
+        ImGui::Text("  %s: %.2fms", timing.name, timing.milliseconds);
+    }
   }
   ImGui::EndChild();
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -232,7 +232,6 @@ void Viewport::saveSettings(tsd::core::DataNode &root)
   root["visualizeAOV"] = static_cast<int>(m_visualizeAOV);
   root["depthVisualMinimum"] = m_depthVisualMinimum;
   root["depthVisualMaximum"] = m_depthVisualMaximum;
-  root["edgeThreshold"] = m_edgeThreshold;
   root["edgeInvert"] = m_edgeInvert;
   root["showAxes"] = m_showAxes;
 
@@ -261,7 +260,6 @@ void Viewport::loadSettings(tsd::core::DataNode &root)
   m_visualizeAOV = static_cast<tsd::rendering::AOVType>(aovType);
   root["depthVisualMinimum"].getValue(ANARI_FLOAT32, &m_depthVisualMinimum);
   root["depthVisualMaximum"].getValue(ANARI_FLOAT32, &m_depthVisualMaximum);
-  root["edgeThreshold"].getValue(ANARI_FLOAT32, &m_edgeThreshold);
   root["edgeInvert"].getValue(ANARI_BOOL, &m_edgeInvert);
   root["showAxes"].getValue(ANARI_BOOL, &m_showAxes);
 
@@ -388,7 +386,6 @@ void Viewport::imagePipeline_populate(tsd::rendering::ImagePipeline &p)
 
   m_visualizeAOVPass = p.emplace_back<tsd::rendering::VisualizeAOVPass>();
   m_visualizeAOVPass->setEnabled(false);
-  m_visualizeAOVPass->setEdgeThreshold(m_edgeThreshold);
   m_visualizeAOVPass->setEdgeInvert(m_edgeInvert);
 
   m_outlinePass = p.emplace_back<tsd::rendering::OutlineRenderPass>();
@@ -724,11 +721,8 @@ void Viewport::ui_menubar_Viewport()
 
       ImGui::BeginDisabled(m_visualizeAOV != tsd::rendering::AOVType::EDGES);
       bool edgeSettingsChanged = false;
-      edgeSettingsChanged |=
-          ImGui::DragFloat("Edge Threshold", &m_edgeThreshold, 0.01f, 0.f, 1.f);
       edgeSettingsChanged |= ImGui::Checkbox("Invert Edges", &m_edgeInvert);
       if (edgeSettingsChanged) {
-        m_visualizeAOVPass->setEdgeThreshold(m_edgeThreshold);
         m_visualizeAOVPass->setEdgeInvert(m_edgeInvert);
       }
       ImGui::EndDisabled();

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -234,6 +234,10 @@ void Viewport::saveSettings(tsd::core::DataNode &root)
   root["depthVisualMaximum"] = m_depthVisualMaximum;
   root["edgeInvert"] = m_edgeInvert;
   root["showAxes"] = m_showAxes;
+  root["autoExposureEnabled"] = m_autoExposureEnabled;
+  root["toneMapExposure"] = m_toneMapExposure;
+  root["toneMapGamma"] = m_toneMapGamma;
+  root["toneMapOperator"] = static_cast<int>(m_toneMapOperator);
 
   // Database Camera //
 
@@ -262,6 +266,13 @@ void Viewport::loadSettings(tsd::core::DataNode &root)
   root["depthVisualMaximum"].getValue(ANARI_FLOAT32, &m_depthVisualMaximum);
   root["edgeInvert"].getValue(ANARI_BOOL, &m_edgeInvert);
   root["showAxes"].getValue(ANARI_BOOL, &m_showAxes);
+  root["autoExposureEnabled"].getValue(ANARI_BOOL, &m_autoExposureEnabled);
+  root["toneMapExposure"].getValue(ANARI_FLOAT32, &m_toneMapExposure);
+  root["toneMapGamma"].getValue(ANARI_FLOAT32, &m_toneMapGamma);
+  int toneMapOperator = static_cast<int>(m_toneMapOperator);
+  root["toneMapOperator"].getValue(ANARI_INT32, &toneMapOperator);
+  m_toneMapOperator =
+      static_cast<tsd::rendering::ToneMapOperator>(toneMapOperator);
 
   // Database Camera //
 
@@ -384,9 +395,20 @@ void Viewport::imagePipeline_populate(tsd::rendering::ImagePipeline &p)
     m_pickPass->setEnabled(false);
   });
 
+  m_autoExposurePass = p.emplace_back<tsd::rendering::AutoExposurePass>();
+
+  m_toneMapPass = p.emplace_back<tsd::rendering::ToneMapPass>();
+  m_toneMapPass->setOperator(m_toneMapOperator);
+  m_toneMapPass->setAutoExposureEnabled(m_autoExposureEnabled);
+  m_toneMapPass->setExposure(m_toneMapExposure);
+
+  m_outputTransformPass = p.emplace_back<tsd::rendering::OutputTransformPass>();
+  m_outputTransformPass->setGamma(m_toneMapGamma);
+
   m_visualizeAOVPass = p.emplace_back<tsd::rendering::VisualizeAOVPass>();
   m_visualizeAOVPass->setEnabled(false);
   m_visualizeAOVPass->setEdgeInvert(m_edgeInvert);
+  updateDisplayPassState();
 
   m_outlinePass = p.emplace_back<tsd::rendering::OutlineRenderPass>();
 
@@ -456,7 +478,9 @@ void Viewport::teardownDevice()
   BaseViewport::imagePipeline_teardown();
 
   m_anariPass = nullptr;
+  m_autoExposurePass = nullptr;
   m_outlinePass = nullptr;
+  m_outputTransformPass = nullptr;
   m_outputPass = nullptr;
   m_saveToFilePass = nullptr;
 
@@ -544,6 +568,8 @@ void Viewport::updateImage()
 
   auto start = std::chrono::steady_clock::now();
   BaseViewport::imagePipeline_render();
+  if (m_autoExposurePass)
+    m_currentAutoExposure = m_autoExposurePass->currentExposure();
   auto end = std::chrono::steady_clock::now();
   m_latestFL = std::chrono::duration<float>(end - start).count() * 1000;
 
@@ -577,6 +603,25 @@ void Viewport::updateAxes()
       m_camera.current->parameterValueAs<tsd::math::float3>("up").value_or(
           tsd::math::float3(0.0f, 1.0f, 0.0f));
   m_axesPass->setView(axesDir, axesUp);
+}
+
+void Viewport::updateDisplayPassState()
+{
+  if (!m_toneMapPass || !m_outputTransformPass)
+    return;
+
+  const bool showBeauty = m_visualizeAOV == tsd::rendering::AOVType::NONE;
+  if (m_autoExposurePass) {
+    m_autoExposurePass->setEnabled(showBeauty && m_autoExposureEnabled);
+    m_autoExposurePass->setHDREnabled(
+        showBeauty && m_colorFormat == ANARI_FLOAT32_VEC4);
+  }
+  m_toneMapPass->setEnabled(showBeauty);
+  m_outputTransformPass->setEnabled(showBeauty);
+  m_toneMapPass->setAutoExposureEnabled(showBeauty && m_autoExposureEnabled);
+  m_toneMapPass->setHDREnabled(
+      showBeauty && m_colorFormat == ANARI_FLOAT32_VEC4);
+  m_outputTransformPass->setColorFormat(m_colorFormat);
 }
 
 void Viewport::ui_menubar()
@@ -628,6 +673,7 @@ void Viewport::ui_menubar_Viewport()
       if (format != m_colorFormat) {
         m_anariPass->setColorFormat(format);
         m_colorFormat = format;
+        updateDisplayPassState();
       }
       ImGui::Unindent(INDENT_AMOUNT);
     }
@@ -688,6 +734,7 @@ void Viewport::ui_menubar_Viewport()
         if (aov != int(m_visualizeAOV)) {
           m_visualizeAOV = static_cast<tsd::rendering::AOVType>(aov);
           m_visualizeAOVPass->setAOVType(m_visualizeAOV);
+          updateDisplayPassState();
           m_anariPass->setEnableAlbedo(
               m_visualizeAOV == tsd::rendering::AOVType::ALBEDO);
           m_anariPass->setEnableNormals(
@@ -731,6 +778,71 @@ void Viewport::ui_menubar_Viewport()
     }
 
     ImGui::Separator();
+
+    {
+      ImGui::Text("Exposure:");
+      ImGui::Indent(INDENT_AMOUNT);
+
+      ImGui::BeginDisabled(m_colorFormat != ANARI_FLOAT32_VEC4
+          || m_visualizeAOV != tsd::rendering::AOVType::NONE);
+
+      if (ImGui::Checkbox("Auto Exposure", &m_autoExposureEnabled))
+        updateDisplayPassState();
+
+      if (m_autoExposureEnabled) {
+        if (ImGui::DragFloat(
+                "Compensation", &m_toneMapExposure, 0.05f, -10.f, 10.f))
+          m_toneMapPass->setExposure(m_toneMapExposure);
+        ImGui::Text("Current EV: %.2f", m_currentAutoExposure);
+      } else if (ImGui::DragFloat(
+                     "Exposure", &m_toneMapExposure, 0.05f, -10.f, 10.f)) {
+        m_toneMapPass->setExposure(m_toneMapExposure);
+      }
+
+      ImGui::EndDisabled();
+      ImGui::Unindent(INDENT_AMOUNT);
+    }
+
+    ImGui::Separator();
+
+    {
+      ImGui::Text("Tonemapping:");
+      ImGui::Indent(INDENT_AMOUNT);
+
+      ImGui::BeginDisabled(m_colorFormat != ANARI_FLOAT32_VEC4
+          || m_visualizeAOV != tsd::rendering::AOVType::NONE);
+
+      const char *toneMapItems[] = {"None",
+          "Reinhard",
+          "ACES Filmic",
+          "Hable",
+          "Khronos PBR Neutral",
+          "AgX"};
+      if (int op = int(m_toneMapOperator); ImGui::Combo(
+              "Operator", &op, toneMapItems, IM_ARRAYSIZE(toneMapItems))) {
+        m_toneMapOperator = static_cast<tsd::rendering::ToneMapOperator>(op);
+        m_toneMapPass->setOperator(m_toneMapOperator);
+      }
+
+      ImGui::EndDisabled();
+      ImGui::Unindent(INDENT_AMOUNT);
+    }
+
+    ImGui::Separator();
+
+    {
+      ImGui::Text("Output Transform:");
+      ImGui::Indent(INDENT_AMOUNT);
+
+      ImGui::BeginDisabled(m_colorFormat == ANARI_UFIXED8_RGBA_SRGB
+          || m_visualizeAOV != tsd::rendering::AOVType::NONE);
+
+      if (ImGui::DragFloat("Gamma", &m_toneMapGamma, 0.01f, 0.1f, 5.f))
+        m_outputTransformPass->setGamma(m_toneMapGamma);
+
+      ImGui::EndDisabled();
+      ImGui::Unindent(INDENT_AMOUNT);
+    }
 
     {
       ImGui::Text("Display:");

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -905,7 +905,7 @@ void Viewport::ui_overlay()
     ImGui::Text("   (min): %.2fms", m_minFL);
     ImGui::Text("   (max): %.2fms", m_maxFL);
 
-    const auto &passTimings = m_pipeline.getPassTimings();
+    const auto &passTimings = imagePipeline().getPassTimings();
     if (!passTimings.empty()) {
       ImGui::Separator();
       ImGui::Text("passes:");

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -10,6 +10,16 @@
 // tsd_rendering
 #include "tsd/rendering/index/RenderIndex.hpp"
 #include "tsd/rendering/pipeline/ImagePipeline.h"
+#include "tsd/rendering/pipeline/passes/AnariAxesRenderPass.h"
+#include "tsd/rendering/pipeline/passes/AnariSceneRenderPass.h"
+#include "tsd/rendering/pipeline/passes/AutoExposurePass.h"
+#include "tsd/rendering/pipeline/passes/CopyToSDLTexturePass.h"
+#include "tsd/rendering/pipeline/passes/OutlineRenderPass.h"
+#include "tsd/rendering/pipeline/passes/OutputTransformPass.h"
+#include "tsd/rendering/pipeline/passes/PickPass.h"
+#include "tsd/rendering/pipeline/passes/SaveToFilePass.h"
+#include "tsd/rendering/pipeline/passes/ToneMapPass.h"
+#include "tsd/rendering/pipeline/passes/VisualizeAOVPass.h"
 #include "tsd/rendering/view/Manipulator.hpp"
 // anari
 #include <anari/frontend/anari_enums.h>
@@ -56,6 +66,7 @@ struct Viewport : public BaseViewport
   void updateFrame();
   void updateImage();
   void updateAxes();
+  void updateDisplayPassState();
 
   void ui_menubar();
   void ui_menubar_Device();
@@ -91,6 +102,13 @@ struct Viewport : public BaseViewport
   bool m_edgeInvert{false};
   anari::DataType m_colorFormat{ANARI_UFIXED8_RGBA_SRGB};
 
+  tsd::rendering::ToneMapOperator m_toneMapOperator{
+      tsd::rendering::ToneMapOperator::ACES};
+  bool m_autoExposureEnabled{false};
+  float m_toneMapExposure{0.f};
+  float m_toneMapGamma{2.2f};
+  float m_currentAutoExposure{0.f};
+
   // Picking state //
 
   bool m_selectObjectNextPick{false};
@@ -109,6 +127,9 @@ struct Viewport : public BaseViewport
   tsd::rendering::AnariSceneRenderPass *m_anariPass{nullptr};
   tsd::rendering::PickPass *m_pickPass{nullptr};
   tsd::rendering::VisualizeAOVPass *m_visualizeAOVPass{nullptr};
+  tsd::rendering::AutoExposurePass *m_autoExposurePass{nullptr};
+  tsd::rendering::ToneMapPass *m_toneMapPass{nullptr};
+  tsd::rendering::OutputTransformPass *m_outputTransformPass{nullptr};
   tsd::rendering::OutlineRenderPass *m_outlinePass{nullptr};
   tsd::rendering::AnariAxesRenderPass *m_axesPass{nullptr};
   tsd::rendering::CopyToSDLTexturePass *m_outputPass{nullptr};

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -107,7 +107,6 @@ struct Viewport : public BaseViewport
 
   // Display //
 
-  tsd::rendering::ImagePipeline m_pipeline;
   tsd::rendering::AnariSceneRenderPass *m_anariPass{nullptr};
   tsd::rendering::PickPass *m_pickPass{nullptr};
   tsd::rendering::VisualizeAOVPass *m_visualizeAOVPass{nullptr};

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -88,7 +88,6 @@ struct Viewport : public BaseViewport
   tsd::rendering::AOVType m_visualizeAOV{tsd::rendering::AOVType::NONE};
   float m_depthVisualMinimum{0.f};
   float m_depthVisualMaximum{1.f};
-  float m_edgeThreshold{0.5f};
   bool m_edgeInvert{false};
   anari::DataType m_colorFormat{ANARI_UFIXED8_RGBA_SRGB};
 


### PR DESCRIPTION
Overall ImagePipeline render passes cleanup.
Introduces three new ImagePipeline passes
- AutoExposurePass (default disable)
- ToneMappingPass (applicable only to float output only)
- OutputTransformPass (handling a possible rsgb conversion for non srgb outputs)
 
making float framebuffer output usable with proper linear-to-sRGB conversion and tone mapping operators.
