### PR TITLE
Volume correctness

### DIFF
--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -419,7 +419,11 @@ struct UniformGridData
   ivec3 dims;
   box3 worldBounds;
   box1 *valueRanges; // min/max ranges
-  float *maxOpacities; // used for adaptive sampling/space skipping
+  // Per-cell α bounds over the TF lookup (linear-filter footprint, both
+  // conservative). Min = control-variate lower bound for decomposition
+  // tracking; max = Woodcock majorant. Invariant: min ≤ max.
+  float *minOpacities;
+  float *maxOpacities;
 };
 
 struct StructuredRegularData

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -417,13 +417,10 @@ struct SurfaceGPUData
 struct UniformGridData
 {
   ivec3 dims;
-  box3 worldBounds;
-  box1 *valueRanges; // min/max ranges
-  // Per-cell α bounds over the TF lookup (linear-filter footprint, both
-  // conservative). Min = control-variate lower bound for decomposition
-  // tracking; max = Woodcock majorant. Invariant: min ≤ max.
-  float *minOpacities;
-  float *maxOpacities;
+  box3 objectBounds;
+  box1 *valueRanges; // data min/max ranges
+  float *minOpacities; // matching tf opacity minima
+  float *maxOpacities; // matching tf opacity maxima
 };
 
 struct StructuredRegularData

--- a/devices/rtx/device/gpu/renderer/raygen_helpers.h
+++ b/devices/rtx/device/gpu/renderer/raygen_helpers.h
@@ -41,9 +41,11 @@
 
 namespace visrtx {
 
-// Compute surface attenuation for shadow/occlusion rays
-// Uses the standard SHADOW ray type for consistency across all renderers
-VISRTX_DEVICE float surfaceAttenuation(ScreenSample &ss, const Ray &r)
+// Surface SHADOW ray → accumulated opacity (0 = unblocked, 1 = blocked).
+// Float payload init 0, accumulateValue(o, α, o) in __anyhit__shadow. The
+// path-tracing renderer uses vec3 transmittance instead — see
+// shadowTransmittance.h.
+VISRTX_DEVICE float surfaceShadowOpacity(ScreenSample &ss, const Ray &r)
 {
   float a = 0.0f;
   intersectSurface(
@@ -51,14 +53,13 @@ VISRTX_DEVICE float surfaceAttenuation(ScreenSample &ss, const Ray &r)
   return a;
 }
 
-// Compute volume attenuation for shadow rays
-// Uses the standard SHADOW ray type for consistency across all renderers
-VISRTX_DEVICE float volumeAttenuation(ScreenSample &ss, const Ray &r)
+// Volume SHADOW ray opacity. Same payload convention as surfaceShadowOpacity.
+VISRTX_DEVICE float volumeShadowOpacity(ScreenSample &ss, const Ray &r)
 {
-  float attenuation = 0.0f;
+  float a = 0.0f;
   intersectVolume(
-      ss, r, RayType::SHADOW, &attenuation, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
-  return attenuation;
+      ss, r, RayType::SHADOW, &a, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
+  return a;
 }
 
 // Templated rendering loop

--- a/devices/rtx/device/gpu/renderer/shadowTransmittance.h
+++ b/devices/rtx/device/gpu/renderer/shadowTransmittance.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,33 +32,37 @@
 #pragma once
 
 #include "gpu/intersectRay.h"
+#include "gpu/renderer/common.h" // RayType
+
+// Shadow-ray transmittance for path tracers. Returns vec3 transmittance
+// (1 = unblocked, 0 = blocked); composes multiplicatively. Payload is vec3
+// init vec3(1.0f); pair with the vec3 __anyhit__shadow program.
+//
+// Opacity-over renderers use raygen_helpers.h's float variants instead — the
+// conventions are not interchangeable without swapping anyhit programs.
 
 namespace visrtx {
 
-VISRTX_DEVICE float computeAO(ScreenSample &ss,
-    const Ray &primaryRay,
-    const Hit &currentHit,
-    float dist,
-    int numSamples,
-    float (*surfaceShadowOpacity)(ScreenSample &, const Ray &))
+VISRTX_DEVICE vec3 surfaceShadowTransmittance(ScreenSample &ss, const Ray &r)
 {
-  float weights = 0.0f;
-  float hits = 0.0f;
-  Ray aoRay;
-  aoRay.org = shadingHitpoint(currentHit) + currentHit.Ng * currentHit.epsilon;
-  aoRay.t.lower = currentHit.epsilon;
-  aoRay.t.upper = dist;
+  vec3 transmittance = vec3(1.0f);
+  intersectSurface(ss,
+      r,
+      RayType::SHADOW,
+      &transmittance,
+      OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
+  return transmittance;
+}
 
-  for (int i = 0; i < numSamples; i++) {
-    aoRay.dir = randomDir(ss.rs, currentHit.Ns);
-    float weight = max(0.f, dot(aoRay.dir, currentHit.Ns));
-    if (weight > 1e-8f) {
-      weights += weight;
-      hits += weight * surfaceShadowOpacity(ss, aoRay);
-    }
-  }
-
-  return weights > 0.f ? (1.f - hits / weights) : 0.f;
+VISRTX_DEVICE vec3 volumeShadowTransmittance(ScreenSample &ss, const Ray &r)
+{
+  vec3 transmittance = vec3(1.0f);
+  intersectVolume(ss,
+      r,
+      RayType::SHADOW,
+      &transmittance,
+      OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
+  return transmittance;
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/gpu/uniformGrid.h
+++ b/devices/rtx/device/gpu/uniformGrid.h
@@ -42,10 +42,9 @@ VISRTX_DEVICE size_t linearIndex(const ivec3 index, const ivec3 dims)
 }
 
 VISRTX_DEVICE ivec3 projectOnGrid(
-    const vec3 V, const ivec3 dims, const box3 worldBounds)
+    const vec3 V, const ivec3 dims, const box3 bounds)
 {
-  const vec3 V01 =
-      (V - worldBounds.lower) / (worldBounds.upper - worldBounds.lower);
+  const vec3 V01 = (V - bounds.lower) / (bounds.upper - bounds.lower);
   return glm::clamp(ivec3(V01 * vec3(dims)), ivec3(0), dims - ivec3(1));
 }
 

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -209,6 +209,11 @@ VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
   return depth;
 }
 
+// Decomposition tracking (Kutz/Thiery/Novák/Iwasaki 2017). Per cell split
+// σ_t = σ_c + σ_r (σ_c = per-cell min, σ_r ∈ [0, σ_maj - σ_c]). Race a
+// closed-form Exp(σ_c) flight against a Woodcock walk on σ_r; first event
+// wins. Albedo/extinction use local σ_t at the event point. σ_c = 0 →
+// plain delta tracking; σ_r = 0 → analytic flight only.
 VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
     const VolumeHit &hit,
     vec3 &albedo,
@@ -237,41 +242,69 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
 
   GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
   while (trav.valid()) {
+    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
     const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
-    const float majorantExtinction =
+    const float σ_min =
+        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+    const float σ_maj =
         opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
 
-    if (majorantExtinction > 0.f) {
-      constexpr int MAX_WOODCOCK_STEPS_PER_CELL = 128;
-      int steps = 0;
-      float t = trav.tEntry;
-      while (t < trav.tExit) {
-        if (++steps > MAX_WOODCOCK_STEPS_PER_CELL)
-          break;
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
-            / majorantExtinction;
+    if (σ_maj <= 0.f) {
+      trav.next();
+      continue;
+    }
 
-        if (t >= trav.tExit)
+    // Closed-form control free-flight starting at trav.tEntry.
+    const float t_control = σ_min > 0.f
+        ? trav.tEntry
+            - logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_min
+        : std::numeric_limits<float>::infinity();
+    const float residualCutoff = fminf(t_control, trav.tExit);
+
+    float t = trav.tEntry;
+    if (σ_residual > 0.f) {
+      while (t < residualCutoff) {
+        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_residual;
+        if (t >= residualCutoff)
           break;
 
         const vec3 p = objRay.org + objRay.dir * t;
         const float s = volumeSamplerSample(&samplerState, field, p);
+        if (glm::isnan(s))
+          continue;
 
-        if (!glm::isnan(s)) {
-          const vec4 co = detail::classifySample(volume, s);
-          const float actualExtinction =
-              opacityToExtinction(co.w, svv.oneOverUnitDistance);
-          if (actualExtinction > 0.f
-              && actualExtinction
-                  >= curand_uniform(&ss.rs) * majorantExtinction) {
-            albedo = vec3(co);
-            extinction = actualExtinction;
-            didScatter = true;
-            scatterPos = p;
-            scatterT = t;
-            break;
-          }
+        const vec4 co = detail::classifySample(volume, s);
+        const float σ_t_p =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        // σ_t_p ≥ σ_min by construction; residual at p is σ_t_p - σ_min.
+        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
+        if (σ_r_p >= curand_uniform(&ss.rs) * σ_residual) {
+          albedo = vec3(co);
+          extinction = σ_t_p;
+          didScatter = true;
+          scatterPos = p;
+          scatterT = t;
+          break;
         }
+      }
+    }
+
+    // If the residual walk didn't fire, accept the control flight if it
+    // landed inside the cell. Every control event is real (σ_min is a lower
+    // bound on σ_t).
+    if (!didScatter && t_control < trav.tExit) {
+      const vec3 p = objRay.org + objRay.dir * t_control;
+      const float s = volumeSamplerSample(&samplerState, field, p);
+      if (!glm::isnan(s)) {
+        const vec4 co = detail::classifySample(volume, s);
+        const float σ_t_p =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        albedo = vec3(co);
+        extinction = σ_t_p;
+        didScatter = true;
+        scatterPos = p;
+        scatterT = t_control;
       }
     }
 
@@ -288,12 +321,10 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
   return scatterT;
 }
 
-// Unbiased ratio-tracking transmittance estimator over one volume segment.
-// At each Woodcock candidate, multiply attenuation by (1 - sigma_t / sigma_maj)
-// rather than terminating on a "real" event. Across multiple any-hit
-// invocations on adjacent volume AABBs, OptiX composes the per-segment
-// estimates multiplicatively via the shared payload, so this is the right
-// primitive to call from __anyhit__shadow.
+// Residual ratio tracking (Novák et al. 2014). Per cell split σ_t = σ_c +
+// σ_r; fold exp(-σ_c · L) into attenuation closed-form, then ratio-track
+// σ_r at majorant σ_r_maj = σ_maj - σ_c (multiply by (1 - σ_r / σ_r_maj)
+// per candidate). Tighter than plain ratio tracking when σ_c > 0.
 VISRTX_DEVICE void ratioTrackTransmittance(
     ScreenSample &ss, const VolumeHit &hit, vec3 &attenuation)
 {
@@ -314,15 +345,35 @@ VISRTX_DEVICE void ratioTrackTransmittance(
 
   GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
   while (trav.valid()) {
+    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
     const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
-    const float majorantExtinction =
+    const float σ_min =
+        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+    const float σ_maj =
         opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
 
-    if (majorantExtinction > 0.f) {
+    if (σ_maj <= 0.f) {
+      trav.next();
+      continue;
+    }
+
+    // Closed-form control factor exp(-σ_min · cell-length) folded into
+    // attenuation. No ratio walk needed for this component.
+    const float cellLength = fmaxf(0.f, trav.tExit - trav.tEntry);
+    if (σ_min > 0.f) {
+      attenuation *= __expf(-σ_min * cellLength);
+      if (glm::all(
+              glm::lessThanEqual(attenuation, vec3(TRANSMITTANCE_EPSILON))))
+        return;
+    }
+
+    // Ratio-track the residual. Note σ_residual can be zero (uniform cell),
+    // in which case the control factor is the complete answer.
+    if (σ_residual > 0.f) {
       float t = trav.tEntry;
       while (true) {
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
-            / majorantExtinction;
+        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_residual;
         if (t >= trav.tExit)
           break;
 
@@ -332,10 +383,10 @@ VISRTX_DEVICE void ratioTrackTransmittance(
           continue;
 
         const vec4 co = classifySample(volume, s);
-        const float actualExtinction =
+        const float σ_t_p =
             opacityToExtinction(co.w, svv.oneOverUnitDistance);
-        const float ratio =
-            glm::clamp(actualExtinction / majorantExtinction, 0.f, 1.f);
+        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
+        const float ratio = glm::clamp(σ_r_p / σ_residual, 0.f, 1.f);
         attenuation *= (1.0f - ratio);
 
         if (glm::all(

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -154,54 +154,80 @@ VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
   auto &svv = volume.data.tf1d;
   auto &field = getSpatialFieldData(*ss.frameData, svv.field);
 
-  VolumeSamplingState samplerState;
-  volumeSamplerInit(&samplerState, field);
-
   // The local ray direction is actually accounting for instance scaling
   // transformation, meaning it's not a unit vector.
   // We need to use that to compensate our step size.
   const float localDirLen = glm::length(hit.localRay.dir);
   const float localStep = volume.stepSize * invSamplingRate;
+  if (localStep <= 0.f || localDirLen <= 0.f)
+    return std::numeric_limits<float>::max();
   const float dt = localStep / localDirLen;
   const float exponent = dt * svv.oneOverUnitDistance;
-  if (localStep <= 0.f)
+
+  const Ray objRay = hit.localRay;
+  if (!(objRay.t.lower < objRay.t.upper))
     return std::numeric_limits<float>::max();
 
-  box1 interval = hit.localRay.t;
-  interval.lower +=
-      curand_uniform(&ss.rs) * min(dt, interval.upper - interval.lower);
+  VolumeSamplingState samplerState;
+  volumeSamplerInit(&samplerState, field);
 
   float depth = std::numeric_limits<float>::max();
 
   constexpr float MIN_OPACITY_THRESHOLD = 1e-2f;
   constexpr float MAX_OPACITY_THRESHOLD = 0.99f;
-  while (opacity < MAX_OPACITY_THRESHOLD && size(interval) >= 0.f) {
-    const vec3 p = hit.localRay.org + hit.localRay.dir * interval.lower;
 
-    const float s = volumeSamplerSample(&samplerState, field, p);
-    if (!glm::isnan(s)) {
-      const vec4 co = classifySample(volume, s);
+  const float jitter =
+      curand_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
+  float nextSampleT = objRay.t.lower + jitter;
 
-      const float stepAlpha = 1.0f - glm::pow(1.0f - co.w, exponent);
-      if (stepAlpha > 0.0f) {
-        const float weight = (1.0f - opacity);
-        if (color)
-          *color += weight * stepAlpha * vec3(co);
-        opacity += weight * stepAlpha;
+  GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
+  while (trav.valid()) {
+    if (opacity >= MAX_OPACITY_THRESHOLD)
+      break;
 
-        if (opacity > MIN_OPACITY_THRESHOLD
-            && depth == std::numeric_limits<float>::max())
-          depth = interval.lower;
-      }
+    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    if (maxOpacity <= 0.f) {
+      trav.next();
+      continue;
     }
 
-    interval.lower += dt;
+    // Snap lattice to first sample inside the cell.
+    if (nextSampleT < trav.tEntry) {
+      const float advance = ceilf((trav.tEntry - nextSampleT) / dt);
+      nextSampleT += advance * dt;
+    }
+
+    while (nextSampleT < trav.tExit) {
+      if (opacity >= MAX_OPACITY_THRESHOLD)
+        break;
+      const vec3 p = objRay.org + objRay.dir * nextSampleT;
+
+      const float s = volumeSamplerSample(&samplerState, field, p);
+      if (!glm::isnan(s)) {
+        const vec4 co = classifySample(volume, s);
+
+        const float stepAlpha = 1.0f - glm::pow(1.0f - co.w, exponent);
+        if (stepAlpha > 0.0f) {
+          const float weight = (1.0f - opacity);
+          if (color)
+            *color += weight * stepAlpha * vec3(co);
+          opacity += weight * stepAlpha;
+
+          if (opacity > MIN_OPACITY_THRESHOLD
+              && depth == std::numeric_limits<float>::max())
+            depth = nextSampleT;
+        }
+      }
+
+      nextSampleT += dt;
+    }
+    trav.next();
   }
 
   if (normal) {
     *normal = vec3(0.f);
     if (depth < std::numeric_limits<float>::max()) {
-      const vec3 p = hit.localRay.org + hit.localRay.dir * depth;
+      const vec3 p = objRay.org + objRay.dir * depth;
       *normal = computeWorldNormal(&samplerState, field, p, hit.worldToObject);
     }
   }
@@ -275,8 +301,7 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
           continue;
 
         const vec4 co = detail::classifySample(volume, s);
-        const float σ_t_p =
-            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
         // σ_t_p ≥ σ_min by construction; residual at p is σ_t_p - σ_min.
         const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
         if (σ_r_p >= curand_uniform(&ss.rs) * σ_residual) {
@@ -298,8 +323,7 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
       const float s = volumeSamplerSample(&samplerState, field, p);
       if (!glm::isnan(s)) {
         const vec4 co = detail::classifySample(volume, s);
-        const float σ_t_p =
-            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
         albedo = vec3(co);
         extinction = σ_t_p;
         didScatter = true;
@@ -337,8 +361,7 @@ VISRTX_DEVICE void ratioTrackTransmittance(
     return;
 
   // Match Quality_ptx.cu's ATTENUATION_EPSILON.
-  constexpr float TRANSMITTANCE_EPSILON =
-      std::numeric_limits<float>::epsilon();
+  constexpr float TRANSMITTANCE_EPSILON = std::numeric_limits<float>::epsilon();
 
   VolumeSamplingState samplerState;
   volumeSamplerInit(&samplerState, field);
@@ -383,8 +406,7 @@ VISRTX_DEVICE void ratioTrackTransmittance(
           continue;
 
         const vec4 co = classifySample(volume, s);
-        const float σ_t_p =
-            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
         const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
         const float ratio = glm::clamp(σ_r_p / σ_residual, 0.f, 1.f);
         attenuation *= (1.0f - ratio);

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -113,7 +113,11 @@ VISRTX_DEVICE float opacityToExtinction(
     float opacity, float oneOverUnitDistance)
 {
   constexpr float OPACITY_EPSILON = 1e-7f;
-  const float clampedOpacity = glm::clamp(opacity, 0.f, 0.9999f);
+  // Ceiling = largest float < 1 (1 - 2⁻²⁴). Keeps 1-α representable for
+  // log() and pins σ_t ≤ σ_maj (cell majorant uses same clamp) — invariant
+  // for the residual ratio-tracking estimator.
+  constexpr float OPACITY_CEILING = 1.f - 0x1p-24f;
+  const float clampedOpacity = glm::clamp(opacity, 0.f, OPACITY_CEILING);
   if (clampedOpacity <= OPACITY_EPSILON || !(oneOverUnitDistance > 0.f))
     return 0.f;
   return -logf(1.f - clampedOpacity) * oneOverUnitDistance;
@@ -284,6 +288,65 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
   return scatterT;
 }
 
+// Unbiased ratio-tracking transmittance estimator over one volume segment.
+// At each Woodcock candidate, multiply attenuation by (1 - sigma_t / sigma_maj)
+// rather than terminating on a "real" event. Across multiple any-hit
+// invocations on adjacent volume AABBs, OptiX composes the per-segment
+// estimates multiplicatively via the shared payload, so this is the right
+// primitive to call from __anyhit__shadow.
+VISRTX_DEVICE void ratioTrackTransmittance(
+    ScreenSample &ss, const VolumeHit &hit, vec3 &attenuation)
+{
+  const auto &volume = *hit.volume;
+  auto &svv = volume.data.tf1d;
+  auto &field = getSpatialFieldData(*ss.frameData, svv.field);
+
+  const Ray objRay = hit.localRay;
+  if (!(objRay.t.lower < objRay.t.upper))
+    return;
+
+  // Match Quality_ptx.cu's ATTENUATION_EPSILON.
+  constexpr float TRANSMITTANCE_EPSILON =
+      std::numeric_limits<float>::epsilon();
+
+  VolumeSamplingState samplerState;
+  volumeSamplerInit(&samplerState, field);
+
+  GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
+  while (trav.valid()) {
+    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float majorantExtinction =
+        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+
+    if (majorantExtinction > 0.f) {
+      float t = trav.tEntry;
+      while (true) {
+        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
+            / majorantExtinction;
+        if (t >= trav.tExit)
+          break;
+
+        const vec3 p = objRay.org + objRay.dir * t;
+        const float s = volumeSamplerSample(&samplerState, field, p);
+        if (glm::isnan(s))
+          continue;
+
+        const vec4 co = classifySample(volume, s);
+        const float actualExtinction =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        const float ratio =
+            glm::clamp(actualExtinction / majorantExtinction, 0.f, 1.f);
+        attenuation *= (1.0f - ratio);
+
+        if (glm::all(
+                glm::lessThanEqual(attenuation, vec3(TRANSMITTANCE_EPSILON))))
+          return;
+      }
+    }
+    trav.next();
+  }
+}
+
 } // namespace detail
 
 VISRTX_DEVICE float sampleDistanceVolume(ScreenSample &ss,
@@ -295,6 +358,12 @@ VISRTX_DEVICE float sampleDistanceVolume(ScreenSample &ss,
 {
   return detail::sampleDistance(
       ss, hit, albedo, extinction, didScatter, normal);
+}
+
+VISRTX_DEVICE void ratioTrackTransmittanceVolume(
+    ScreenSample &ss, const VolumeHit &hit, vec3 &attenuation)
+{
+  detail::ratioTrackTransmittance(ss, hit, attenuation);
 }
 
 VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -180,7 +180,7 @@ VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
       curand_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
   float nextSampleT = objRay.t.lower + jitter;
 
-  GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
   while (trav.valid()) {
     if (opacity >= MAX_OPACITY_THRESHOLD)
       break;
@@ -266,7 +266,7 @@ VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
   if (!(objRay.t.lower < objRay.t.upper))
     return scatterT;
 
-  GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
   while (trav.valid()) {
     const float minOpacity = field.grid.minOpacities[trav.cellIndex];
     const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
@@ -366,7 +366,7 @@ VISRTX_DEVICE void ratioTrackTransmittance(
   VolumeSamplingState samplerState;
   volumeSamplerInit(&samplerState, field);
 
-  GridTraversal trav(objRay, field.grid.dims, field.grid.worldBounds);
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
   while (trav.valid()) {
     const float minOpacity = field.grid.minOpacities[trav.cellIndex];
     const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];

--- a/devices/rtx/device/renderer/Fast_ptx.cu
+++ b/devices/rtx/device/renderer/Fast_ptx.cu
@@ -105,7 +105,7 @@ struct FastShadingPolicy
               hit,
               rendererParams.occlusionDistance,
               aoParams.aoSamples,
-              &surfaceAttenuation)
+              &surfaceShadowOpacity)
         : 1.f;
 
     auto materialBaseColor = materialEvaluateTint(shadingState);

--- a/devices/rtx/device/renderer/Interactive_ptx.cu
+++ b/devices/rtx/device/renderer/Interactive_ptx.cu
@@ -77,7 +77,7 @@ struct InteractiveShadingPolicy
               hit,
               rendererParams.occlusionDistance,
               interactiveParams.aoSamples,
-              &surfaceAttenuation)
+              &surfaceShadowOpacity)
         : 1.f;
 
     vec3 contrib = materialEvaluateEmission(shadingState, -ray.dir);
@@ -104,8 +104,9 @@ struct InteractiveShadingPolicy
       };
 
       const float surface_attenuation =
-          1.0f - surfaceAttenuation(ss, shadowRay);
-      const float volume_attenuation = 1.0f - volumeAttenuation(ss, shadowRay);
+          1.0f - surfaceShadowOpacity(ss, shadowRay);
+      const float volume_attenuation =
+          1.0f - volumeShadowOpacity(ss, shadowRay);
       const float attenuation = surface_attenuation * volume_attenuation;
 
       // Complete occlusion?

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -437,12 +437,16 @@ VISRTX_GLOBAL void __raygen__()
       }
 
       if (!surfaceHit.foundHit && !volumeSample.didScatter) {
-        if (vec3 hdri; getBackgroundLight(frameData, ray.dir, hdri)) {
-          sample.color += sampleContribution * hdri;
-          accumulateValue(sample.opacity, 1.f, sample.opacity);
-        }
-
+        // Primary-ray HDRI = rendered background. Bounce misses skip it:
+        // NEE at the previous vertex already sampled HDRI as a light, so
+        // adding it on miss double-counts for non-Dirac BSDFs (almost all
+        // scivis materials). Dirac mirrors / specular transmission lose
+        // HDRI under this rule — no MIS yet to recover them.
         if (isFirstBounce) {
+          if (vec3 hdri; getBackgroundLight(frameData, ray.dir, hdri)) {
+            sample.color += sampleContribution * hdri;
+            accumulateValue(sample.opacity, 1.f, sample.opacity);
+          }
           setPixelIds(frameData.fb, ss.pixel, ray.t.upper, ~0u, ~0u, ~0u);
         }
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -40,6 +40,7 @@
 #include "gpu/intersectRay.h"
 #include "gpu/populateHit.h"
 #include "gpu/renderer/common.h"
+#include "gpu/renderer/shadowTransmittance.h"
 #include "gpu/sampleLight.h"
 #include "gpu/shadingState.h"
 #include "gpu/volumeIntegration.h"
@@ -83,22 +84,6 @@ VISRTX_DEVICE void accumPixelSample(
       vec4(sample.color, sample.opacity),
       sample.albedo,
       sample.normal);
-}
-
-VISRTX_DEVICE vec3 surfaceAttenuation(ScreenSample &ss, Ray r)
-{
-  vec3 attenuation = vec3(1.0f);
-  intersectSurface(
-      ss, r, RayType::SHADOW, &attenuation, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
-  return attenuation;
-}
-
-VISRTX_DEVICE vec3 volumeAttenuation(ScreenSample &ss, Ray r)
-{
-  vec3 attenuation = vec3(1.0f);
-  intersectVolume(
-      ss, r, RayType::SHADOW, &attenuation, OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT);
-  return attenuation;
 }
 
 VISRTX_DEVICE vec3 evaluateOpacity(const MaterialShadingState &shadingState)
@@ -334,8 +319,8 @@ VISRTX_GLOBAL void __raygen__()
                 lightSample.dir,
                 {eps, lightSample.dist},
             };
-            const auto attenuation = surfaceAttenuation(ss, shadowRay)
-                * volumeAttenuation(ss, shadowRay);
+            const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
+                * volumeShadowTransmittance(ss, shadowRay);
 
             constexpr float INV_4PI = 1.0f / (4.0f * float(M_PI));
             const vec3 directLight = volumeSample.albedo * lightSample.radiance
@@ -411,8 +396,8 @@ VISRTX_GLOBAL void __raygen__()
                 lightSample.dir,
                 {surfaceHit.epsilon, lightSample.dist},
             };
-            const auto attenuation = surfaceAttenuation(ss, shadowRay)
-                * volumeAttenuation(ss, shadowRay);
+            const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
+                * volumeShadowTransmittance(ss, shadowRay);
             const vec3 directLight = materialShadeSurface(
                 shadingState, surfaceHit, lightSample, -ray.dir);
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -237,14 +237,9 @@ VISRTX_GLOBAL void __anyhit__shadow()
     VolumeHit hit;
     ray::populateVolumeHit(hit);
 
-    vec3 albedo = vec3(0.0f);
-    float sampledExtinction = 0.0f;
-    bool sampledDidScatter = false;
-    sampleDistanceVolume(
-        ray::screenSample(), hit, albedo, sampledExtinction, sampledDidScatter);
-
-    if (sampledDidScatter)
-      attenuation *= albedo;
+    // Unbiased ratio-tracking transmittance over this volume segment.
+    // Scalar σ_t (TF is monochrome) broadcast to vec3 in the callee.
+    ratioTrackTransmittanceVolume(ray::screenSample(), hit, attenuation);
 
     if (glm::all(glm::lessThanEqual(attenuation, vec3(ATTENUATION_EPSILON))))
       optixTerminateRay();

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -75,9 +75,8 @@ struct SampleDetails
   vec3 normal;
 };
 
-VISRTX_DEVICE void accumPixelSample(const FrameGPUData &frame,
-    const uvec2 &pixel,
-    const SampleDetails &sample)
+VISRTX_DEVICE void accumPixelSample(
+    const FrameGPUData &frame, const uvec2 &pixel, const SampleDetails &sample)
 {
   accumPixelSample(frame,
       pixel,
@@ -163,6 +162,42 @@ VISRTX_DEVICE LightSample sampleLights(ScreenSample &ss,
         lightPickPdf * cosNs * float(M_1_PI),
     };
   } else {
+    const auto &lightInstance = world.lightInstances[selectedIdx];
+    auto ls =
+        sampleLight(ss, origin, lightInstance.lightIndex, lightInstance.xfm);
+    ls.pdf *= lightPickPdf;
+    return ls;
+  }
+}
+
+VISRTX_DEVICE LightSample sampleLightsVolume(
+    ScreenSample &ss, const FrameGPUData &frameData, const vec3 &origin)
+{
+  const auto &world = frameData.world;
+  const bool hasAmbientLight = frameData.renderer.ambientIntensity > 0.0f;
+  const auto numLights = world.numLightInstances + hasAmbientLight;
+
+  if (numLights == 0)
+    return {};
+
+  const size_t selectedIdx =
+      glm::min(size_t((1.0f - curand_uniform(&ss.rs)) * float(numLights)),
+          numLights - 1);
+
+  const float lightPickPdf = 1.0f / float(numLights);
+
+  if (selectedIdx == world.numLightInstances) {
+    const auto &rendererParams = frameData.renderer;
+    constexpr float INV_4PI = 1.0f / (4.0f * float(M_PI));
+    const vec3 dir = randomDir(ss.rs);
+    return LightSample{
+        rendererParams.ambientColor * rendererParams.ambientIntensity,
+        dir,
+        std::numeric_limits<float>::max(),
+        lightPickPdf * INV_4PI,
+    };
+  } else {
+    // Ambient sampled uniform-sphere (pdf 1/(4π)) to match the isotropic phase.
     const auto &lightInstance = world.lightInstances[selectedIdx];
     auto ls =
         sampleLight(ss, origin, lightInstance.lightIndex, lightInstance.xfm);
@@ -290,7 +325,7 @@ VISRTX_GLOBAL void __raygen__()
 
         {
           LightSample lightSample =
-              sampleLights(ss, frameData, scatterPos, volumeSample.normal);
+              sampleLightsVolume(ss, frameData, scatterPos);
           if (lightSample.pdf >= ATTENUATION_EPSILON
               && lightSample.dist > 0.0f) {
             const float eps = VOLUME_SCATTER_EPSILON;

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
@@ -151,13 +151,13 @@ size_t UniformGrid::numCells() const
   return m_dims.x * size_t(m_dims.y) * m_dims.z;
 }
 
-void UniformGrid::init(ivec3 dims, box3 worldBounds)
+void UniformGrid::init(ivec3 dims, box3 objectBounds)
 {
   m_fieldDims = dims;
   m_dims = ivec3(iDivUp(dims.x, MACROCELL_SIZE),
       iDivUp(dims.y, MACROCELL_SIZE),
       iDivUp(dims.z, MACROCELL_SIZE));
-  m_worldBounds = worldBounds;
+  m_objectBounds = objectBounds;
 
   size_t n = numCells();
 
@@ -245,7 +245,7 @@ UniformGridData UniformGrid::gpuData() const
 {
   UniformGridData grid;
   grid.dims = m_dims;
-  grid.worldBounds = m_worldBounds;
+  grid.objectBounds = m_objectBounds;
   grid.valueRanges = m_valueRanges;
   grid.minOpacities = m_minOpacities;
   grid.maxOpacities = m_maxOpacities;

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
@@ -38,7 +38,8 @@
 
 namespace visrtx {
 
-__global__ void computeMaxOpacitiesGPU(float *maxOpacities,
+__global__ void computeOpacityBoundsGPU(float *minOpacities,
+    float *maxOpacities,
     const box1 *valueRanges,
     cudaTextureObject_t colorMap,
     size_t numMCs,
@@ -53,12 +54,14 @@ __global__ void computeMaxOpacitiesGPU(float *maxOpacities,
   box1 valueRange = valueRanges[threadID];
 
   if (valueRange.upper < valueRange.lower) {
+    minOpacities[threadID] = 0.f;
     maxOpacities[threadID] = 0.f;
     return;
   }
 
   const float xfRangeSize = xfRange.upper - xfRange.lower;
   if (xfRangeSize <= 0.f) {
+    minOpacities[threadID] = 0.f;
     maxOpacities[threadID] = 0.f;
     return;
   }
@@ -75,12 +78,19 @@ __global__ void computeMaxOpacitiesGPU(float *maxOpacities,
   int hi = glm::clamp(
       int(normalizedHi * (numColors - 1)) + 1, 0, int(numColors - 1));
 
+  // The scan range plus 1-bin TF margin and 1-voxel field margin makes both
+  // bounds conservative (max ≥ true max, min ≤ true min) for the
+  // linear-filter TF lookup over the cell.
+  float minOpacity = 1.f;
   float maxOpacity = 0.f;
   for (int i = lo; i <= hi; ++i) {
     float tc = (i + .5f) / numColors;
-    maxOpacity = fmaxf(maxOpacity, tex1D<::float4>(colorMap, tc).w);
+    float a = tex1D<::float4>(colorMap, tc).w;
+    minOpacity = fminf(minOpacity, a);
+    maxOpacity = fmaxf(maxOpacity, a);
   }
 
+  minOpacities[threadID] = minOpacity;
   maxOpacities[threadID] = maxOpacity;
 }
 
@@ -152,9 +162,11 @@ void UniformGrid::init(ivec3 dims, box3 worldBounds)
   size_t n = numCells();
 
   cudaFree(m_valueRanges);
+  cudaFree(m_minOpacities);
   cudaFree(m_maxOpacities);
 
   cudaMalloc(&m_valueRanges, n * sizeof(box1));
+  cudaMalloc(&m_minOpacities, n * sizeof(float));
   cudaMalloc(&m_maxOpacities, n * sizeof(float));
 }
 
@@ -221,9 +233,11 @@ void UniformGrid::computeValueRanges(const SpatialFieldGPUData &sfgd)
 void UniformGrid::cleanup()
 {
   cudaFree(m_valueRanges);
+  cudaFree(m_minOpacities);
   cudaFree(m_maxOpacities);
 
   m_valueRanges = nullptr;
+  m_minOpacities = nullptr;
   m_maxOpacities = nullptr;
 }
 
@@ -233,17 +247,18 @@ UniformGridData UniformGrid::gpuData() const
   grid.dims = m_dims;
   grid.worldBounds = m_worldBounds;
   grid.valueRanges = m_valueRanges;
+  grid.minOpacities = m_minOpacities;
   grid.maxOpacities = m_maxOpacities;
   return grid;
 }
 
-void UniformGrid::computeMaxOpacities(
+void UniformGrid::computeOpacityBounds(
     CUstream stream, cudaTextureObject_t cm, size_t cmSize, box1 cmRange)
 {
   size_t n = numCells();
   size_t numThreads = 1024;
-  computeMaxOpacitiesGPU<<<iDivUp(n, numThreads), numThreads, 0, stream>>>(
-      m_maxOpacities, m_valueRanges, cm, n, cmSize, cmRange);
+  computeOpacityBoundsGPU<<<iDivUp(n, numThreads), numThreads, 0, stream>>>(
+      m_minOpacities, m_maxOpacities, m_valueRanges, cm, n, cmSize, cmRange);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
@@ -40,7 +40,7 @@ constexpr int MACROCELL_SIZE = 16;
 
 struct UniformGrid
 {
-  void init(ivec3 dims, box3 worldBounds);
+  void init(ivec3 dims, box3 objectBounds);
 
   void computeValueRanges(const SpatialFieldGPUData &sfgd);
 
@@ -61,7 +61,7 @@ struct UniformGrid
   float *m_maxOpacities = nullptr;
   ivec3 m_dims;
   ivec3 m_fieldDims;
-  box3 m_worldBounds;
+  box3 m_objectBounds;
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
@@ -46,7 +46,10 @@ struct UniformGrid
 
   void cleanup();
   UniformGridData gpuData() const;
-  void computeMaxOpacities(CUstream stream,
+  // Compute both per-cell min and max opacity over the TF in one scan. Min is
+  // used as a constant lower bound for residual / decomposition tracking; max
+  // is the Woodcock majorant.
+  void computeOpacityBounds(CUstream stream,
       cudaTextureObject_t cm,
       size_t cmSize,
       box1 cmRange = {0.f, 1.f});
@@ -54,6 +57,7 @@ struct UniformGrid
   size_t numCells() const;
 
   box1 *m_valueRanges = nullptr;
+  float *m_minOpacities = nullptr;
   float *m_maxOpacities = nullptr;
   ivec3 m_dims;
   ivec3 m_fieldDims;

--- a/devices/rtx/device/volume/TransferFunction1D.cpp
+++ b/devices/rtx/device/volume/TransferFunction1D.cpp
@@ -85,7 +85,7 @@ void TransferFunction1D::finalize()
 
   discritizeTFData();
   createTFTexture();
-  m_field->m_uniformGrid.computeMaxOpacities(
+  m_field->m_uniformGrid.computeOpacityBounds(
       deviceState()->stream, m_textureObject, m_tfDim, m_valueRange);
   upload();
 }

--- a/devices/rtx/device/volume/TransferFunction1D.cpp
+++ b/devices/rtx/device/volume/TransferFunction1D.cpp
@@ -51,7 +51,11 @@ void TransferFunction1D::commitParameters()
   getParam("color", ANARI_FLOAT32_VEC3, &m_uniformColor);
   getParam("color", ANARI_FLOAT32_VEC4, &m_uniformColor);
   m_opacity = getParamObject<Array1D>("opacity");
-  m_uniformOpacity = getParam<float>("opacity", 1.f) * m_uniformColor.w;
+  // Raw scalar. ANARI 1.1 §5.12.1: final α = color.w · opacity. The
+  // multiplication happens once per bin in discritizeTFData (m_tf[i].w =
+  // c.w * o); folding c.w in here would double-count whenever c.w comes
+  // from m_uniformColor.
+  m_uniformOpacity = getParam<float>("opacity", 1.f);
   m_unitDistance = getParam<float>("unitDistance", 1.f);
   const SpatialField *previousField = m_field.get();
   m_field = getParamObject<SpatialField>("value");
@@ -106,7 +110,9 @@ VolumeGPUData TransferFunction1D::gpuData() const
   retval.data.tf1d.oneOverUnitDistance = 1.0f / m_unitDistance;
   retval.data.tf1d.field = m_field->index();
   retval.data.tf1d.uniformColor = vec3(m_uniformColor);
-  retval.data.tf1d.uniformOpacity = m_uniformOpacity;
+  // Fold c.w · o here for the null-tfTex fallback in classifySample (that
+  // path doesn't see discritizeTFData's per-bin fold).
+  retval.data.tf1d.uniformOpacity = m_uniformOpacity * m_uniformColor.w;
   return retval;
 }
 

--- a/devices/rtx/device/volume/TransferFunction1D.cpp
+++ b/devices/rtx/device/volume/TransferFunction1D.cpp
@@ -53,7 +53,12 @@ void TransferFunction1D::commitParameters()
   m_opacity = getParamObject<Array1D>("opacity");
   m_uniformOpacity = getParam<float>("opacity", 1.f) * m_uniformColor.w;
   m_unitDistance = getParam<float>("unitDistance", 1.f);
+  const SpatialField *previousField = m_field.get();
   m_field = getParamObject<SpatialField>("value");
+  // AABB comes from m_field. Only a field-pointer swap moves it; field
+  // data changes hit SpatialField::markFinalized.
+  if (m_field.get() != previousField)
+    deviceState()->objectUpdates.lastVolumeBLASChange = helium::newTimeStamp();
   getParam("valueRange", ANARI_FLOAT32_VEC2, &m_valueRange);
   getParam("valueRange", ANARI_FLOAT32_BOX1, &m_valueRange);
   double valueRange_d[2] = {0.0, 1.0};

--- a/devices/rtx/device/volume/Volume.cpp
+++ b/devices/rtx/device/volume/Volume.cpp
@@ -44,14 +44,19 @@ Volume::Volume(DeviceGlobalState *d)
 
 void Volume::commitParameters()
 {
+  const bool wasVisible = m_visible;
   m_id = getParam<uint32_t>("id", ~0u);
   m_visible = getParam<bool>("visible", true);
+  // Visibility flip → BVH partition changes. Other Volume params are
+  // GPU-side metadata only.
+  if (wasVisible != m_visible)
+    deviceState()->objectUpdates.lastVolumeBLASChange = helium::newTimeStamp();
 }
 
 void Volume::markFinalized()
 {
   Object::markFinalized();
-  deviceState()->objectUpdates.lastVolumeBLASChange = helium::newTimeStamp();
+  // No BLAS bump — most volume finalizations are TF tweaks; AABB stays put.
 }
 
 bool Volume::isVisible() const


### PR DESCRIPTION
Improve `Quality` volume rendering:
- Shadows: ratio-track instead of one-event-then-stop; multiply transmittance, not albedo.
- In-volume scatter: uniform-sphere phase pdf 1/(4π), was wrongly using cosine-hemisphere around the TF gradient.
- HDRI: gate miss-path HDRI on first bounce; NEE already counts it.
- Woodcock fixes

Improve `Interactive/Fast` volume rendering:
- ray-march: skip empty macrocells via GridTraversal

Transfer function:
- Fixed wrong pre-folding  color.w into opacity — discritizeTFData already does it
- Commits no longer trigger BLAS/TLAS rebuild (TF doesn't change AABB).

In severe-broken cases:
<table>
<tr>
  <th>before</th>
  <th>after</th>
</tr>
<tr>
  <td><img width="1024" height="768" alt="old" src="https://github.com/user-attachments/assets/f30f993c-a004-4234-92aa-72db8049eb97" /></td>
  <td><img width="1024" height="768" alt="new" src="https://github.com/user-attachments/assets/c0eb79f3-1011-4731-9fd7-ef36bb7e9f81" /></td>
</tr>
<tr>
  <td><img width="1024" height="768" alt="dragon-old" src="https://github.com/user-attachments/assets/9d130b97-4fdf-4add-9a0a-c7e62703dc14" /></td>
  <td><img width="1024" height="768" alt="dragon-new" src="https://github.com/user-attachments/assets/3ded5ec6-d560-44ec-8b27-33710cac80f8" /></td>
</tr>
</table>

Subsequent PRs to work on performances.