### PR TITLE
Fix bg interaction with interactive renderer

### DIFF
--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -716,8 +716,9 @@ struct RendererGPUData
   float occlusionDistance;
   bool cullTriangleBF;
   bool premultiplyBackground;
-  bool tonemap; // enable internal tonemapping during sample accumulation
-  glm::vec4 cutPlane; // cutting plane (nx,ny,nz,d); disabled when all zero (GPU default)
+  bool fireflyFilter; // enable internal tonemapping during sample accumulation
+  glm::vec4 cutPlane; // cutting plane (nx,ny,nz,d); disabled when all zero (GPU
+                      // default)
 };
 
 // Frame //

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -301,11 +301,11 @@ VISRTX_DEVICE vec4 getBackgroundImage(
       : make_vec4(tex2D<::float4>(rd.background.texobj, loc.x, loc.y));
 }
 
-VISRTX_DEVICE vec4 getBackground(
-    const FrameGPUData &fd, const vec2 &loc, const vec3 &rayDir)
+VISRTX_DEVICE bool getBackgroundLight(
+    const FrameGPUData &fd, const vec3 &rayDir, vec3 &outRadiance)
 {
   // Accumulate contributions from all visible HDRI lights
-  vec3 hdriContribution = vec3(0.f);
+  outRadiance = vec3(0.f);
   bool hasVisibleHDRI = false;
 
   for (size_t i = 0; i < fd.world.numHdriLightInstances; i++) {
@@ -316,11 +316,19 @@ VISRTX_DEVICE vec4 getBackground(
       // For orthonormal matrices, inverse = transpose
       const mat3 xfmInv = glm::transpose(mat3(hdriLight.xfm));
       const vec3 localRayDir = xfmInv * rayDir;
-      hdriContribution += sampleHDRI(light, localRayDir);
+      outRadiance += sampleHDRI(light, localRayDir);
       hasVisibleHDRI = true;
     }
   }
 
+  return hasVisibleHDRI;
+}
+
+VISRTX_DEVICE vec4 getBackground(
+    const FrameGPUData &fd, const vec2 &loc, const vec3 &rayDir)
+{
+  vec3 hdriContribution;
+  const bool hasVisibleHDRI = getBackgroundLight(fd, rayDir, hdriContribution);
   if (hasVisibleHDRI)
     return vec4(hdriContribution, 1.f);
 

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -454,7 +454,7 @@ VISRTX_DEVICE void accumPixelSample(const FrameGPUData &frame,
   const auto frameID = fb.frameID + frameIDOffset;
 
   // Conditionally apply tonemapping during accumulation
-  if (frame.renderer.tonemap)
+  if (frame.renderer.fireflyFilter)
     detail::accumValue(
         fb.buffers.colorAccumulation, idx, detail::tonemap(color));
   else
@@ -466,7 +466,7 @@ VISRTX_DEVICE void accumPixelSample(const FrameGPUData &frame,
   // Conditionally apply inverse tonemapping on output
   const float frameDivisor = float(fb.frameID + frameIDOffset + 1);
   const auto normalizedColor = accumColor / frameDivisor;
-  const auto outputColor = frame.renderer.tonemap
+  const auto outputColor = frame.renderer.fireflyFilter
       ? detail::inverseTonemap(normalizedColor)
       : normalizedColor;
 

--- a/devices/rtx/device/renderer/Interactive_ptx.cu
+++ b/devices/rtx/device/renderer/Interactive_ptx.cu
@@ -150,10 +150,9 @@ struct InteractiveShadingPolicy
             * rendererParams.ambientColor * rendererParams.ambientIntensity;
         contrib += color * nextRay.contributionWeight;
       } else {
-        // No hit, get background contribution directly (no surface to weight
-        // against)
-        const auto color = getBackground(frameData, ss.screen, bounceRay.dir);
-        contrib += vec3(color) * nextRay.contributionWeight;
+        if (vec3 hdri; getBackgroundLight(frameData, bounceRay.dir, hdri)) {
+          contrib += vec3(hdri) * nextRay.contributionWeight;
+        }
       }
     }
 

--- a/devices/rtx/device/renderer/Renderer.cpp
+++ b/devices/rtx/device/renderer/Renderer.cpp
@@ -164,7 +164,8 @@ void Renderer::commitParameters()
       (denoiseMode == "colorAlbedo" || denoiseMode == "colorAlbedoNormal");
   m_denoiseNormal = (denoiseMode == "colorAlbedoNormal");
 
-  m_tonemap = getParam<bool>("tonemap", true);
+  m_fireflyFilter =
+      getParam<bool>("fireflyFilter", getParam<bool>("tonemap", true));
   m_sampleLimit = getParam<int>("sampleLimit", 128);
   m_cullTriangleBF = getParam<bool>("cullTriangleBackfaces", false);
   m_volumeSamplingRate =
@@ -207,7 +208,7 @@ void Renderer::populateFrameData(FrameGPUData &fd) const
   fd.renderer.ambientIntensity = m_ambientIntensity;
   fd.renderer.occlusionDistance = m_occlusionDistance;
   fd.renderer.cullTriangleBF = m_cullTriangleBF;
-  fd.renderer.tonemap = m_tonemap;
+  fd.renderer.fireflyFilter = m_fireflyFilter;
   fd.renderer.inverseVolumeSamplingRate = 1.f / m_volumeSamplingRate;
   fd.renderer.numIterations = std::max(m_spp, 1);
   fd.renderer.premultiplyBackground = m_premultiplyBackground;
@@ -951,9 +952,9 @@ void Renderer::cleanup()
   }
 }
 
-bool Renderer::tonemap() const
+bool Renderer::filterFireflies() const
 {
-  return m_tonemap;
+  return m_fireflyFilter;
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/renderer/Renderer.h
+++ b/devices/rtx/device/renderer/Renderer.h
@@ -74,7 +74,7 @@ struct Renderer : public Object
   bool denoise() const;
   bool denoiseUsingAlbedo() const;
   bool denoiseUsingNormal() const;
-  bool tonemap() const;
+  bool filterFireflies() const;
   int sampleLimit() const;
 
   static Renderer *createInstance(
@@ -90,7 +90,7 @@ struct Renderer : public Object
   bool m_denoise{false};
   bool m_denoiseAlbedo{false};
   bool m_denoiseNormal{false};
-  bool m_tonemap{
+  bool m_fireflyFilter{
       true}; // enable internal tonemapping during sample accumulation
   int m_sampleLimit{0};
   bool m_cullTriangleBF{false};

--- a/devices/rtx/device/visrtx_device.json
+++ b/devices/rtx/device/visrtx_device.json
@@ -96,13 +96,13 @@
           "description": "mode controlling buffers given to the denoiser"
         },
         {
-          "name": "tonemap",
+          "name": "fireflyFilter",
           "types": [
             "ANARI_BOOL"
           ],
           "tags": [],
           "default": true,
-          "description": "enable internal tonemapping during sample accumulation"
+          "description": "suppress fireflies via reversible tonemapping before accumulation"
         },
         {
           "name": "premultiplyBackground",
@@ -200,7 +200,12 @@
             "ANARI_FLOAT32_VEC4"
           ],
           "tags": [],
-          "default": [0.0, 0.0, 0.0, 0.0],
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            0.0
+          ],
           "description": "cutting plane equation (nx, ny, nz, d); disabled when all zero (vec4(0))"
         }
       ]
@@ -221,7 +226,9 @@
         },
         {
           "name": "fixedAmbientLighting",
-          "types": ["ANARI_BOOL"],
+          "types": [
+            "ANARI_BOOL"
+          ],
           "tags": [],
           "default": true,
           "description": "ignore 'ambientRaidance' and 'ambientColor' parameters on the renderer"
@@ -250,13 +257,13 @@
           "description": "mode controlling buffers given to the denoiser"
         },
         {
-          "name": "tonemap",
+          "name": "fireflyFilter",
           "types": [
             "ANARI_BOOL"
           ],
           "tags": [],
           "default": true,
-          "description": "enable internal tonemapping during sample accumulation"
+          "description": "suppress fireflies via reversible tonemapping before accumulation"
         },
         {
           "name": "premultiplyBackground",
@@ -343,7 +350,12 @@
             "ANARI_FLOAT32_VEC4"
           ],
           "tags": [],
-          "default": [0.0, 0.0, 0.0, 0.0],
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            0.0
+          ],
           "description": "cutting plane equation (nx, ny, nz, d); disabled when all zero (vec4(0))"
         }
       ]
@@ -386,13 +398,13 @@
           "description": "mode controlling buffers given to the denoiser"
         },
         {
-          "name": "tonemap",
+          "name": "fireflyFilter",
           "types": [
             "ANARI_BOOL"
           ],
           "tags": [],
           "default": true,
-          "description": "enable internal tonemapping during sample accumulation"
+          "description": "suppress fireflies via reversible tonemapping before accumulation"
         },
         {
           "name": "cullTriangleBackfaces",
@@ -438,7 +450,12 @@
             "ANARI_FLOAT32_VEC4"
           ],
           "tags": [],
-          "default": [0.0, 0.0, 0.0, 0.0],
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            0.0
+          ],
           "description": "cutting plane equation (nx, ny, nz, d); disabled when all zero (vec4(0))"
         }
       ]
@@ -489,7 +506,12 @@
             "ANARI_FLOAT32_VEC4"
           ],
           "tags": [],
-          "default": [0.0, 0.0, 0.0, 0.0],
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            0.0
+          ],
           "description": "cutting plane equation (nx, ny, nz, d); disabled when all zero (vec4(0))"
         }
       ]


### PR DESCRIPTION
- Fix background color or image leaking into the lighting computation.
- Rename `tonemap` to `fireflyFilter`. Even if using tonemapper internally, the former name was misleading when considering an actual tonemapping stages as TSD now has.