### PR TITLE
Usd load vtu

### DIFF
--- a/tsd/src/tsd/app/Context.cpp
+++ b/tsd/src/tsd/app/Context.cpp
@@ -106,6 +106,8 @@ void Context::parseCommandLine(std::vector<std::string> &args)
       importerType = tsd::io::ImporterType::VTP;
     else if (arg == "-vtu")
       importerType = tsd::io::ImporterType::VTU;
+    else if (arg == "-vtu_property")
+      this->commandLine.vtuProperty = args[++i];
     else if (arg == "-xyzdp")
       importerType = tsd::io::ImporterType::XYZDP;
     else if (arg == "-volume")
@@ -130,10 +132,17 @@ void Context::parseCommandLine(std::vector<std::string> &args)
             this->commandLine.animationLayerNames.push_back(
                 this->commandLine.currentLayerName);
           }
-          this->commandLine.currentAnimationSequence->second.push_back(arg);
+          auto file = arg;
+          if (importerType == tsd::io::ImporterType::VOLUME_ANIMATION
+              && !this->commandLine.vtuProperty.empty())
+            file += ';' + this->commandLine.vtuProperty;
+          this->commandLine.currentAnimationSequence->second.push_back(file);
         } else {
-          this->commandLine.filenames.push_back(
-              {importerType, arg + ';' + this->commandLine.currentLayerName});
+          auto file = arg + ';' + this->commandLine.currentLayerName;
+          if (importerType == tsd::io::ImporterType::VTU
+              && !this->commandLine.vtuProperty.empty())
+            file += ';' + this->commandLine.vtuProperty;
+          this->commandLine.filenames.push_back({importerType, file});
           this->commandLine.currentAnimationSequence = nullptr;
         }
       } else {

--- a/tsd/src/tsd/app/Context.h
+++ b/tsd/src/tsd/app/Context.h
@@ -36,6 +36,7 @@ struct CommandLineOptions
   tsd::io::ImporterType importerType{tsd::io::ImporterType::NONE};
   std::string cameraFile;
   std::vector<std::string> ensightFields;
+  std::string vtuProperty;
 };
 
 struct TSDState

--- a/tsd/src/tsd/io/importers.hpp
+++ b/tsd/src/tsd/io/importers.hpp
@@ -7,6 +7,7 @@
 #include "tsd/core/FlatMap.hpp"
 #include "tsd/scene/Scene.hpp"
 // std
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -81,7 +82,7 @@ void import_SWC(Scene &scene, tsd::animation::AnimationManager &animMgr, const c
 void import_TRK(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filename, LayerNodeRef location = {});
 void import_USD(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filename, LayerNodeRef location = {});
 void import_VTP(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filepath, LayerNodeRef location = {});
-void import_VTU(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filepath, LayerNodeRef location);
+void import_VTU(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filepath, LayerNodeRef location, std::optional<std::string> propertyName = std::nullopt);
 void import_XYZDP(Scene &scene, tsd::animation::AnimationManager &animMgr, const char *filename, LayerNodeRef location = {});
 
 // Spatial field importers //
@@ -89,7 +90,7 @@ void import_XYZDP(Scene &scene, tsd::animation::AnimationManager &animMgr, const
 // Dispatch to the appropriate spatial field importer based on file extension.
 // Supports: .raw, .flash/.hdf5, .nvdb, .mhd, .vtu, .silo/.sil
 // Note: .vti is not supported here; use import_volume() for VTI files.
-SpatialFieldRef import_spatial_field(Scene &scene, const char *filename);
+SpatialFieldRef import_spatial_field(Scene &scene, const char *filename, std::optional<std::string> propertyName = std::nullopt);
 
 SpatialFieldRef import_RAW(Scene &scene, const char *filename);
 SpatialFieldRef import_FLASH(Scene &scene, const char *filename);
@@ -99,7 +100,7 @@ SpatialFieldRef import_VTI(Scene &scene,
     const char *filename,
     LayerNodeRef location = {},
     std::vector<SpatialFieldRef> *extraFields = nullptr);
-SpatialFieldRef import_VTU(Scene &scene, const char *filename);
+SpatialFieldRef import_VTU(Scene &scene, const char *filename, std::optional<std::string> propertyName = std::nullopt);
 SpatialFieldRef import_SILO(Scene &scene, const char *filename);
 
 // clang-format on

--- a/tsd/src/tsd/io/importers/import_USD.cpp
+++ b/tsd/src/tsd/io/importers/import_USD.cpp
@@ -1255,6 +1255,8 @@ static void importUsdVolume(Scene &scene,
 
   // Find the field data by following field relationships
   std::vector<std::string> filePaths;
+  bool isVTUAsset = false;
+  std::optional<std::string> propertyName;
 
   // Try field:volume relationship first (for VDB volumes and OpenVDBAsset)
   pxr::UsdRelationship fieldRel =
@@ -1268,6 +1270,18 @@ static void importUsdVolume(Scene &scene,
     if (!targets.empty()) {
       pxr::UsdPrim fieldPrim = prim.GetStage()->GetPrimAtPath(targets[0]);
       if (fieldPrim) {
+        isVTUAsset = fieldPrim.GetTypeName() == "VTUAsset";
+        if (isVTUAsset) {
+          // Nullable property: unset means default.
+          // Empty means no property. else load what's requested.
+          if (auto propAttr =
+                  fieldPrim.GetAttribute(pxr::TfToken("property"))) {
+            std::string val;
+            if (propAttr.Get(&val))
+              propertyName = std::move(val);
+          }
+        }
+
         pxr::UsdAttribute filePathAttr =
             fieldPrim.GetAttribute(pxr::TfToken("filePath"));
         if (filePathAttr) {
@@ -1318,18 +1332,25 @@ static void importUsdVolume(Scene &scene,
   std::string filePath = filePaths[0];
 
   SpatialFieldRef field;
-  const auto ext = extensionOf(filePath);
-  if (ext == ".raw")
-    field = import_RAW(scene, filePath.c_str());
-  else if (ext == ".flash")
-    field = import_FLASH(scene, filePath.c_str());
-  else if (ext == ".nvdb" || ext == ".vdb")
-    field = import_NVDB(scene, filePath.c_str());
-  else if (ext == ".mhd")
-    field = import_MHD(scene, filePath.c_str());
-  else {
-    throw std::runtime_error(
-        "[import_USD] no loader for file type '" + ext + "'");
+  if (isVTUAsset) {
+    field =
+        import_spatial_field(scene, filePath.c_str(), std::move(propertyName));
+  } else {
+    const auto ext = extensionOf(filePath);
+    if (ext == ".raw")
+      field = import_RAW(scene, filePath.c_str());
+    else if (ext == ".flash")
+      field = import_FLASH(scene, filePath.c_str());
+    else if (ext == ".nvdb" || ext == ".vdb")
+      field = import_NVDB(scene, filePath.c_str());
+    else if (ext == ".mhd")
+      field = import_MHD(scene, filePath.c_str());
+    else if (ext == ".vtu")
+      field = import_VTU(scene, filePath.c_str(), propertyName);
+    else {
+      throw std::runtime_error(
+          "[import_USD] no loader for file type '" + ext + "'");
+    }
   }
 
   if (!field) {

--- a/tsd/src/tsd/io/importers/import_VTU.cpp
+++ b/tsd/src/tsd/io/importers/import_VTU.cpp
@@ -11,8 +11,6 @@
 #include "tsd/scene/algorithms/computeScalarRange.hpp"
 // std
 #include <algorithm>
-#include <array>
-#include <cstring>
 #include <set>
 #include <string_view>
 
@@ -435,10 +433,25 @@ static SpatialFieldRef createFieldFromVolumeCells(Scene &scene,
     vtkDataArray *array = cellData->GetArray(i);
     if (!array)
       continue;
+    int nComp = array->GetNumberOfComponents();
     std::string arrName = (array->GetName() && array->GetName()[0] != '\0')
         ? array->GetName()
         : baseName;
-    candidates.push_back({Source::Cell, i, -1, arrName});
+
+    if (nComp == 1) {
+      candidates.push_back({Source::Cell, i, 0, arrName});
+    } else if (nComp == 3) {
+      for (int c = 0; c < 3; ++c) {
+        const char *suffix = (c == 0) ? "_x" : (c == 1) ? "_y" : "_z";
+        candidates.push_back({Source::Cell, i, c, arrName + suffix});
+      }
+    } else {
+      logWarning(
+          "[import_VTU] cell array '%s' has %d components (only 1 or 3 are "
+          "supported) -- skipping",
+          arrName.c_str(),
+          nComp);
+    }
   }
 
   // Tri-state selection: nullopt = auto, "" = topology only, "name" = by name.

--- a/tsd/src/tsd/io/importers/import_VTU.cpp
+++ b/tsd/src/tsd/io/importers/import_VTU.cpp
@@ -9,6 +9,13 @@
 #include "tsd/io/importers.hpp"
 #include "tsd/io/importers/detail/importer_common.hpp"
 #include "tsd/scene/algorithms/computeScalarRange.hpp"
+// std
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <set>
+#include <string_view>
+
 #if TSD_USE_VTK
 // vtk
 #include <vtkCell.h>
@@ -26,6 +33,8 @@
 #include <vtkXMLUnstructuredGridReader.h>
 #endif
 
+using namespace std::string_view_literals;
+
 namespace tsd::io {
 
 #if TSD_USE_VTK
@@ -39,6 +48,28 @@ static bool isVolumeCell(int type)
 {
   return type == VTK_TETRA || type == VTK_VOXEL || type == VTK_HEXAHEDRON
       || type == VTK_WEDGE || type == VTK_PYRAMID;
+}
+
+// Bookkeeping arrays that are useless for visualization.
+// Skipped during auto-selection; honored if explicitly requested.
+static const auto metadataArrayNames = std::set{
+    "CellID"sv,
+    "NodeID"sv,
+    "GlobalElementId"sv,
+    "GlobalNodeId"sv,
+    "ObjectId"sv,
+    "RegionId"sv,
+    "vtkOriginalPointIds"sv,
+    "vtkOriginalCellIds"sv,
+    "vtkGhostType"sv,
+    "vtkValidPointMask"sv,
+};
+
+static bool isMetadataArray(const std::string_view name)
+{
+  if (name.empty())
+    return false;
+  return metadataArrayNames.count(name) != 0;
 }
 
 static vtkSmartPointer<vtkUnstructuredGrid> loadVTUGrid(const char *filepath)
@@ -65,25 +96,6 @@ static vtkSmartPointer<vtkUnstructuredGrid> loadVTUGrid(const char *filepath)
   return grid;
 }
 
-static ArrayRef makeFloatArray1D(
-    Scene &scene, vtkDataArray *array, vtkIdType count)
-{
-  int numComponents = array->GetNumberOfComponents();
-  if (numComponents > 1) {
-    logWarning(
-        "[import_VTU] only single-component arrays are supported, "
-        "array '%s' has %d components -- only using first component",
-        array->GetName(),
-        numComponents);
-  }
-  auto arr = scene.createArray(ANARI_FLOAT32, count);
-  auto *buffer = arr->mapAs<float>();
-  for (vtkIdType i = 0; i < count; ++i)
-    buffer[i] = static_cast<float>(array->GetComponent(i, 0));
-  arr->unmap();
-  return arr;
-}
-
 static bool isScalarArray(const ArrayRef &a)
 {
   if (!a)
@@ -93,21 +105,39 @@ static bool isScalarArray(const ArrayRef &a)
   return !anari::isObject(type) && anari::componentsOf(type) == 1;
 }
 
-static ArrayRef firstScalarArray(const std::vector<ArrayRef> &arrays)
+static ArrayRef firstScalarArray(
+    const std::vector<ArrayRef> &arrays, bool skipMetadata = true)
 {
   for (const auto &a : arrays) {
-    if (isScalarArray(a))
-      return a;
+    if (!isScalarArray(a))
+      continue;
+    if (skipMetadata && isMetadataArray(a->name()))
+      continue;
+    return a;
   }
 
+  // Fall back: if all scalar arrays are metadata, return the first one anyway
+  if (skipMetadata)
+    return firstScalarArray(arrays, false);
   return {};
 }
 
-// Build a triangle surface from surface cells in the grid
+static ArrayRef findArrayByName(
+    const std::vector<ArrayRef> &arrays, const std::string &name)
+{
+  for (const auto &a : arrays) {
+    if (a && a->name() == name)
+      return a;
+  }
+  return {};
+}
+
+// Build a triangle surface from surface cells in the grid.
 static void createSurfaceFromGrid(Scene &scene,
     vtkUnstructuredGrid *grid,
     const char *filepath,
-    LayerNodeRef location)
+    LayerNodeRef location,
+    const std::optional<std::string> &propertyName = std::nullopt)
 {
   auto filename = fileOf(filepath);
 
@@ -239,11 +269,26 @@ static void createSurfaceFromGrid(Scene &scene,
       tokens::material::physicallyBased);
   mat->setName(("vtu_material | " + std::string(filename)).c_str());
 
-  if (auto colorArray = firstScalarArray(vertexDataArrays); colorArray) {
-    auto colorRange = tsd::scene::computeScalarRange(*colorArray);
-    mat->setParameterObject(
-        "baseColor", *makeDefaultColorMapSampler(scene, colorRange));
-  } else if (auto colorArray = firstScalarArray(faceDataArrays); colorArray) {
+  ArrayRef colorArray;
+  if (propertyName.has_value()) {
+    if (!propertyName->empty()) {
+      colorArray = findArrayByName(vertexDataArrays, *propertyName);
+      if (!colorArray)
+        colorArray = findArrayByName(faceDataArrays, *propertyName);
+      if (!colorArray)
+        logWarning(
+            "[import_VTU] requested property '%s' not found for "
+            "colormapping, rendering without colormap",
+            propertyName->c_str());
+    }
+    // else: explicit empty -> no colormap
+  } else {
+    colorArray = firstScalarArray(vertexDataArrays);
+    if (!colorArray)
+      colorArray = firstScalarArray(faceDataArrays);
+  }
+
+  if (colorArray) {
     auto colorRange = tsd::scene::computeScalarRange(*colorArray);
     mat->setParameterObject(
         "baseColor", *makeDefaultColorMapSampler(scene, colorRange));
@@ -258,12 +303,10 @@ static void createSurfaceFromGrid(Scene &scene,
 }
 
 // Build an unstructured spatial field from volume cells only.
-// All point-data arrays are exposed as named SpatialFields sharing topology:
-//   1-component → one field named after the array
-//   3-component → three fields named {arr}_x, {arr}_y, {arr}_z
-// Returns the first SpatialField created (used for the scene volume wrapper).
-static SpatialFieldRef createFieldFromVolumeCells(
-    Scene &scene, vtkUnstructuredGrid *grid, const char *filepath)
+static SpatialFieldRef createFieldFromVolumeCells(Scene &scene,
+    vtkUnstructuredGrid *grid,
+    const char *filepath,
+    const std::optional<std::string> &propertyName = std::nullopt)
 {
   vtkIdType numCells = grid->GetNumberOfCells();
 
@@ -330,7 +373,7 @@ static SpatialFieldRef createFieldFromVolumeCells(
   cellTypesArray->setData(cellTypes.data());
 
   // Helper: create a new unstructured SpatialField with shared topology
-  auto makeTopoField = [&](const std::string &name) -> SpatialFieldRef {
+  auto makeField = [&](const std::string &name) -> SpatialFieldRef {
     auto f = scene.createObject<tsd::scene::SpatialField>(
         tokens::spatial_field::unstructured);
     f->setName(name.c_str());
@@ -341,10 +384,27 @@ static SpatialFieldRef createFieldFromVolumeCells(
     return f;
   };
 
-  // Vertex data: expose all point arrays
-  vtkPointData *pointData = grid->GetPointData();
-  SpatialFieldRef firstField;
+  // Unified scan of point and cell data arrays. The tri-state `propertyName`
+  // selects exactly one target (vertex.data XOR cell.data); binding both would
+  // leave renderers guessing which attribute to consume.
   std::string baseName = fileOf(filepath);
+
+  enum class Source
+  {
+    Point,
+    Cell,
+  };
+  struct ArrayCandidate
+  {
+    Source source;
+    int index;
+    int component; // -1 = scalar, 0/1/2 = component of a 3-vec (point only)
+    std::string name;
+  };
+  std::vector<ArrayCandidate> candidates;
+
+  vtkPointData *pointData = grid->GetPointData();
+  vtkCellData *cellData = grid->GetCellData();
 
   for (int i = 0; i < pointData->GetNumberOfArrays(); ++i) {
     vtkDataArray *array = pointData->GetArray(i);
@@ -356,77 +416,99 @@ static SpatialFieldRef createFieldFromVolumeCells(
         : baseName;
 
     if (nComp == 1) {
-      auto dataArr = scene.createArray(ANARI_FLOAT32, numPoints);
-      auto *buf = dataArr->mapAs<float>();
-      for (vtkIdType j = 0; j < numPoints; ++j)
-        buf[j] = static_cast<float>(array->GetComponent(j, 0));
-      dataArr->unmap();
-      auto f = makeTopoField(arrName);
-      f->setParameterObject("vertex.data", *dataArr);
-      if (!firstField)
-        firstField = f;
+      candidates.push_back({Source::Point, i, 0, arrName});
     } else if (nComp == 3) {
       for (int c = 0; c < 3; ++c) {
         const char *suffix = (c == 0) ? "_x" : (c == 1) ? "_y" : "_z";
-        std::string compName = arrName + suffix;
-        auto dataArr = scene.createArray(ANARI_FLOAT32, numPoints);
-        auto *buf = dataArr->mapAs<float>();
-        for (vtkIdType j = 0; j < numPoints; ++j)
-          buf[j] = static_cast<float>(array->GetComponent(j, c));
-        dataArr->unmap();
-        auto f = makeTopoField(compName);
-        f->setParameterObject("vertex.data", *dataArr);
-        if (!firstField)
-          firstField = f;
+        candidates.push_back({Source::Point, i, c, arrName + suffix});
       }
-      logStatus(
-          "[import_VTU] split 3-component array '%s' into '%s_x', '%s_y', "
-          "'%s_z'",
-          arrName.c_str(),
-          arrName.c_str(),
-          arrName.c_str(),
-          arrName.c_str());
     } else {
       logWarning(
-          "[import_VTU] array '%s' has %d components (only 1 or 3 are "
+          "[import_VTU] point array '%s' has %d components (only 1 or 3 are "
           "supported) -- skipping",
           arrName.c_str(),
           nComp);
     }
   }
 
-  // Fallback: no point arrays → create a topology-only field
-  if (!firstField)
-    firstField = makeTopoField(baseName);
-
-  // Cell data: attach first scalar array to firstField for rendering
-  vtkCellData *cellData = grid->GetCellData();
-  for (int i = 0; i < std::min(1, cellData->GetNumberOfArrays()); ++i) {
+  for (int i = 0; i < cellData->GetNumberOfArrays(); ++i) {
     vtkDataArray *array = cellData->GetArray(i);
     if (!array)
       continue;
-    auto a = makeFloatArray1D(scene, array, numCells);
-
-    // Filter to volume cells only
-    auto filtered = scene.createArray(ANARI_FLOAT32, numVolumeCells);
-    auto *src = a->mapAs<float>();
-    auto *dst = filtered->mapAs<float>();
-    for (vtkIdType j = 0; j < numVolumeCells; ++j)
-      dst[j] = src[volumeCellIndices[j]];
-    a->unmap();
-    filtered->unmap();
-
-    firstField->setParameterObject("cell.data", *filtered);
+    std::string arrName = (array->GetName() && array->GetName()[0] != '\0')
+        ? array->GetName()
+        : baseName;
+    candidates.push_back({Source::Cell, i, -1, arrName});
   }
 
-  return firstField;
+  // Tri-state selection: nullopt = auto, "" = topology only, "name" = by name.
+  const ArrayCandidate *selected = nullptr;
+
+  if (propertyName.has_value()) {
+    if (!propertyName->empty()) {
+      for (auto &c : candidates) {
+        if (c.name == *propertyName) {
+          selected = &c;
+          break;
+        }
+      }
+      if (!selected)
+        logWarning(
+            "[import_VTU] requested property '%s' not found, "
+            "loading topology only",
+            propertyName->c_str());
+    }
+    // else: explicit empty -> topology-only (selected stays null)
+  } else {
+    for (auto &c : candidates) {
+      if (!isMetadataArray(c.name)) {
+        selected = &c;
+        break;
+      }
+    }
+    if (!selected && !candidates.empty())
+      selected = &candidates[0];
+  }
+
+  // Materialize the selected candidate into exactly one of vertex.data /
+  // cell.data, or produce a topology-only field if nothing was selected.
+  SpatialFieldRef selectedField;
+
+  if (selected) {
+    selectedField = makeField(selected->name);
+
+    if (selected->source == Source::Point) {
+      vtkDataArray *array = pointData->GetArray(selected->index);
+      auto dataArr = scene.createArray(ANARI_FLOAT32, numPoints);
+      auto *buf = dataArr->mapAs<float>();
+      for (vtkIdType j = 0; j < numPoints; ++j)
+        buf[j] =
+            static_cast<float>(array->GetComponent(j, selected->component));
+      dataArr->unmap();
+      selectedField->setParameterObject("vertex.data", *dataArr);
+    } else {
+      vtkDataArray *array = cellData->GetArray(selected->index);
+      auto filtered = scene.createArray(ANARI_FLOAT32, numVolumeCells);
+      auto *dst = filtered->mapAs<float>();
+      for (vtkIdType j = 0; j < numVolumeCells; ++j)
+        dst[j] =
+            static_cast<float>(array->GetComponent(volumeCellIndices[j], 0));
+      filtered->unmap();
+      selectedField->setParameterObject("cell.data", *filtered);
+    }
+  } else {
+    selectedField = makeField(baseName);
+  }
+
+  return selectedField;
 }
 
 // Full-scene importer: surfaces + volumes
 void import_VTU(Scene &scene,
     tsd::animation::AnimationManager &animMgr,
     const char *filepath,
-    LayerNodeRef location)
+    LayerNodeRef location,
+    std::optional<std::string> propertyName)
 {
   (void)animMgr;
   auto grid = loadVTUGrid(filepath);
@@ -459,10 +541,11 @@ void import_VTU(Scene &scene,
       fileOf(filepath).c_str());
 
   if (hasSurface)
-    createSurfaceFromGrid(scene, grid, filepath, root);
+    createSurfaceFromGrid(scene, grid, filepath, root, propertyName);
 
   if (hasVolume) {
-    auto field = createFieldFromVolumeCells(scene, grid, filepath);
+    auto field =
+        createFieldFromVolumeCells(scene, grid, filepath, propertyName);
     if (field) {
       tsd::math::float2 valueRange = field->computeValueRange();
       auto [inst, volume] = scene.insertNewChildObjectNode<tsd::scene::Volume>(
@@ -477,14 +560,15 @@ void import_VTU(Scene &scene,
   }
 }
 
-// Spatial field-only importer (backward compatible, used by -volume)
-SpatialFieldRef import_VTU(Scene &scene, const char *filepath)
+// Spatial field-only importer
+SpatialFieldRef import_VTU(
+    Scene &scene, const char *filepath, std::optional<std::string> propertyName)
 {
   auto grid = loadVTUGrid(filepath);
   if (!grid)
     return {};
 
-  return createFieldFromVolumeCells(scene, grid, filepath);
+  return createFieldFromVolumeCells(scene, grid, filepath, propertyName);
 }
 
 #else
@@ -492,14 +576,18 @@ SpatialFieldRef import_VTU(Scene &scene, const char *filepath)
 void import_VTU(Scene &scene,
     tsd::animation::AnimationManager &animMgr,
     const char *filepath,
-    LayerNodeRef location)
+    LayerNodeRef location,
+    std::optional<std::string> propertyName)
 {
   (void)animMgr;
+  (void)propertyName;
   logError("[import_VTU] VTK not enabled in TSD build.");
 }
 
-SpatialFieldRef import_VTU(Scene &scene, const char *filepath)
+SpatialFieldRef import_VTU(
+    Scene &scene, const char *filepath, std::optional<std::string> propertyName)
 {
+  (void)propertyName;
   logError("[import_VTU] VTK not enabled in TSD build.");
   return {};
 }

--- a/tsd/src/tsd/io/importers/import_file.cpp
+++ b/tsd/src/tsd/io/importers/import_file.cpp
@@ -88,8 +88,12 @@ void import_file(Scene &scene,
     tsd::io::import_USD(scene, animMgr, file.c_str(), root);
   else if (f.first == ImporterType::VTP)
     tsd::io::import_VTP(scene, animMgr, file.c_str(), root);
-  else if (f.first == ImporterType::VTU)
-    tsd::io::import_VTU(scene, animMgr, file.c_str(), root);
+  else if (f.first == ImporterType::VTU) {
+    std::optional<std::string> prop;
+    if (files.size() > 2 && !files[2].empty())
+      prop = files[2];
+    tsd::io::import_VTU(scene, animMgr, file.c_str(), root, std::move(prop));
+  }
   else if (f.first == ImporterType::XYZDP)
     tsd::io::import_XYZDP(scene, animMgr, file.c_str(), root);
   else if (f.first == ImporterType::VOLUME)

--- a/tsd/src/tsd/io/importers/import_volume.cpp
+++ b/tsd/src/tsd/io/importers/import_volume.cpp
@@ -52,21 +52,31 @@ void applyTransferFunction(Scene &scene,
 
 // import_volume definitions //////////////////////////////////////////////////
 
-SpatialFieldRef import_spatial_field(Scene &scene, const char *filepath)
+SpatialFieldRef import_spatial_field(
+    Scene &scene, const char *filepath, std::optional<std::string> propertyName)
 {
-  auto ext = extensionOf(filepath);
+  // filepath may carry a ';property' suffix (CLI-encoded for animation
+  // frames). Split it off; the arg-supplied propertyName wins if given.
+  std::string file = filepath;
+  if (auto sep = file.find(';'); sep != std::string::npos) {
+    if (!propertyName)
+      propertyName = file.substr(sep + 1);
+    file.resize(sep);
+  }
+
+  auto ext = extensionOf(file.c_str());
   if (ext == ".raw")
-    return import_RAW(scene, filepath);
+    return import_RAW(scene, file.c_str());
   else if (ext == ".flash" || ext == ".hdf5")
-    return import_FLASH(scene, filepath);
+    return import_FLASH(scene, file.c_str());
   else if (ext == ".nvdb")
-    return import_NVDB(scene, filepath);
+    return import_NVDB(scene, file.c_str());
   else if (ext == ".mhd")
-    return import_MHD(scene, filepath);
+    return import_MHD(scene, file.c_str());
   else if (ext == ".vtu")
-    return import_VTU(scene, filepath);
+    return import_VTU(scene, file.c_str(), std::move(propertyName));
   else if (ext == ".silo" || ext == ".sil")
-    return import_SILO(scene, filepath);
+    return import_SILO(scene, file.c_str());
   else {
     logError(
         "[import_spatial_field] no loader for file type '%s'", ext.c_str());


### PR DESCRIPTION
Improve the `VTU` importer so that:
- The property to load on the mesh can be specified (CLI parameter `-vtu_property`)
- It defaults to ignoring grid metadata (CellID, NodeID...) as property, unless explicitly requested. Instead, it loads the first non metadata scalarfield to `vertex.data`/`cell.data`

The USD importer now supports a non standard `VTUAsset` (sibling to `OpenVDBAsset` and `Field3DAsset`) to trigger VTU import from a USD description.

Animation cleanup is done at the beginning of next frame (instead of happening at the time the new resources are set), as some resources might still be used by the in-flight frame.
Solves a crash when animation unstructured volumes with Barney where raw pointers are cascading from TSD's scene to its RenderIndex and then Barney's own descriptors.