### PR TITLE
Volume rendering optimization pass

### DIFF
--- a/devices/rtx/device/CMakeLists.txt
+++ b/devices/rtx/device/CMakeLists.txt
@@ -47,6 +47,10 @@ endif()
 
 set(VISRTX_CUDA_COMPILE_OPTIONS
   "--expt-relaxed-constexpr" "--extended-lambda" # Lambdas from device code
+  # Routes sinf/cosf/expf etc. through the SFU instead of libm argument
+  # reduction (which uses double internally and trips OptiX's double-
+  # precision warning). Slight accuracy loss in transcendentals.
+  "--use_fast_math"
   # Silence the spamming of glm warning about `__host__ annotation is ignored on a function("vec") that is explicitly defaulted on its first declaration`
   "-Xcudafe=--diag_suppress=20012"
   # Silence the multitude of warnings about deprecated/to be removed GPU architectures

--- a/devices/rtx/device/CMakeLists.txt
+++ b/devices/rtx/device/CMakeLists.txt
@@ -277,7 +277,6 @@ PUBLIC
 PRIVATE
   anari::helium
   CUDA::cuda_driver
-  CUDA::curand
   $<$<BOOL:${VISRTX_ENABLE_NVTX}>:CUDA::nvToolsExt>
   $<$<BOOL:${VISRTX_ENABLE_MDL_SUPPORT}>:libmdl>
 )
@@ -346,7 +345,6 @@ function(GenerateEmbeddedPTX DIR BASE_NAME)
     OptiX::OptiX
     anari::anari_headers
     anari::helium
-    CUDA::curand
     $<$<BOOL:${VISRTX_ENABLE_MDL_SUPPORT}>:libmdl>
   )
   target_include_directories(${INPUT_TARGET}

--- a/devices/rtx/device/gpu/cameraCreateRay.h
+++ b/devices/rtx/device/gpu/cameraCreateRay.h
@@ -73,7 +73,7 @@ VISRTX_DEVICE Ray cameraCreateRay(const CameraGPUData &c, vec2 screen, vec2 r)
 
 VISRTX_DEVICE Ray makePrimaryRay(ScreenSample &ss, bool centerPixel = false)
 {
-  const ::float4 r = curand_uniform4(&ss.rs);
+  const ::float4 r = pcg_uniform4(&ss.rs);
   ss.screen = (centerPixel ? vec2(ss.pixel.x, ss.pixel.y)
                            : vec2(ss.pixel.x + r.x, ss.pixel.y + r.y))
       * ss.frameData->fb.invSize;

--- a/devices/rtx/device/gpu/cameraCreateRay.h
+++ b/devices/rtx/device/gpu/cameraCreateRay.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include "gpu/halton.h"
 #include "gpu_objects.h"
 
 namespace visrtx {
@@ -71,9 +72,18 @@ VISRTX_DEVICE Ray cameraCreateRay(const CameraGPUData &c, vec2 screen, vec2 r)
   return ray;
 }
 
-VISRTX_DEVICE Ray makePrimaryRay(ScreenSample &ss, bool centerPixel = false)
+// sampleIdx is a (frame-counter × spp_loop) ordinal advancing once per
+// camera sample within the frame's accumulation; combined with a
+// per-pixel hash offset it indexes a Halton 4D point used for
+// sub-pixel jitter (dims 0/1) + lens aperture (dims 2/3). Halton at
+// the camera level converges the AA / DoF integrals strictly faster
+// than uniform random — see gpu/halton.h.
+VISRTX_DEVICE Ray makePrimaryRay(
+    ScreenSample &ss, uint32_t sampleIdx, bool centerPixel = false)
 {
-  const ::float4 r = pcg_uniform4(&ss.rs);
+  const uint32_t haltonIdx =
+      sampleIdx + haltonPixelHash(ss.pixel.x, ss.pixel.y);
+  const ::float4 r = halton4D(haltonIdx);
   ss.screen = (centerPixel ? vec2(ss.pixel.x, ss.pixel.y)
                            : vec2(ss.pixel.x + r.x, ss.pixel.y + r.y))
       * ss.frameData->fb.invSize;

--- a/devices/rtx/device/gpu/createScreenSample.h
+++ b/devices/rtx/device/gpu/createScreenSample.h
@@ -60,6 +60,7 @@ VISRTX_DEVICE ScreenSample createScreenSample(const FrameGPUData &frameData)
   ss.pixel.x = x;
   ss.pixel.y = y;
   ss.frameData = &frameData;
+  ss.shadowContribWeight = 1.0f;
 
   return ss;
 }

--- a/devices/rtx/device/gpu/createScreenSample.h
+++ b/devices/rtx/device/gpu/createScreenSample.h
@@ -55,7 +55,12 @@ VISRTX_DEVICE ScreenSample createScreenSample(const FrameGPUData &frameData)
   const int x = computePixelX(launchIdx.x, frameData.fb.checkerboardID);
   const int y = computePixelY(launchIdx.y, frameData.fb.checkerboardID);
   const int w = frameData.fb.size.x;
-  curand_init(y * w + x, 0, frameData.fb.frameID * 512, &ss.rs);
+  // streamId = pixel linear index (per-pixel parallel streams via the odd
+  // `inc` selector); seed = frameID, so each frame restarts from a fresh
+  // LCG state per pixel.
+  const uint64_t pixelLinear = uint64_t(y) * uint64_t(w) + uint64_t(x);
+  const uint64_t frameSeed = uint64_t(frameData.fb.frameID);
+  pcg_init(&ss.rs, frameSeed, pixelLinear);
 
   ss.pixel.x = x;
   ss.pixel.y = y;

--- a/devices/rtx/device/gpu/gpu_math.h
+++ b/devices/rtx/device/gpu/gpu_math.h
@@ -126,9 +126,6 @@ struct VolumeGPUData;
 
 struct SurfaceHit
 {
-  mat3x4 worldToObject;
-  mat3x4 objectToWorld;
-
   vec3 hitpoint;
   float t;
   vec3 Ng;
@@ -152,9 +149,6 @@ struct SurfaceHit
 
 struct VolumeHit
 {
-  mat3x4 worldToObject;
-  mat3x4 objectToWorld;
-
   const VolumeGPUData *volume{nullptr};
   const InstanceVolumeGPUData *instance{nullptr};
   Ray localRay;

--- a/devices/rtx/device/gpu/gpu_math.h
+++ b/devices/rtx/device/gpu/gpu_math.h
@@ -44,6 +44,13 @@
 
 namespace visrtx {
 
+// Float π. Bare M_PI is double — silently promotes whole expressions;
+// Ada runs DP at ~1/32 float throughput.
+inline constexpr float kPi = 3.14159265358979323846f;
+inline constexpr float kTwoPi = 6.28318530717958647692f;
+inline constexpr float kInvPi = 0.31830988618379067154f;
+inline constexpr float kInvTwoPi = 0.15915494309189533577f;
+
 using glm::fquat;
 using glm::ivec1;
 using glm::ivec2;
@@ -262,7 +269,7 @@ VISRTX_HOST_DEVICE vec2 sphericalCoordsFromDirection(vec3 dir)
 {
   float theta = acosf(glm::clamp(dir.z, -1.0f, 1.0f));
   float p = atan2f(dir.y, dir.x);
-  float phi = p < 0.f ? p + 2.f * float(M_PI) : p;
+  float phi = p < 0.f ? p + kTwoPi : p;
 
   return vec2(theta, phi);
 }
@@ -299,7 +306,7 @@ VISRTX_HOST_DEVICE bool intersectBox(
 VISRTX_HOST_DEVICE vec2 uniformSampleDisk(float radius, const vec2 &s)
 {
   const float r = sqrtf(s.x) * radius;
-  const float phi = 2.f * float(M_PI) * s.y;
+  const float phi = kTwoPi * s.y;
   return vec2{r * cosf(phi), r * sinf(phi)};
 }
 
@@ -308,7 +315,7 @@ VISRTX_HOST_DEVICE vec3 uniformSampleCone(
     vec3 s) // rand uniforms in [0,1)
 {
   // Sample direction in cone
-  float phi = 2.0f * M_PI * s.x;
+  float phi = kTwoPi * s.x;
   float cosTheta = (1.0f - s.y) + s.y * cosThetaMax;
   float sinTheta = sqrtf(1.0f - cosTheta * cosTheta);
 

--- a/devices/rtx/device/gpu/gpu_math.h
+++ b/devices/rtx/device/gpu/gpu_math.h
@@ -133,12 +133,14 @@ struct SurfaceHit
   vec3 tU;
   float epsilon;
   vec3 tV;
-  bool isFrontFace;
-  bool foundHit;
+  bool isFrontFace : 1;
+  bool foundHit : 1;
 
   const InstanceSurfaceGPUData *instance{nullptr};
   const GeometryGPUData *geometry{nullptr};
   const MaterialGPUData *material{nullptr};
+
+  VISRTX_DEVICE SurfaceHit() : isFrontFace(false), foundHit(false) {}
 };
 
 struct VolumeHit

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -393,6 +393,11 @@ struct MaterialGPUData
 
   uint32_t callableBaseIndex{~0u};
 
+  // Static shadow attenuator: OPAQUE alphaMode, opacity + alpha channels
+  // constant 1.0, transmission constant 0.0, no opacity/transmission
+  // sampler. Shadow anyhit short-circuits via optixTerminateRay.
+  bool isFullyOpaque{false};
+
   union MaterialData
   {
     Matte matte;

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -418,9 +418,9 @@ struct UniformGridData
 {
   ivec3 dims;
   box3 objectBounds;
-  box1 *valueRanges; // data min/max ranges
-  float *minOpacities; // matching tf opacity minima
-  float *maxOpacities; // matching tf opacity maxima
+  box1 *valueRanges; // min/max ranges
+  float2 *opacityBounds; // Per-cell α bounds (.x = min, .y = max) over the TF
+                         // lookup.
 };
 
 struct StructuredRegularData

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -451,6 +451,8 @@ struct NVdbRegularData
   const void *gridData;
   bool cellCentered;
   SpatialFieldFilter filter;
+  // Host-precomputed 1 / (2 · voxelSize). Keeps Vec3d off the device init.
+  vec3 invTwoVoxelSize;
 
   NVdbRegularData() = default;
 };

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -815,6 +815,12 @@ struct ScreenSample
   glm::vec2 screen;
   mutable RandState rs;
   const FrameGPUData *frameData;
+  // Adaptive shadow ratio-tracking knob. Set by the raygen before each
+  // shadow trace to (max pre-attenuation contribution) / RR_BASE, capped
+  // at 1.0. Smaller values raise the RR threshold inside
+  // applyShadowRussianRoulette so dim-contribution shadow rays terminate
+  // sooner. Default 1.0 = full-precision RR (current behaviour).
+  float shadowContribWeight;
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -642,6 +642,10 @@ struct LightGPUData
 
 struct InstanceSurfaceGPUData
 {
+  // Pre-computed at instance commit (World.cpp's buildInstance*GPUData).
+  mat3x4 objectToWorld;
+  mat3x4 worldToObject;
+
   const DeviceObjectIndex *surfaces;
   AttributeDataSet attrUniformArray;
   AttributeDataSetUniform attrUniform;
@@ -653,6 +657,9 @@ struct InstanceSurfaceGPUData
 
 struct InstanceVolumeGPUData
 {
+  mat3x4 objectToWorld;
+  mat3x4 worldToObject;
+
   const DeviceObjectIndex *volumes;
   uint32_t id;
 };

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -36,8 +36,10 @@
 
 // optix
 #include <optix.h>
-// curand
-#include <curand_kernel.h>
+// cuda runtime — cudaTextureObject_t and friends
+#include <cuda_runtime.h>
+// PCG RNG, see gpu/pcg.h
+#include "gpu/pcg.h"
 // anari
 #include <anari/anari_cpp.hpp>
 #include <glm/ext/matrix_float3x4.hpp>
@@ -57,7 +59,7 @@
 
 namespace visrtx {
 
-using RandState = curandStatePhilox4_32_10_t;
+using RandState = PCGState;
 using DeviceObjectIndex = int32_t;
 
 enum class MaterialAttribute : uint8_t

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -201,7 +201,7 @@ VISRTX_DEVICE vec3 randomDir(RandState &rs)
 {
   const float cosTheta = 1.f - 2.f * curand_uniform(&rs);
   const float sinTheta = sqrtf(fmaxf(0.f, 1.f - cosTheta * cosTheta));
-  const float phi = 2.f * float(M_PI) * curand_uniform(&rs);
+  const float phi = kTwoPi * curand_uniform(&rs);
   return vec3(sinTheta * cosf(phi), sinTheta * sinf(phi), cosTheta);
 }
 
@@ -231,7 +231,7 @@ VISRTX_DEVICE vec3 sampleHemisphere(RandState &rs, const vec3 &normal)
   const float u2 = curand_uniform(&rs);
   const float r = sqrtf(u1);
   const float z = sqrtf(fmaxf(0.f, 1.f - r * r));
-  const float phi = 2.f * float(M_PI) * u2;
+  const float phi = kTwoPi * u2;
   const vec3 sample(r * cosf(phi), r * sinf(phi), z);
   return computeOrthonormalBasis(normal) * sample;
 }
@@ -241,7 +241,7 @@ VISRTX_DEVICE vec3 sampleUnitSphere(RandState &rs, const vec3 &normal)
   // sample unit sphere
   const float cost = 1.f - 2.f * curand_uniform(&rs);
   const float sint = sqrtf(fmaxf(0.f, 1.f - cost * cost));
-  const float phi = 2.f * float(M_PI) * curand_uniform(&rs);
+  const float phi = kTwoPi * curand_uniform(&rs);
 
   return computeOrthonormalBasis(normal)
       * vec3(sint * cosf(phi), sint * sinf(phi), -cost);
@@ -372,8 +372,8 @@ VISRTX_DEVICE vec3 sampleHDRI(const LightGPUData &ld, const vec3 &rayDir)
   if (ld.type != LightType::HDRI)
     return vec3(0.f);
 
-  constexpr float invPi = 1.f / float(M_PI);
-  constexpr float inv2Pi = 1.f / (2.f * float(M_PI));
+  constexpr float invPi = 1.f / kPi;
+  constexpr float inv2Pi = 1.f / (kTwoPi);
   const vec3 d = ld.hdri.xfm * rayDir;
   const vec2 thetaPhi = sphericalCoordsFromDirection(d);
   const float u = thetaPhi.y * inv2Pi;

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -333,10 +333,10 @@ VISRTX_DEVICE vec3 shadingHitpoint(const SurfaceHit &hit)
     n2 = -n2;
   }
 
-  const vec3 Plocal = xfmPoint(hit.worldToObject, hit.hitpoint);
+  const vec3 Plocal = xfmPoint(hit.instance->worldToObject, hit.hitpoint);
   const vec3 Psmooth =
       shadowTerminatorOffset(Plocal, v0, v1, v2, n0, n1, n2, hit.uvw);
-  return xfmPoint(hit.objectToWorld, Psmooth);
+  return xfmPoint(hit.instance->objectToWorld, Psmooth);
 }
 
 VISRTX_DEVICE bool pixelOutOfFrame(

--- a/devices/rtx/device/gpu/gpu_util.h
+++ b/devices/rtx/device/gpu/gpu_util.h
@@ -199,9 +199,9 @@ VISRTX_DEVICE vec3 boolColor(bool pred)
 // Downstream uses: isotropic volume scatter, AO/bounce hemisphere base.
 VISRTX_DEVICE vec3 randomDir(RandState &rs)
 {
-  const float cosTheta = 1.f - 2.f * curand_uniform(&rs);
+  const float cosTheta = 1.f - 2.f * pcg_uniform(&rs);
   const float sinTheta = sqrtf(fmaxf(0.f, 1.f - cosTheta * cosTheta));
-  const float phi = kTwoPi * curand_uniform(&rs);
+  const float phi = kTwoPi * pcg_uniform(&rs);
   return vec3(sinTheta * cosf(phi), sinTheta * sinf(phi), cosTheta);
 }
 
@@ -227,8 +227,8 @@ VISRTX_DEVICE mat3 computeOrthonormalBasis(const vec3 &normal)
 // Cosine-weighted hemisphere sample (Malley's method); pdf = cos(theta)/pi.
 VISRTX_DEVICE vec3 sampleHemisphere(RandState &rs, const vec3 &normal)
 {
-  const float u1 = curand_uniform(&rs);
-  const float u2 = curand_uniform(&rs);
+  const float u1 = pcg_uniform(&rs);
+  const float u2 = pcg_uniform(&rs);
   const float r = sqrtf(u1);
   const float z = sqrtf(fmaxf(0.f, 1.f - r * r));
   const float phi = kTwoPi * u2;
@@ -239,9 +239,9 @@ VISRTX_DEVICE vec3 sampleHemisphere(RandState &rs, const vec3 &normal)
 VISRTX_DEVICE vec3 sampleUnitSphere(RandState &rs, const vec3 &normal)
 {
   // sample unit sphere
-  const float cost = 1.f - 2.f * curand_uniform(&rs);
+  const float cost = 1.f - 2.f * pcg_uniform(&rs);
   const float sint = sqrtf(fmaxf(0.f, 1.f - cost * cost));
-  const float phi = kTwoPi * curand_uniform(&rs);
+  const float phi = kTwoPi * pcg_uniform(&rs);
 
   return computeOrthonormalBasis(normal)
       * vec3(sint * cosf(phi), sint * sinf(phi), -cost);

--- a/devices/rtx/device/gpu/halton.h
+++ b/devices/rtx/device/gpu/halton.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "gpu/gpu_decl.h"
+
+#include <vector_types.h> // ::float4
+#include <cstdint>
+
+// Halton low-discrepancy sequence for the 2–4D top of the path (camera
+// jitter + DoF lens). Pattern: PCG everywhere, QMC at the camera.
+//   dims 0..1 (bases 2, 3): pixel x/y sub-pixel jitter
+//   dims 2..3 (bases 5, 7): lens u/v for DoF
+//
+// Pixel decorrelation: additive offset = haltonPixelHash(pixel). Not full
+// Owen scrambling — adequate at 4D, full scrambling is more code for
+// negligible win.
+
+namespace visrtx {
+
+// Per-pixel scramble hash — PCG-style integer mixer, additive offset on
+// the Halton sample index.
+VISRTX_DEVICE uint32_t haltonPixelHash(uint32_t x, uint32_t y)
+{
+  // Salt breaks the (0, 0) zero fixed point — otherwise pixel (0, 0) would
+  // share its Halton subsequence with the origin.
+  uint32_t v = x + y * 0x9E3779B9u + 0xB5297A4Du;
+  v ^= v >> 16;
+  v *= 0x7feb352du;
+  v ^= v >> 15;
+  v *= 0x846ca68bu;
+  v ^= v >> 16;
+  return v;
+}
+
+// Radical inverse Φ_Base(i): digits of i in base Base, reversed across the
+// decimal point. Generic loop covers bases 2/3/5/7; Base=2 could specialise
+// to __brev but the saving is marginal at this dimensionality.
+template <uint32_t Base>
+VISRTX_DEVICE float radicalInverse(uint32_t i)
+{
+  static_assert(Base >= 2u, "radicalInverse requires Base >= 2");
+  constexpr float invBase = 1.0f / float(Base);
+  float result = 0.0f;
+  float scale = 1.0f;
+  while (i > 0u) {
+    scale *= invBase;
+    result += float(i % Base) * scale;
+    i /= Base;
+  }
+  // FP rounding can push the sum to exactly 1.0f; callers need [0, 1).
+  return fminf(result, 0x1.fffffep-1f);
+}
+
+// Halton 4D point (Φ_2, Φ_3, Φ_5, Φ_7), each in [0, 1). Combine sampleIdx
+// with haltonPixelHash for per-pixel decorrelation.
+VISRTX_DEVICE ::float4 halton4D(uint32_t sampleIdx)
+{
+  return ::float4{
+      radicalInverse<2>(sampleIdx),
+      radicalInverse<3>(sampleIdx),
+      radicalInverse<5>(sampleIdx),
+      radicalInverse<7>(sampleIdx),
+  };
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/gpu/pcg.h
+++ b/devices/rtx/device/gpu/pcg.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "gpu/gpu_decl.h"
+
+#include <vector_types.h> // ::float4
+#include <cstdint>
+
+// PCG-XSH-RR-32 (O'Neill 2014, "PCG: A Family of Simple Fast Space-Efficient
+// Statistically Good Algorithms for Random Number Generation"). 64-bit
+// internal state, 32-bit output, period 2^64. Passes TestU01 BigCrush.
+//
+// 8 B per-thread state, single-output, uniform convention [0, 1). `inc`
+// selects one of 2^63 parallel streams — that independence is what
+// makes this fit per-pixel seeds keyed on (pixel_id, frame_id).
+
+namespace visrtx {
+
+struct PCGState
+{
+  uint64_t state;
+  uint64_t inc; // odd;
+};
+
+namespace detail {
+
+// One step of the PCG-XSH-RR-32 permutation. Internal helper; callers want
+// pcg_uniform / pcg_uniform4 below.
+VISRTX_DEVICE uint32_t pcg_advance(PCGState *s)
+{
+  // LCG multiplier constants from PCG canonical implementation.
+  constexpr uint64_t LCG_MULT = 6364136223846793005ULL;
+  const uint64_t oldState = s->state;
+  s->state = oldState * LCG_MULT + s->inc;
+  // XSH-RR-32 output function: xorshift, then rotate the high bits.
+  const uint32_t xorshifted = uint32_t(((oldState >> 18u) ^ oldState) >> 27u);
+  const uint32_t rot = uint32_t(oldState >> 59u);
+  return (xorshifted >> rot) | (xorshifted << ((0u - rot) & 31u));
+}
+
+} // namespace detail
+
+// Seed the stream. `seed` becomes the initial counter; `streamId` selects
+// one of 2^63 statistically-independent streams (must be made odd; the
+// `| 1u` ensures this). Per-pixel streams are typically streamed by
+// (pixel.y * width + pixel.x), with `seed` carrying the frame counter so
+// successive frames advance the sequence.
+VISRTX_DEVICE void pcg_init(PCGState *s, uint64_t seed, uint64_t streamId)
+{
+  s->state = 0u;
+  s->inc = (streamId << 1u) | 1u;
+  (void)detail::pcg_advance(s);
+  s->state += seed;
+  (void)detail::pcg_advance(s);
+}
+
+// Float in [0, 1). 24-bit mantissa precision — matches the natural
+// single-precision resolution; the half-open convention matches
+// std::uniform_real_distribution and most modern RNGs.
+VISRTX_DEVICE float pcg_uniform(PCGState *s)
+{
+  // Upper 24 bits of the 32-bit PCG output → integer in [0, 2^24).
+  // Multiplied by 2^-24 gives a float in [0, 1 - 2^-24] ⊂ [0, 1).
+  return float(detail::pcg_advance(s) >> 8) * (1.0f / 16777216.0f);
+}
+
+VISRTX_DEVICE ::float4 pcg_uniform4(PCGState *s)
+{
+  // Four independent draws. Compiler should pipeline the four PCG
+  // advances since each only depends on the previous state.
+  const float x = pcg_uniform(s);
+  const float y = pcg_uniform(s);
+  const float z = pcg_uniform(s);
+  const float w = pcg_uniform(s);
+  return ::float4{x, y, z, w};
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -403,18 +403,6 @@ VISRTX_DEVICE void populateSurfaceHit(SurfaceHit &hit)
   hit.instID = isd.id;
   hit.epsilon = epsilonFrom(ray::hitpoint(), ray::direction(), ray::t());
   ray::computeTangentSpace(gd, ray::primID(), hit);
-
-  const auto &handle = optixGetTransformListHandle(0);
-  const ::float4 *tW = optixGetInstanceTransformFromHandle(handle);
-  const ::float4 *tO = optixGetInstanceInverseTransformFromHandle(handle);
-
-  hit.objectToWorld[0] = bit_cast<vec4>(tW[0]);
-  hit.objectToWorld[1] = bit_cast<vec4>(tW[1]);
-  hit.objectToWorld[2] = bit_cast<vec4>(tW[2]);
-
-  hit.worldToObject[0] = bit_cast<vec4>(tO[0]);
-  hit.worldToObject[1] = bit_cast<vec4>(tO[1]);
-  hit.worldToObject[2] = bit_cast<vec4>(tO[2]);
 }
 
 VISRTX_DEVICE void populateVolumeHit(VolumeHit &hit)
@@ -433,18 +421,6 @@ VISRTX_DEVICE void populateVolumeHit(VolumeHit &hit)
   hit.localRay.dir = ray::volume_local_direction();
   hit.localRay.t.lower = ray::t();
   hit.localRay.t.upper = ray::volume_out_t();
-
-  const auto &handle = optixGetTransformListHandle(0);
-  const ::float4 *tW = optixGetInstanceTransformFromHandle(handle);
-  const ::float4 *tO = optixGetInstanceInverseTransformFromHandle(handle);
-
-  hit.objectToWorld[0] = bit_cast<vec4>(tW[0]);
-  hit.objectToWorld[1] = bit_cast<vec4>(tW[1]);
-  hit.objectToWorld[2] = bit_cast<vec4>(tW[2]);
-
-  hit.worldToObject[0] = bit_cast<vec4>(tO[0]);
-  hit.worldToObject[1] = bit_cast<vec4>(tO[1]);
-  hit.worldToObject[2] = bit_cast<vec4>(tO[2]);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/devices/rtx/device/gpu/renderer/raygen_helpers.h
+++ b/devices/rtx/device/gpu/renderer/raygen_helpers.h
@@ -78,7 +78,11 @@ VISRTX_DEVICE void renderPixel(FrameGPUData &frameData, ScreenSample ss)
     // First go with the main ray, pixel centered if first frame.
     // Jittered samples are produced by next iterations.
     bool isVeryFirstRay = i == 0 && ss.frameData->fb.frameID == 0;
-    auto ray = makePrimaryRay(ss, isVeryFirstRay);
+    const uint32_t sampleIdx =
+        uint32_t(ss.frameData->fb.frameID)
+            * uint32_t(rendererParams.numIterations)
+        + uint32_t(i);
+    auto ray = makePrimaryRay(ss, sampleIdx, isVeryFirstRay);
     applyCuttingPlane(rendererParams.cutPlane, ray);
     float tmax = ray.t.upper;
 

--- a/devices/rtx/device/gpu/sampleLight.h
+++ b/devices/rtx/device/gpu/sampleLight.h
@@ -41,7 +41,6 @@
 #include <glm/gtx/color_space.hpp>
 
 // cuda
-#include <curand_uniform.h>
 #include <device_atomic_functions.h>
 
 // cccl
@@ -108,8 +107,8 @@ VISRTX_DEVICE LightSample sampleSphereLight(
     const LightGPUData &ld, const mat4 &xfm, const vec3 &origin, RandState &rs)
 {
   LightSample ls;
-  auto u1 = curand_uniform(&rs);
-  auto u2 = curand_uniform(&rs);
+  auto u1 = pcg_uniform(&rs);
+  auto u2 = pcg_uniform(&rs);
 
   // Uniform sampling on unit sphere using Marsaglia's method
   // u1 maps to z-coordinate: z ∈ [-1, 1]
@@ -162,7 +161,7 @@ VISRTX_DEVICE LightSample sampleRectLight(
     const LightGPUData &ld, const mat4 &xfm, const vec3 &origin, RandState &rs)
 {
   LightSample ls;
-  auto uv = vec2(curand_uniform(&rs), curand_uniform(&rs));
+  auto uv = vec2(pcg_uniform(&rs), pcg_uniform(&rs));
 
   // Uniform sampling on rectangle: uv ∈ [0,1]² maps to rectangle
   auto rectangleSample = ld.rect.edge1 * uv.x + ld.rect.edge2 * uv.y;
@@ -209,8 +208,8 @@ VISRTX_DEVICE LightSample sampleRingLight(
     const LightGPUData &ld, const mat4 &xfm, const vec3 &origin, RandState &rs)
 {
   LightSample ls;
-  auto u1 = curand_uniform(&rs);
-  auto u2 = curand_uniform(&rs);
+  auto u1 = pcg_uniform(&rs);
+  auto u2 = pcg_uniform(&rs);
 
   // Sample angle uniformly around the ring: φ ∈ [0, 2π]
   auto phi = kTwoPi * u1;
@@ -352,10 +351,10 @@ VISRTX_DEVICE LightSample sampleHDRILight(
   // First sample row (y) using marginal CDF, then column (x) using conditional
   // CDF
   auto y = inverseSampleCDF(
-      ld.hdri.marginalCDF, ld.hdri.size.y, curand_uniform(&rs));
+      ld.hdri.marginalCDF, ld.hdri.size.y, pcg_uniform(&rs));
   auto x = inverseSampleCDF(ld.hdri.conditionalCDF + y * ld.hdri.size.x,
       ld.hdri.size.x,
-      curand_uniform(&rs));
+      pcg_uniform(&rs));
 
   auto xy = glm::uvec2(x, y);
 
@@ -365,7 +364,7 @@ VISRTX_DEVICE LightSample sampleHDRILight(
   }
 #endif
   // Add sub-pixel jitter to avoid aliasing
-  auto jitter = glm::vec2(curand_uniform(&rs), curand_uniform(&rs));
+  auto jitter = glm::vec2(pcg_uniform(&rs), pcg_uniform(&rs));
   auto uv =
       glm::clamp((glm::vec2(xy) + jitter) / glm::vec2(ld.hdri.size), 0.f, 1.f);
 

--- a/devices/rtx/device/gpu/sampleLight.h
+++ b/devices/rtx/device/gpu/sampleLight.h
@@ -117,7 +117,7 @@ VISRTX_DEVICE LightSample sampleSphereLight(
   // r is the radius in the xy-plane for this z-level
   auto r = sqrtf(std::max(0.f, 1.f - z * z));
   // u2 maps to azimuthal angle: φ ∈ [0, 2π]
-  auto phi = 2.f * float(M_PI) * u2;
+  auto phi = kTwoPi * u2;
   auto x = r * cosf(phi);
   auto y = r * sinf(phi);
 
@@ -147,7 +147,7 @@ VISRTX_DEVICE LightSample sampleSphereLight(
     // jacobian) Currently assumes uniform scaling or no scaling of the light
     // geometry
     float areaPdf =
-        1.f / (4.f * float(M_PI) * ld.sphere.radius * ld.sphere.radius);
+        1.f / (4.f * kPi * ld.sphere.radius * ld.sphere.radius);
     ls.pdf = areaPdf * pow2(ls.dist) / cosTheta;
   } else {
     // Back-facing surface element contributes no light
@@ -213,7 +213,7 @@ VISRTX_DEVICE LightSample sampleRingLight(
   auto u2 = curand_uniform(&rs);
 
   // Sample angle uniformly around the ring: φ ∈ [0, 2π]
-  auto phi = 2.0f * M_PI * u1;
+  auto phi = kTwoPi * u1;
 
   // Sample radial position uniformly by area between inner and outer radius
   // For uniform area sampling: r² = u₂(R² - r²) + r² where R=outer, r=inner
@@ -327,7 +327,7 @@ VISRTX_DEVICE LightSample sampleHDRILight(
   // Map spherical coordinates to UV texture coordinates
   // θ ∈ [0,π] → v ∈ [0,1], φ ∈ [0,2π] → u ∈ [0,1]
   auto uv = glm::vec2(thetaPhi.y, thetaPhi.x)
-      / glm::vec2(float(M_PI) * 2.0f, float(M_PI));
+      / glm::vec2(kTwoPi, kPi);
 
   auto radiance = sampleHDRI(ld, uv);
   // pdf_ω = (L/totalL) · pdfWeight; the equirectangular sinθ jacobian is
@@ -371,7 +371,7 @@ VISRTX_DEVICE LightSample sampleHDRILight(
 
   // Convert UV coordinates to spherical coordinates
   // uv.y ∈ [0,1] → θ ∈ [0,π], uv.x ∈ [0,1] → φ ∈ [0,2π]
-  auto thetaPhi = float(M_PI) * glm::vec2(uv.y, 2.0f * (uv.x));
+  auto thetaPhi = kPi * glm::vec2(uv.y, 2.0f * (uv.x));
 
   // pdf_ω = (L/totalL) · pdfWeight; the equirectangular sinθ jacobian is
   // already folded into the CDF and pdfWeight, so do not re-multiply here.

--- a/devices/rtx/device/gpu/sbt.h
+++ b/devices/rtx/device/gpu/sbt.h
@@ -54,6 +54,12 @@ enum class SpatialFieldSamplerEntryPoints
 {
   Init = 0,
   Sample,
+  // Heavy Woodcock-loop bodies live as per-variant direct-callables in each
+  // sampler PTX module. Renderer wrappers in volumeIntegration.h compute
+  // (samplerCallableIndex + offset) and invoke via optixDirectCall.
+  SampleDistance,
+  RatioTrackTransmittance,
+  RayMarchVolume,
   Count
 };
 

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -37,6 +37,7 @@
 
 #ifdef USE_MDL
 #include <mi/neuraylib/target_code_types.h>
+#include "libmdl/MDLBackendConfig.h"
 #endif
 
 // nanovdb
@@ -126,12 +127,13 @@ struct alignas(8) MDLShadingState
   TextureHandler textureHandler;
   ResourceData resData;
 
-  // The maximum number of samplers we support.
-  // See MDLCompiler.cpp numTextureSpaces and numTextureResults.
-  glm::vec4 textureResults[32];
-  glm::vec3 textureCoords[4];
-  glm::vec3 textureTangentsU[4];
-  glm::vec3 textureTangentsV[4];
+  // Sized to match the MDL backend's num_texture_spaces / num_texture_results
+  // options — see libmdl/MDLBackendConfig.h. The two sides must agree because
+  // MDL's generated PTX indexes these arrays directly.
+  glm::vec4 textureResults[libmdl::kNumTextureResults];
+  glm::vec3 textureCoords[libmdl::kNumTextureSpaces];
+  glm::vec3 textureTangentsU[libmdl::kNumTextureSpaces];
+  glm::vec3 textureTangentsV[libmdl::kNumTextureSpaces];
 
   bool isFrontFace;
 };

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -111,7 +111,7 @@ struct PhysicallyBasedShadingState
 struct TextureHandler : mi::neuraylib::Texture_handler_base
 {
   const visrtx::FrameGPUData *fd;
-  visrtx::DeviceObjectIndex samplers[32];
+  const visrtx::DeviceObjectIndex *samplers;
   unsigned int numSamplers;
 };
 
@@ -125,7 +125,6 @@ struct alignas(8) MDLShadingState
   ShadingStateMaterial state;
   TextureHandler textureHandler;
   ResourceData resData;
-
 
   // The maximum number of samplers we support.
   // See MDLCompiler.cpp numTextureSpaces and numTextureResults.

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -183,7 +183,9 @@ template <typename T>
 struct NvdbRegularSamplerState
 {
   using GridType = nanovdb::Grid<nanovdb::NanoTree<T>>;
-  using AccessorType = typename GridType::AccessorType;
+  // Purposefully use ReadAccessor<> as below instead of default
+  // GridType::ReadAccessor. Keeps less cache state that we never hit anyway.
+  using AccessorType = nanovdb::ReadAccessor<T, 0, -1, -1>;
   using NearestSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 0>;
   using LinearSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
 
@@ -208,7 +210,9 @@ template <typename T>
 struct NvdbRectilinearSamplerState
 {
   using GridType = nanovdb::Grid<nanovdb::NanoTree<T>>;
-  using AccessorType = typename GridType::AccessorType;
+  // Purposefully use ReadAccessor<> as below instead of default
+  // GridType::ReadAccessor. Keeps less cache state that we never hit anyway.
+  using AccessorType = nanovdb::ReadAccessor<T, 0, -1, -1>;
   using NearestSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 0>;
   using LinearSamplerType = nanovdb::math::SampleFromVoxels<AccessorType, 1>;
 

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -126,8 +126,6 @@ struct alignas(8) MDLShadingState
   TextureHandler textureHandler;
   ResourceData resData;
 
-  glm::mat3x4 objectToWorld;
-  glm::mat3x4 worldToObject;
 
   // The maximum number of samplers we support.
   // See MDLCompiler.cpp numTextureSpaces and numTextureResults.

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -199,6 +199,7 @@ struct NvdbRegularSamplerState
   nanovdb::Vec3f scale;
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
+  nanovdb::Vec3f invTwoVoxelSize;
   SpatialFieldFilter filter;
 };
 

--- a/devices/rtx/device/gpu/volumeIntegration.h
+++ b/devices/rtx/device/gpu/volumeIntegration.h
@@ -31,17 +31,19 @@
 
 #pragma once
 
+// Renderer-side volume integration dispatch. Heavy Woodcock bodies live as
+// per-sampler direct-callables in `spatial_field/*Sampler_ptx.cu`; wrappers
+// here are `optixDirectCall` shims (one call per ray segment).
+//
+// RAY_TYPE-templated outer loops stay here — they invoke
+// `intersectVolume<RAY_TYPE>` then dispatch per-segment via the same shim.
+
 #include "gpu/gpu_decl.h"
 #include "gpu/gpu_objects.h"
 #include "gpu/gpu_util.h"
-#include "gpu/gridTraversal.h"
+#include "gpu/intersectRay.h"
+#include "gpu/sbt.h"
 #include "gpu/shadingState.h"
-
-// cuda
-#include <texture_types.h>
-
-// nanovdb
-#include <nanovdb/NanoVDB.h>
 
 // optix
 #include <optix_device.h>
@@ -56,371 +58,11 @@ VISRTX_DEVICE const SpatialFieldGPUData &getSpatialFieldData(
   return frameData.registry.fields[idx];
 }
 
-VISRTX_DEVICE void volumeSamplerInit(
-    VolumeSamplingState *samplerState, const SpatialFieldGPUData &field)
-{
-  optixDirectCall<void>(uint32_t(field.samplerCallableIndex)
-          + static_cast<uint32_t>(SpatialFieldSamplerEntryPoints::Init),
-      samplerState,
-      &field);
-}
-
-VISRTX_DEVICE float volumeSamplerSample(const VolumeSamplingState *samplerState,
-    const SpatialFieldGPUData &field,
-    const vec3 &position)
-{
-  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
-          + static_cast<uint32_t>(SpatialFieldSamplerEntryPoints::Sample),
-      samplerState,
-      &position,
-      (vec3 *)nullptr);
-}
-
-VISRTX_DEVICE float volumeSamplerSampleWithGradient(
-    const VolumeSamplingState *samplerState,
-    const SpatialFieldGPUData &field,
-    const vec3 &position,
-    vec3 *gradient)
-{
-  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
-          + static_cast<uint32_t>(SpatialFieldSamplerEntryPoints::Sample),
-      samplerState,
-      &position,
-      gradient);
-}
-
-namespace detail {
-
-VISRTX_DEVICE vec4 classifySample(const VolumeGPUData &v, float s)
-{
-  vec4 retval(0.f);
-  switch (v.type) {
-  case VolumeType::TF1D: {
-    if (v.data.tf1d.tfTex) {
-      float coord = position(s, v.data.tf1d.valueRange);
-      retval = make_vec4(tex1D<::float4>(v.data.tf1d.tfTex, coord));
-    } else
-      retval = vec4(v.data.tf1d.uniformColor, v.data.tf1d.uniformOpacity);
-    break;
-  }
-  default:
-    break;
-  }
-  return retval;
-}
-
-VISRTX_DEVICE float opacityToExtinction(
-    float opacity, float oneOverUnitDistance)
-{
-  constexpr float OPACITY_EPSILON = 1e-7f;
-  // Ceiling = largest float < 1 (1 - 2⁻²⁴). Keeps 1-α representable for
-  // log() and pins σ_t ≤ σ_maj (cell majorant uses same clamp) — invariant
-  // for the residual ratio-tracking estimator.
-  constexpr float OPACITY_CEILING = 1.f - 0x1p-24f;
-  const float clampedOpacity = glm::clamp(opacity, 0.f, OPACITY_CEILING);
-  if (clampedOpacity <= OPACITY_EPSILON || !(oneOverUnitDistance > 0.f))
-    return 0.f;
-  return -logf(1.f - clampedOpacity) * oneOverUnitDistance;
-}
-
-VISRTX_DEVICE vec3 computeWorldNormal(const VolumeSamplingState *samplerState,
-    const SpatialFieldGPUData &field,
-    const vec3 &localPos,
-    const mat3x4 &worldToObject)
-{
-  vec3 localGradient(0.f);
-  volumeSamplerSampleWithGradient(
-      samplerState, field, localPos, &localGradient);
-  constexpr float MIN_GRADIENT_LENGTH_SQ = 1e-12f;
-  if (glm::dot(localGradient, localGradient) <= MIN_GRADIENT_LENGTH_SQ)
-    return vec3(0.f);
-  const mat3 normalXfm = glm::transpose(mat3(worldToObject));
-  const vec3 worldNormal = normalXfm * (-localGradient);
-  const float worldNormalLength = glm::length(worldNormal);
-  constexpr float MIN_WORLD_NORMAL_LENGTH = 1e-6f;
-  if (worldNormalLength <= MIN_WORLD_NORMAL_LENGTH)
-    return vec3(0.f);
-  return worldNormal * (1.f / worldNormalLength);
-}
-
-VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
-    const VolumeHit &hit,
-    vec3 *color,
-    vec3 *normal,
-    float &opacity,
-    float invSamplingRate)
-{
-  const auto &volume = *hit.volume;
-  auto &svv = volume.data.tf1d;
-  auto &field = getSpatialFieldData(*ss.frameData, svv.field);
-
-  // The local ray direction is actually accounting for instance scaling
-  // transformation, meaning it's not a unit vector.
-  // We need to use that to compensate our step size.
-  const float localDirLen = glm::length(hit.localRay.dir);
-  const float localStep = volume.stepSize * invSamplingRate;
-  if (localStep <= 0.f || localDirLen <= 0.f)
-    return std::numeric_limits<float>::max();
-  const float dt = localStep / localDirLen;
-  const float exponent = dt * svv.oneOverUnitDistance;
-
-  const Ray objRay = hit.localRay;
-  if (!(objRay.t.lower < objRay.t.upper))
-    return std::numeric_limits<float>::max();
-
-  VolumeSamplingState samplerState;
-  volumeSamplerInit(&samplerState, field);
-
-  float depth = std::numeric_limits<float>::max();
-
-  constexpr float MIN_OPACITY_THRESHOLD = 1e-2f;
-  constexpr float MAX_OPACITY_THRESHOLD = 0.99f;
-
-  const float jitter =
-      curand_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
-  float nextSampleT = objRay.t.lower + jitter;
-
-  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
-  while (trav.valid()) {
-    if (opacity >= MAX_OPACITY_THRESHOLD)
-      break;
-
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
-    if (maxOpacity <= 0.f) {
-      trav.next();
-      continue;
-    }
-
-    // Snap lattice to first sample inside the cell.
-    if (nextSampleT < trav.tEntry) {
-      const float advance = ceilf((trav.tEntry - nextSampleT) / dt);
-      nextSampleT += advance * dt;
-    }
-
-    while (nextSampleT < trav.tExit) {
-      if (opacity >= MAX_OPACITY_THRESHOLD)
-        break;
-      const vec3 p = objRay.org + objRay.dir * nextSampleT;
-
-      const float s = volumeSamplerSample(&samplerState, field, p);
-      if (!glm::isnan(s)) {
-        const vec4 co = classifySample(volume, s);
-
-        const float stepAlpha = 1.0f - glm::pow(1.0f - co.w, exponent);
-        if (stepAlpha > 0.0f) {
-          const float weight = (1.0f - opacity);
-          if (color)
-            *color += weight * stepAlpha * vec3(co);
-          opacity += weight * stepAlpha;
-
-          if (opacity > MIN_OPACITY_THRESHOLD
-              && depth == std::numeric_limits<float>::max())
-            depth = nextSampleT;
-        }
-      }
-
-      nextSampleT += dt;
-    }
-    trav.next();
-  }
-
-  if (normal) {
-    *normal = vec3(0.f);
-    if (depth < std::numeric_limits<float>::max()) {
-      const vec3 p = objRay.org + objRay.dir * depth;
-      *normal = computeWorldNormal(&samplerState, field, p, hit.worldToObject);
-    }
-  }
-
-  return depth;
-}
-
-// Decomposition tracking (Kutz/Thiery/Novák/Iwasaki 2017). Per cell split
-// σ_t = σ_c + σ_r (σ_c = per-cell min, σ_r ∈ [0, σ_maj - σ_c]). Race a
-// closed-form Exp(σ_c) flight against a Woodcock walk on σ_r; first event
-// wins. Albedo/extinction use local σ_t at the event point. σ_c = 0 →
-// plain delta tracking; σ_r = 0 → analytic flight only.
-VISRTX_DEVICE float sampleDistance(ScreenSample &ss,
-    const VolumeHit &hit,
-    vec3 &albedo,
-    float &extinction,
-    bool &didScatter,
-    vec3 *normal = nullptr)
-{
-  const auto &volume = *hit.volume;
-  auto &svv = volume.data.tf1d;
-  auto &field = getSpatialFieldData(*ss.frameData, svv.field);
-
-  VolumeSamplingState samplerState;
-  volumeSamplerInit(&samplerState, field);
-
-  albedo = vec3(0.f);
-  extinction = 0.f;
-  didScatter = false;
-  if (normal)
-    *normal = vec3(0.f);
-
-  float scatterT = hit.localRay.t.upper;
-  vec3 scatterPos(0.f);
-  const Ray objRay = hit.localRay;
-  if (!(objRay.t.lower < objRay.t.upper))
-    return scatterT;
-
-  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
-  while (trav.valid()) {
-    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
-    const float σ_min =
-        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
-    const float σ_maj =
-        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
-    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
-
-    if (σ_maj <= 0.f) {
-      trav.next();
-      continue;
-    }
-
-    // Closed-form control free-flight starting at trav.tEntry.
-    const float t_control = σ_min > 0.f
-        ? trav.tEntry
-            - logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_min
-        : std::numeric_limits<float>::infinity();
-    const float residualCutoff = fminf(t_control, trav.tExit);
-
-    float t = trav.tEntry;
-    if (σ_residual > 0.f) {
-      while (t < residualCutoff) {
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_residual;
-        if (t >= residualCutoff)
-          break;
-
-        const vec3 p = objRay.org + objRay.dir * t;
-        const float s = volumeSamplerSample(&samplerState, field, p);
-        if (glm::isnan(s))
-          continue;
-
-        const vec4 co = detail::classifySample(volume, s);
-        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
-        // σ_t_p ≥ σ_min by construction; residual at p is σ_t_p - σ_min.
-        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
-        if (σ_r_p >= curand_uniform(&ss.rs) * σ_residual) {
-          albedo = vec3(co);
-          extinction = σ_t_p;
-          didScatter = true;
-          scatterPos = p;
-          scatterT = t;
-          break;
-        }
-      }
-    }
-
-    // If the residual walk didn't fire, accept the control flight if it
-    // landed inside the cell. Every control event is real (σ_min is a lower
-    // bound on σ_t).
-    if (!didScatter && t_control < trav.tExit) {
-      const vec3 p = objRay.org + objRay.dir * t_control;
-      const float s = volumeSamplerSample(&samplerState, field, p);
-      if (!glm::isnan(s)) {
-        const vec4 co = detail::classifySample(volume, s);
-        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
-        albedo = vec3(co);
-        extinction = σ_t_p;
-        didScatter = true;
-        scatterPos = p;
-        scatterT = t_control;
-      }
-    }
-
-    if (didScatter)
-      break;
-    trav.next();
-  }
-
-  if (normal && didScatter) {
-    *normal =
-        computeWorldNormal(&samplerState, field, scatterPos, hit.worldToObject);
-  }
-
-  return scatterT;
-}
-
-// Residual ratio tracking (Novák et al. 2014). Per cell split σ_t = σ_c +
-// σ_r; fold exp(-σ_c · L) into attenuation closed-form, then ratio-track
-// σ_r at majorant σ_r_maj = σ_maj - σ_c (multiply by (1 - σ_r / σ_r_maj)
-// per candidate). Tighter than plain ratio tracking when σ_c > 0.
-VISRTX_DEVICE void ratioTrackTransmittance(
-    ScreenSample &ss, const VolumeHit &hit, vec3 &attenuation)
-{
-  const auto &volume = *hit.volume;
-  auto &svv = volume.data.tf1d;
-  auto &field = getSpatialFieldData(*ss.frameData, svv.field);
-
-  const Ray objRay = hit.localRay;
-  if (!(objRay.t.lower < objRay.t.upper))
-    return;
-
-  // Match Quality_ptx.cu's ATTENUATION_EPSILON.
-  constexpr float TRANSMITTANCE_EPSILON = std::numeric_limits<float>::epsilon();
-
-  VolumeSamplingState samplerState;
-  volumeSamplerInit(&samplerState, field);
-
-  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
-  while (trav.valid()) {
-    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
-    const float σ_min =
-        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
-    const float σ_maj =
-        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
-    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
-
-    if (σ_maj <= 0.f) {
-      trav.next();
-      continue;
-    }
-
-    // Closed-form control factor exp(-σ_min · cell-length) folded into
-    // attenuation. No ratio walk needed for this component.
-    const float cellLength = fmaxf(0.f, trav.tExit - trav.tEntry);
-    if (σ_min > 0.f) {
-      attenuation *= __expf(-σ_min * cellLength);
-      if (glm::all(
-              glm::lessThanEqual(attenuation, vec3(TRANSMITTANCE_EPSILON))))
-        return;
-    }
-
-    // Ratio-track the residual. Note σ_residual can be zero (uniform cell),
-    // in which case the control factor is the complete answer.
-    if (σ_residual > 0.f) {
-      float t = trav.tEntry;
-      while (true) {
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_residual;
-        if (t >= trav.tExit)
-          break;
-
-        const vec3 p = objRay.org + objRay.dir * t;
-        const float s = volumeSamplerSample(&samplerState, field, p);
-        if (glm::isnan(s))
-          continue;
-
-        const vec4 co = classifySample(volume, s);
-        const float σ_t_p = opacityToExtinction(co.w, svv.oneOverUnitDistance);
-        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
-        const float ratio = glm::clamp(σ_r_p / σ_residual, 0.f, 1.f);
-        attenuation *= (1.0f - ratio);
-
-        if (glm::all(
-                glm::lessThanEqual(attenuation, vec3(TRANSMITTANCE_EPSILON))))
-          return;
-      }
-    }
-    trav.next();
-  }
-}
-
-} // namespace detail
+// ---------------------------------------------------------------------------
+// Per-segment dispatch wrappers. Resolve sampler callable base offset,
+// invoke per-variant Woodcock body. One direct-call amortised over the
+// 10–100 candidates running inside the callable.
+// ---------------------------------------------------------------------------
 
 VISRTX_DEVICE float sampleDistanceVolume(ScreenSample &ss,
     const VolumeHit &hit,
@@ -429,14 +71,28 @@ VISRTX_DEVICE float sampleDistanceVolume(ScreenSample &ss,
     bool &didScatter,
     vec3 *normal = nullptr)
 {
-  return detail::sampleDistance(
-      ss, hit, albedo, extinction, didScatter, normal);
+  const auto &field =
+      getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::SampleDistance),
+      &ss,
+      &hit,
+      &albedo,
+      &extinction,
+      &didScatter,
+      normal);
 }
 
 VISRTX_DEVICE void ratioTrackTransmittanceVolume(
     ScreenSample &ss, const VolumeHit &hit, vec3 &attenuation)
 {
-  detail::ratioTrackTransmittance(ss, hit, attenuation);
+  const auto &field =
+      getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+  optixDirectCall<void>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance),
+      &ss,
+      &hit,
+      &attenuation);
 }
 
 VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
@@ -444,8 +100,16 @@ VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
     float &opacity,
     float invSamplingRate)
 {
-  return detail::rayMarchVolume(
-      ss, hit, nullptr, nullptr, opacity, invSamplingRate);
+  const auto &field =
+      getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::RayMarchVolume),
+      &ss,
+      &hit,
+      (vec3 *)nullptr,
+      (vec3 *)nullptr,
+      &opacity,
+      invSamplingRate);
 }
 
 VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
@@ -454,9 +118,23 @@ VISRTX_DEVICE float rayMarchVolume(ScreenSample &ss,
     float &opacity,
     float invSamplingRate)
 {
-  return detail::rayMarchVolume(
-      ss, hit, &color, nullptr, opacity, invSamplingRate);
+  const auto &field =
+      getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::RayMarchVolume),
+      &ss,
+      &hit,
+      &color,
+      (vec3 *)nullptr,
+      &opacity,
+      invSamplingRate);
 }
+
+// ---------------------------------------------------------------------------
+// RAY_TYPE-templated outer loops. Surface / shadow / AOV pass each picks
+// up its own `intersectVolume<RAY_TYPE>` overload; per-segment dispatch
+// goes through the wrappers above.
+// ---------------------------------------------------------------------------
 
 template <typename RAY_TYPE>
 VISRTX_DEVICE float rayMarchAllVolumes(ScreenSample &ss,
@@ -489,12 +167,17 @@ VISRTX_DEVICE float rayMarchAllVolumes(ScreenSample &ss,
 
     // Ray march through this volume segment
     vec3 thisNormal(0.f);
-    float thisDepth = detail::rayMarchVolume(ss,
-        hit,
-        &color,
-        normal ? &thisNormal : nullptr,
-        opacity,
-        invSamplingRate);
+    const auto &field =
+        getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+    float thisDepth =
+        optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
+                + uint32_t(SpatialFieldSamplerEntryPoints::RayMarchVolume),
+            &ss,
+            &hit,
+            &color,
+            normal ? &thisNormal : (vec3 *)nullptr,
+            &opacity,
+            invSamplingRate);
 
     // Track closest intersection depth
     if (thisDepth < depth) {
@@ -549,8 +232,16 @@ VISRTX_DEVICE float sampleDistanceAllVolumes(ScreenSample &ss,
     vec3 norm(0.f);
     float ext = 0.f;
     bool segmentDidScatter = false;
-    float d = detail::sampleDistance(
-        ss, hit, alb, ext, segmentDidScatter, normal ? &norm : nullptr);
+    const auto &fld =
+        getSpatialFieldData(*ss.frameData, hit.volume->data.tf1d.field);
+    float d = optixDirectCall<float>(uint32_t(fld.samplerCallableIndex)
+            + uint32_t(SpatialFieldSamplerEntryPoints::SampleDistance),
+        &ss,
+        &hit,
+        &alb,
+        &ext,
+        &segmentDidScatter,
+        normal ? &norm : (vec3 *)nullptr);
     if (segmentDidScatter) {
       depth = d;
       albedo = alb;

--- a/devices/rtx/device/gpu/volumeIntegrationDetail.h
+++ b/devices/rtx/device/gpu/volumeIntegrationDetail.h
@@ -286,7 +286,7 @@ VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
     *normal = computeWorldNormal(samplerState,
         field,
         scatterPos,
-        hit.worldToObject,
+        hit.instance->worldToObject,
         sampleWithGradient);
   }
 
@@ -469,7 +469,7 @@ VISRTX_DEVICE  float latticeRayMarchVolume(ScreenSample &ss,
       *normal = computeWorldNormal(samplerState,
           field,
           p,
-          hit.worldToObject,
+          hit.instance->worldToObject,
           sampleWithGradient);
     }
   }

--- a/devices/rtx/device/gpu/volumeIntegrationDetail.h
+++ b/devices/rtx/device/gpu/volumeIntegrationDetail.h
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Shared helpers + Woodcock-body templates for the per-sampler callables.
+// Templates parameterised on state type and sample / sampleWithGradient
+// closures; each sampler _ptx.cu passes inline lambdas so codegen stays
+// monomorphic per variant.
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_math.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/gpu_util.h"
+#include "gpu/gridTraversal.h"
+#include "gpu/sbt.h"
+#include "gpu/shadingState.h"
+
+#include <curand_kernel.h>
+
+#include <limits>
+#include <type_traits>
+
+namespace visrtx {
+
+VISRTX_DEVICE const SpatialFieldGPUData &getSpatialFieldData(
+    const FrameGPUData &frameData, DeviceObjectIndex idx)
+{
+  return frameData.registry.fields[idx];
+}
+
+// Suppresses default ctor for `State` — some sampler states embed members
+// with deleted default ctors (nanovdb::ReadAccessor, SampleFromVoxels —
+// they hold references). Variant init writes into the raw storage via
+// assignment (trivially-copyable members) or placement-new (inner union).
+template <typename State>
+union SamplerStateBox
+{
+  // Empty dtor skips State's destruction — fine while sampler states hold
+  // only POD / non-owning refs. static_assert breaks the build if anyone
+  // adds a non-trivial destructor.
+  static_assert(std::is_trivially_destructible_v<State>,
+      "SamplerStateBox skips destruction; State must be trivially "
+      "destructible.");
+
+  State state;
+  VISRTX_DEVICE SamplerStateBox() {}
+  VISRTX_DEVICE ~SamplerStateBox() {}
+};
+
+namespace detail {
+
+VISRTX_DEVICE vec4 classifySample(const VolumeGPUData &v, float s)
+{
+  vec4 retval(0.f);
+  switch (v.type) {
+  case VolumeType::TF1D: {
+    if (v.data.tf1d.tfTex) {
+      float coord = position(s, v.data.tf1d.valueRange);
+      retval = make_vec4(tex1D<::float4>(v.data.tf1d.tfTex, coord));
+    } else
+      retval = vec4(v.data.tf1d.uniformColor, v.data.tf1d.uniformOpacity);
+    break;
+  }
+  default:
+    break;
+  }
+  return retval;
+}
+
+VISRTX_DEVICE float opacityToExtinction(
+    float opacity, float oneOverUnitDistance)
+{
+  constexpr float OPACITY_EPSILON = 1e-7f;
+  // Clamp ceiling at 1 - 2^-24 (largest float strictly less than 1) so
+  // 1 - α stays representable for log(). The cell majorant is computed with
+  // the same clamp; any non-saturating candidate's σ_t therefore stays ≤
+  // σ_maj — load-bearing invariant for the residual ratio-tracking estimator.
+  constexpr float OPACITY_CEILING = 1.f - 0x1p-24f;
+  const float clampedOpacity = glm::clamp(opacity, 0.f, OPACITY_CEILING);
+  if (clampedOpacity <= OPACITY_EPSILON || !(oneOverUnitDistance > 0.f))
+    return 0.f;
+  return -logf(1.f - clampedOpacity) * oneOverUnitDistance;
+}
+
+// Shadow ratio-track RR. Returns true on kill. Survive with
+// p = maxAttn / RR_THRESHOLD, rescale by 1/p — unbiased. Post-survival
+// max channel = RR_THRESHOLD by construction → weights bounded. Hard-kill
+// below TRANSMITTANCE_EPSILON.
+VISRTX_DEVICE bool applyShadowRussianRoulette(
+    vec3 &attenuation, ScreenSample &ss)
+{
+  // Higher → shorter shadow rays in dense regions, higher per-survival
+  // variance.
+  constexpr float RR_THRESHOLD = 0.5f;
+  constexpr float TRANSMITTANCE_EPSILON =
+      std::numeric_limits<float>::epsilon();
+
+  const float maxAttn =
+      glm::max(attenuation.x, glm::max(attenuation.y, attenuation.z));
+  if (maxAttn <= TRANSMITTANCE_EPSILON) {
+    attenuation = vec3(0.0f);
+    return true;
+  }
+  if (maxAttn >= RR_THRESHOLD)
+    return false;
+
+  const float pSurvive = maxAttn / RR_THRESHOLD;
+  if (curand_uniform(&ss.rs) > pSurvive) {
+    attenuation = vec3(0.0f);
+    return true;
+  }
+  attenuation *= (1.0f / pSurvive);
+  return false;
+}
+
+// `sampleWithGradient` is a __device__ lambda capturing nothing —
+// compiler inlines through it.
+template <typename State, typename SampleWithGradientFn>
+VISRTX_DEVICE  vec3 computeWorldNormal(const State &samplerState,
+    const SpatialFieldGPUData &field,
+    const vec3 &localPos,
+    const mat3x4 &worldToObject,
+    SampleWithGradientFn sampleWithGradient)
+{
+  vec3 localGradient(0.f);
+  sampleWithGradient(samplerState, field, localPos, localGradient);
+  constexpr float MIN_GRADIENT_LENGTH_SQ = 1e-12f;
+  if (glm::dot(localGradient, localGradient) <= MIN_GRADIENT_LENGTH_SQ)
+    return vec3(0.f);
+  const mat3 normalXfm = glm::transpose(mat3(worldToObject));
+  const vec3 worldNormal = normalXfm * (-localGradient);
+  const float worldNormalLength = glm::length(worldNormal);
+  constexpr float MIN_WORLD_NORMAL_LENGTH = 1e-6f;
+  if (worldNormalLength <= MIN_WORLD_NORMAL_LENGTH)
+    return vec3(0.f);
+  return worldNormal * (1.f / worldNormalLength);
+}
+
+// ---------------------------------------------------------------------------
+// Woodcock-loop body templates. Each sampler family's per-variant callable
+// passes its inline sample / sampleWithGradient closures (typically
+// __device__ lambdas) and an already-inited state. The compiler inlines
+// through the lambdas, so each variant's hot path is monomorphic.
+
+// Distance sampling via decomposition tracking (Kutz/Thiery/Novák/Iwasaki 2017):
+// inside each macrocell, split σ_t = σ_c + σ_r where σ_c = per-cell min
+// extinction (constant lower bound) and σ_r ∈ [0, σ_maj - σ_c]. Race a
+// closed-form Exp(σ_c) free-flight against a Woodcock walk on the residual.
+// Whichever fires first is the next event; both branches use the local σ_t at
+// the event point for albedo/extinction. Degenerates to pure delta tracking
+// when σ_c = 0 (sharp TF) and to closed-form analytic flight when σ_r = 0.
+template <typename State, typename SampleFn, typename SampleWithGradientFn>
+VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
+    const VolumeHit &hit,
+    State &samplerState,
+    const SpatialFieldGPUData &field,
+    vec3 &albedo,
+    float &extinction,
+    bool &didScatter,
+    vec3 *normal,
+    SampleFn sample,
+    SampleWithGradientFn sampleWithGradient)
+{
+  const auto &volume = *hit.volume;
+  auto &svv = volume.data.tf1d;
+
+  albedo = vec3(0.f);
+  extinction = 0.f;
+  didScatter = false;
+  if (normal)
+    *normal = vec3(0.f);
+
+  float scatterT = hit.localRay.t.upper;
+  vec3 scatterPos(0.f);
+  const Ray objRay = hit.localRay;
+  if (!(objRay.t.lower < objRay.t.upper))
+    return scatterT;
+
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
+  while (trav.valid()) {
+    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
+    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float σ_min =
+        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+    const float σ_maj =
+        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
+
+    if (σ_maj <= 0.f) {
+      trav.next();
+      continue;
+    }
+
+    // Closed-form control free-flight starting at trav.tEntry.
+    const float t_control = σ_min > 0.f
+        ? trav.tEntry
+            - logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_min
+        : std::numeric_limits<float>::infinity();
+    const float residualCutoff = fminf(t_control, trav.tExit);
+
+    float t = trav.tEntry;
+    if (σ_residual > 0.f) {
+      // Hoist the reciprocal out of the inner candidate loop — divisions
+      // by σ_residual are otherwise on the critical path for every
+      // candidate's t-advance and acceptance test.
+      const float invSigmaResidual = 1.0f / σ_residual;
+      while (t < residualCutoff) {
+        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
+            * invSigmaResidual;
+        if (t >= residualCutoff)
+          break;
+
+        const vec3 p = objRay.org + objRay.dir * t;
+        const float s = sample(samplerState, field, p);
+        if (glm::isnan(s))
+          continue;
+
+        const vec4 co = classifySample(volume, s);
+        const float σ_t_p =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        // σ_t_p ≥ σ_min by construction; residual at p is σ_t_p - σ_min.
+        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
+        if (σ_r_p * invSigmaResidual >= curand_uniform(&ss.rs)) {
+          albedo = vec3(co);
+          extinction = σ_t_p;
+          didScatter = true;
+          scatterPos = p;
+          scatterT = t;
+          break;
+        }
+      }
+    }
+
+    // If the residual walk didn't fire, accept the control flight if it
+    // landed inside the cell. Every control event is real (σ_min is a lower
+    // bound on σ_t).
+    if (!didScatter && t_control < trav.tExit) {
+      const vec3 p = objRay.org + objRay.dir * t_control;
+      const float s = sample(samplerState, field, p);
+      if (!glm::isnan(s)) {
+        const vec4 co = classifySample(volume, s);
+        const float σ_t_p =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        albedo = vec3(co);
+        extinction = σ_t_p;
+        didScatter = true;
+        scatterPos = p;
+        scatterT = t_control;
+      }
+    }
+
+    if (didScatter)
+      break;
+    trav.next();
+  }
+
+  if (normal && didScatter) {
+    *normal = computeWorldNormal(samplerState,
+        field,
+        scatterPos,
+        hit.worldToObject,
+        sampleWithGradient);
+  }
+
+  return scatterT;
+}
+
+// Residual ratio tracking (Novák et al. 2014) over one volume segment.
+// Splits σ_t = σ_c + σ_r per cell where σ_c is the per-cell min extinction
+// (constant lower bound). The control factor exp(-σ_c · L) is evaluated in
+// closed form per cell; the residual factor is ratio-tracked at majorant
+// σ_r_maj = σ_maj - σ_c, accumulating attenuation *= (1 - σ_r / σ_r_maj) per
+// candidate. Tighter than plain ratio tracking when σ_c > 0; degenerates to
+// plain ratio tracking when σ_c = 0.
+template <typename State, typename SampleFn>
+VISRTX_DEVICE  void woodcockRatioTrackTransmittance(ScreenSample &ss,
+    const VolumeHit &hit,
+    State &samplerState,
+    const SpatialFieldGPUData &field,
+    vec3 &attenuation,
+    SampleFn sample)
+{
+  const auto &volume = *hit.volume;
+  auto &svv = volume.data.tf1d;
+
+  const Ray objRay = hit.localRay;
+  if (!(objRay.t.lower < objRay.t.upper))
+    return;
+
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
+  while (trav.valid()) {
+    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
+    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float σ_min =
+        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+    const float σ_maj =
+        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+    const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
+
+    if (σ_maj <= 0.f) {
+      trav.next();
+      continue;
+    }
+
+    // Closed-form control factor exp(-σ_min · cell-length) folded into
+    // attenuation. No ratio walk needed for this component.
+    const float cellLength = fmaxf(0.f, trav.tExit - trav.tEntry);
+    if (σ_min > 0.f) {
+      attenuation *= __expf(-σ_min * cellLength);
+      if (applyShadowRussianRoulette(attenuation, ss))
+        return;
+    }
+
+    // Ratio-track the residual. Note σ_residual can be zero (uniform cell),
+    // in which case the control factor is the complete answer.
+    if (σ_residual > 0.f) {
+      // Hoist the reciprocal — same rationale as sampleDistance.
+      const float invSigmaResidual = 1.0f / σ_residual;
+      float t = trav.tEntry;
+      while (true) {
+        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
+            * invSigmaResidual;
+        if (t >= trav.tExit)
+          break;
+
+        const vec3 p = objRay.org + objRay.dir * t;
+        const float s = sample(samplerState, field, p);
+        if (glm::isnan(s))
+          continue;
+
+        const vec4 co = classifySample(volume, s);
+        const float σ_t_p =
+            opacityToExtinction(co.w, svv.oneOverUnitDistance);
+        const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
+        const float ratio = glm::clamp(σ_r_p * invSigmaResidual, 0.f, 1.f);
+        attenuation *= (1.0f - ratio);
+
+        if (applyShadowRussianRoulette(attenuation, ss))
+          return;
+      }
+    }
+    trav.next();
+  }
+}
+
+// Front-to-back lattice integration (the non-distance-sampling renderers'
+// shadow / AOV path). Sample positions across the whole interval lie on a
+// fixed dt-spaced lattice; each macrocell continues marching where the
+// previous one left off — empty cells are skipped without disturbing the
+// lattice phase. Despite living next to the Woodcock-family bodies above,
+// this is deterministic emission-absorption ray marching: the macrocell
+// `maxOpacity` is used only as an empty-cell flag, never as a majorant for
+// null-collision sampling.
+template <typename State, typename SampleFn, typename SampleWithGradientFn>
+VISRTX_DEVICE  float latticeRayMarchVolume(ScreenSample &ss,
+    const VolumeHit &hit,
+    State &samplerState,
+    const SpatialFieldGPUData &field,
+    vec3 *color,
+    vec3 *normal,
+    float &opacity,
+    float invSamplingRate,
+    SampleFn sample,
+    SampleWithGradientFn sampleWithGradient)
+{
+  const auto &volume = *hit.volume;
+  auto &svv = volume.data.tf1d;
+
+  // The local ray direction accounts for instance scaling transformation,
+  // meaning it's not a unit vector. We use that to compensate step size.
+  const float localDirLen = glm::length(hit.localRay.dir);
+  const float localStep = volume.stepSize * invSamplingRate;
+  if (localStep <= 0.f || localDirLen <= 0.f)
+    return std::numeric_limits<float>::max();
+  const float dt = localStep / localDirLen;
+  const float exponent = dt * svv.oneOverUnitDistance;
+
+  const Ray objRay = hit.localRay;
+  if (!(objRay.t.lower < objRay.t.upper))
+    return std::numeric_limits<float>::max();
+
+  float depth = std::numeric_limits<float>::max();
+
+  constexpr float MIN_OPACITY_THRESHOLD = 1e-2f;
+  constexpr float MAX_OPACITY_THRESHOLD = 0.99f;
+
+  // Single stratified jitter at the segment start.
+  const float jitter =
+      curand_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
+  float nextSampleT = objRay.t.lower + jitter;
+
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
+  while (trav.valid()) {
+    if (opacity >= MAX_OPACITY_THRESHOLD)
+      break;
+
+    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    if (maxOpacity <= 0.f) {
+      trav.next();
+      continue;
+    }
+
+    // Skip forward on the global sample lattice to the first sample inside
+    // this cell.
+    if (nextSampleT < trav.tEntry) {
+      const float advance = ceilf((trav.tEntry - nextSampleT) / dt);
+      nextSampleT += advance * dt;
+    }
+
+    while (nextSampleT < trav.tExit) {
+      if (opacity >= MAX_OPACITY_THRESHOLD)
+        break;
+      const vec3 p = objRay.org + objRay.dir * nextSampleT;
+
+      const float s = sample(samplerState, field, p);
+      if (!glm::isnan(s)) {
+        const vec4 co = classifySample(volume, s);
+
+        const float stepAlpha = 1.0f - glm::pow(1.0f - co.w, exponent);
+        if (stepAlpha > 0.0f) {
+          const float weight = (1.0f - opacity);
+          if (color)
+            *color += weight * stepAlpha * vec3(co);
+          opacity += weight * stepAlpha;
+
+          if (opacity > MIN_OPACITY_THRESHOLD
+              && depth == std::numeric_limits<float>::max())
+            depth = nextSampleT;
+        }
+      }
+
+      nextSampleT += dt;
+    }
+    trav.next();
+  }
+
+  if (normal) {
+    *normal = vec3(0.f);
+    if (depth < std::numeric_limits<float>::max()) {
+      const vec3 p = objRay.org + objRay.dir * depth;
+      *normal = computeWorldNormal(samplerState,
+          field,
+          p,
+          hit.worldToObject,
+          sampleWithGradient);
+    }
+  }
+
+  return depth;
+}
+
+} // namespace detail
+} // namespace visrtx

--- a/devices/rtx/device/gpu/volumeIntegrationDetail.h
+++ b/devices/rtx/device/gpu/volumeIntegrationDetail.h
@@ -112,17 +112,29 @@ VISRTX_DEVICE float opacityToExtinction(
 }
 
 // Shadow ratio-track RR. Returns true on kill. Survive with
-// p = maxAttn / RR_THRESHOLD, rescale by 1/p — unbiased. Post-survival
-// max channel = RR_THRESHOLD by construction → weights bounded. Hard-kill
-// below TRANSMITTANCE_EPSILON.
+// p = maxAttn / threshold, rescale by 1/p — unbiased.
+//
+// `ss.shadowContribWeight ∈ (0, 1]` (raygen-set, = maxContrib / RR_BASE)
+// raises the threshold for dim rays so RR engages sooner. Per-ray variance
+// climbs; per-ray expected work drops faster.
+//
+// Amplification 1/pSurvive = rrThreshold/maxAttn. RR_MAX_THRESHOLD caps the
+// numerator; maxAttn floats with transmittance and can land near
+// TRANSMITTANCE_EPSILON → worst-case amplification ~6.7e7 with these
+// constants. Unbiased in expectation; downstream firefly filter handles
+// the tail.
 VISRTX_DEVICE bool applyShadowRussianRoulette(
     vec3 &attenuation, ScreenSample &ss)
 {
-  // Higher → shorter shadow rays in dense regions, higher per-survival
-  // variance.
-  constexpr float RR_THRESHOLD = 0.5f;
+  constexpr float RR_BASE = 0.5f;
+  // Numerator cap. Does NOT bound amplification — see header comment.
+  constexpr float RR_MAX_THRESHOLD = 8.0f;
+  constexpr float MIN_CONTRIB_WEIGHT = 1.0e-3f;
   constexpr float TRANSMITTANCE_EPSILON =
       std::numeric_limits<float>::epsilon();
+
+  const float w = glm::max(ss.shadowContribWeight, MIN_CONTRIB_WEIGHT);
+  const float rrThreshold = glm::min(RR_BASE / w, RR_MAX_THRESHOLD);
 
   const float maxAttn =
       glm::max(attenuation.x, glm::max(attenuation.y, attenuation.z));
@@ -130,10 +142,10 @@ VISRTX_DEVICE bool applyShadowRussianRoulette(
     attenuation = vec3(0.0f);
     return true;
   }
-  if (maxAttn >= RR_THRESHOLD)
+  if (maxAttn >= rrThreshold)
     return false;
 
-  const float pSurvive = maxAttn / RR_THRESHOLD;
+  const float pSurvive = maxAttn / rrThreshold;
   if (curand_uniform(&ss.rs) > pSurvive) {
     attenuation = vec3(0.0f);
     return true;

--- a/devices/rtx/device/gpu/volumeIntegrationDetail.h
+++ b/devices/rtx/device/gpu/volumeIntegrationDetail.h
@@ -44,7 +44,7 @@
 #include "gpu/sbt.h"
 #include "gpu/shadingState.h"
 
-#include <curand_kernel.h>
+// PCG RNG, see gpu/pcg.h
 
 #include <limits>
 #include <type_traits>
@@ -146,7 +146,7 @@ VISRTX_DEVICE bool applyShadowRussianRoulette(
     return false;
 
   const float pSurvive = maxAttn / rrThreshold;
-  if (curand_uniform(&ss.rs) > pSurvive) {
+  if (pcg_uniform(&ss.rs) >= pSurvive) {
     attenuation = vec3(0.0f);
     return true;
   }
@@ -234,7 +234,7 @@ VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
     // Closed-form control free-flight starting at trav.tEntry.
     const float t_control = σ_min > 0.f
         ? trav.tEntry
-            - logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs))) / σ_min
+            - logf(fmaxf(1e-10f, pcg_uniform(&ss.rs))) / σ_min
         : std::numeric_limits<float>::infinity();
     const float residualCutoff = fminf(t_control, trav.tExit);
 
@@ -245,7 +245,7 @@ VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
       // candidate's t-advance and acceptance test.
       const float invSigmaResidual = 1.0f / σ_residual;
       while (t < residualCutoff) {
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
+        t += -logf(fmaxf(1e-10f, pcg_uniform(&ss.rs)))
             * invSigmaResidual;
         if (t >= residualCutoff)
           break;
@@ -260,7 +260,7 @@ VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
             opacityToExtinction(co.w, svv.oneOverUnitDistance);
         // σ_t_p ≥ σ_min by construction; residual at p is σ_t_p - σ_min.
         const float σ_r_p = fmaxf(0.f, σ_t_p - σ_min);
-        if (σ_r_p * invSigmaResidual >= curand_uniform(&ss.rs)) {
+        if (σ_r_p * invSigmaResidual > pcg_uniform(&ss.rs)) {
           albedo = vec3(co);
           extinction = σ_t_p;
           didScatter = true;
@@ -357,7 +357,7 @@ VISRTX_DEVICE  void woodcockRatioTrackTransmittance(ScreenSample &ss,
       const float invSigmaResidual = 1.0f / σ_residual;
       float t = trav.tEntry;
       while (true) {
-        t += -logf(fmaxf(1e-10f, 1.f - curand_uniform(&ss.rs)))
+        t += -logf(fmaxf(1e-10f, pcg_uniform(&ss.rs)))
             * invSigmaResidual;
         if (t >= trav.tExit)
           break;
@@ -425,7 +425,7 @@ VISRTX_DEVICE  float latticeRayMarchVolume(ScreenSample &ss,
 
   // Single stratified jitter at the segment start.
   const float jitter =
-      curand_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
+      pcg_uniform(&ss.rs) * fminf(dt, objRay.t.upper - objRay.t.lower);
   float nextSampleT = objRay.t.lower + jitter;
 
   GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);

--- a/devices/rtx/device/gpu/volumeIntegrationDetail.h
+++ b/devices/rtx/device/gpu/volumeIntegrationDetail.h
@@ -207,12 +207,11 @@ VISRTX_DEVICE  float woodcockSampleDistance(ScreenSample &ss,
 
   GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
   while (trav.valid()) {
-    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float2 bounds = __ldg(&field.grid.opacityBounds[trav.cellIndex]);
     const float σ_min =
-        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+        opacityToExtinction(bounds.x, svv.oneOverUnitDistance);
     const float σ_maj =
-        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+        opacityToExtinction(bounds.y, svv.oneOverUnitDistance);
     const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
 
     if (σ_maj <= 0.f) {
@@ -318,12 +317,11 @@ VISRTX_DEVICE  void woodcockRatioTrackTransmittance(ScreenSample &ss,
 
   GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
   while (trav.valid()) {
-    const float minOpacity = field.grid.minOpacities[trav.cellIndex];
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float2 bounds = __ldg(&field.grid.opacityBounds[trav.cellIndex]);
     const float σ_min =
-        opacityToExtinction(minOpacity, svv.oneOverUnitDistance);
+        opacityToExtinction(bounds.x, svv.oneOverUnitDistance);
     const float σ_maj =
-        opacityToExtinction(maxOpacity, svv.oneOverUnitDistance);
+        opacityToExtinction(bounds.y, svv.oneOverUnitDistance);
     const float σ_residual = fmaxf(0.f, σ_maj - σ_min);
 
     if (σ_maj <= 0.f) {
@@ -423,7 +421,8 @@ VISRTX_DEVICE  float latticeRayMarchVolume(ScreenSample &ss,
     if (opacity >= MAX_OPACITY_THRESHOLD)
       break;
 
-    const float maxOpacity = field.grid.maxOpacities[trav.cellIndex];
+    const float2 bounds = __ldg(&field.grid.opacityBounds[trav.cellIndex]);
+    const float maxOpacity = bounds.y;
     if (maxOpacity <= 0.f) {
       trav.next();
       continue;

--- a/devices/rtx/device/light/sampling/CDF.cu
+++ b/devices/rtx/device/light/sampling/CDF.cu
@@ -31,6 +31,7 @@
 
 #include "CDF.h"
 
+#include "gpu/gpu_math.h"
 #include "utility/DeviceBuffer.h"
 
 // anari
@@ -77,7 +78,7 @@ void computeWeightedLuminance(
         // Scale distribution by the sine to get the sampling uniform. (Avoid
         // sampling more values near the poles.) See Physically Based Rendering
         // v2, chapter 14.6.5 on Infinite Area Lights, page 728.
-        auto sinTheta = sinf(float(M_PI) * (y + 0.5f) / height);
+        auto sinTheta = sinf(kPi * (y + 0.5f) / height);
         auto rowEnvMapPtr = envMapBegin + y * width;
         auto rowLuminancePtr = luminanceBegin + y * width;
         for (auto i = 0; i < width; i++) {
@@ -189,8 +190,7 @@ float generateCDFTables(const float *luminanceImage,
   // already folded into the CDF luminance, so the per-pixel area factor is
   // 2π²/(W·H) and pdf_ω = (L/totalL) · (W·H)/(2π²).
   // A zero-luminance map produces an inf weight; return 0 instead.
-  const float equirectJacobian =
-      2.0f * float(M_PI) * float(M_PI) / (width * height);
+  const float equirectJacobian = 2.0f * kPi * kPi / (width * height);
   const float weight =
       totalLuminance > 0.0f ? 1.0f / (totalLuminance * equirectJacobian) : 0.0f;
 

--- a/devices/rtx/device/light/sampling/CDF.cu
+++ b/devices/rtx/device/light/sampling/CDF.cu
@@ -45,6 +45,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
@@ -122,16 +123,23 @@ void computeConditionalCDFs(
 {
   using thrust::device_pointer_cast;
 
-  for (int y = 0; y < height; ++y) {
-    auto luminanceRow = device_pointer_cast(luminance + y * width);
-    auto conditionalCdfRow = device_pointer_cast(conditionalCdf + y * width);
-    thrust::inclusive_scan(
-        luminanceRow, luminanceRow + width, conditionalCdfRow);
-  }
+  // Segmented inclusive scan: key = row index (`i / width`), so the running
+  // sum resets at every row boundary. One launch family independent of
+  // `height`.
+  const auto keys = thrust::make_transform_iterator(
+      thrust::counting_iterator<int>(0),
+      [width] __host__ __device__(int i) { return i / width; });
+
+  thrust::inclusive_scan_by_key(keys,
+      keys + width * height,
+      device_pointer_cast(luminance),
+      device_pointer_cast(conditionalCdf));
 }
 
 void normalizeCDF(thrust::device_ptr<float> cdf, int n)
 {
+  if (n <= 0)
+    return;
   const float total = cdf[n - 1];
   if (total > 0.0f) {
     thrust::transform(
@@ -148,12 +156,36 @@ void normalizeMarginalCDF(float *marginalCdf, int height)
   normalizeCDF(thrust::device_pointer_cast(marginalCdf), height);
 }
 
+__global__ void normalizeConditionalCDFsKernel(float *cdf, int width)
+{
+  // One block per row. Read the row total (cdf[width-1] = sum after the
+  // inclusive scan) into shared memory, then normalize each element in
+  // parallel. Empty rows (total ≤ 0) fill with 1.0 so a downstream sampler
+  // walks the row uniformly instead of running off the end.
+  const int y = blockIdx.x;
+  const int tid = threadIdx.x;
+  float *row = cdf + y * width;
+
+  __shared__ float s_total;
+  if (tid == 0)
+    s_total = row[width - 1];
+  __syncthreads();
+
+  const bool empty = !(s_total > 0.0f);
+  const float invTotal = empty ? 0.0f : 1.0f / s_total;
+
+  for (int x = tid; x < width; x += blockDim.x)
+    row[x] = empty ? 1.0f : row[x] * invTotal;
+}
+
 void normalizeConditionalCDFs(float *d_conditional_cdf, int width, int height)
 {
-  for (int y = 0; y < height; ++y) {
-    normalizeCDF(
-        thrust::device_pointer_cast(d_conditional_cdf + y * width), width);
-  }
+  // One block per row, all `height` rows in parallel.
+  if (width <= 0 || height <= 0)
+    return;
+  constexpr int kThreadsPerBlock = 256;
+  normalizeConditionalCDFsKernel<<<height, kThreadsPerBlock>>>(
+      d_conditional_cdf, width);
 }
 
 } // namespace

--- a/devices/rtx/device/material/Material.h
+++ b/devices/rtx/device/material/Material.h
@@ -73,6 +73,18 @@ inline AlphaMode alphaModeFromString(const std::string &s)
     return AlphaMode::OPAQUE;
 }
 
+// Inline VALUE with channel ≥ 1 — no sampler/attribute can lower it.
+inline bool isStaticOne(const MaterialParameter &mp, int channel = 0)
+{
+  return mp.type == MaterialParameterType::VALUE && mp.value[channel] >= 1.0f;
+}
+
+// Inline VALUE clamped to 0. Used to gate the static-opaque shortcut.
+inline bool isStaticZero(const MaterialParameter &mp, int channel = 0)
+{
+  return mp.type == MaterialParameterType::VALUE && mp.value[channel] <= 0.0f;
+}
+
 } // namespace visrtx
 
 VISRTX_ANARI_TYPEFOR_SPECIALIZATION(visrtx::Material *, ANARI_MATERIAL);

--- a/devices/rtx/device/material/Matte.cpp
+++ b/devices/rtx/device/material/Matte.cpp
@@ -72,6 +72,10 @@ MaterialGPUData Matte::gpuData() const
   retval.materialData.matte.cutoff = m_cutoff;
   retval.materialData.matte.alphaMode = m_mode;
 
+  retval.isFullyOpaque = m_mode == AlphaMode::OPAQUE
+      || (isStaticOne(retval.materialData.matte.opacity)
+          && isStaticOne(retval.materialData.matte.color, 3));
+
   return retval;
 }
 

--- a/devices/rtx/device/material/PBR.cpp
+++ b/devices/rtx/device/material/PBR.cpp
@@ -177,6 +177,15 @@ MaterialGPUData PBR::gpuData() const
   pb.cutoff = m_cutoff;
   pb.alphaMode = m_mode;
 
+  // OPAQUE mode ignores alpha at shading time (see adjustedMaterialOpacity),
+  // so it alone implies alpha-opaque; otherwise both opacity and baseColor.alpha
+  // must be statically 1. Transmission is orthogonal — non-zero values let
+  // light through even at OPAQUE, opacity=1, alpha=1 — so it must also be zero.
+  retval.isFullyOpaque = (m_mode == AlphaMode::OPAQUE
+                             || (isStaticOne(pb.opacity)
+                                 && isStaticOne(pb.baseColor, 3)))
+      && isStaticZero(pb.transmission);
+
   pb.occlusionSampler =
       m_occlusionSampler ? m_occlusionSampler->index() : ~DeviceObjectIndex{0};
 

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -135,12 +135,13 @@ VISRTX_CALLABLE void __direct_callable__init(MDLShadingState *shadingState,
   shadingState->state.tangent_v =
       reinterpret_cast<const float3 *>(shadingState->textureTangentsV);
 
-  // Resources shared by all mdl calls.
+  // Resources shared by all mdl calls. The sampler table is shared with the
+  // material descriptor (md->samplers lives in GPU global memory for the
+  // lifetime of the material), so the handler holds a pointer rather than an
+  // inline copy.
   shadingState->textureHandler.vtable = nullptr;
   shadingState->textureHandler.fd = fd;
-  memcpy(shadingState->textureHandler.samplers,
-      md->samplers,
-      sizeof(md->samplers));
+  shadingState->textureHandler.samplers = md->samplers;
   shadingState->textureHandler.numSamplers = md->numSamplers;
   shadingState->resData = {nullptr, &shadingState->textureHandler};
 

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -92,9 +92,6 @@ VISRTX_CALLABLE void __direct_callable__init(MDLShadingState *shadingState,
   auto tU = hit->tU;
   auto tV = hit->tV;
 
-  shadingState->objectToWorld = hit->objectToWorld;
-  shadingState->worldToObject = hit->worldToObject;
-
   // The number of texture spaces we support. Matching the number of attributes
   // ANARI exposes (4)
   shadingState->textureCoords[0] =
@@ -125,9 +122,9 @@ VISRTX_CALLABLE void __direct_callable__init(MDLShadingState *shadingState,
   shadingState->state.meters_per_scene_unit = 1.0f;
   shadingState->state.object_id = hit->objID;
   shadingState->state.object_to_world =
-      reinterpret_cast<const float4 *>(&shadingState->objectToWorld);
+      reinterpret_cast<const float4 *>(&hit->instance->objectToWorld);
   shadingState->state.world_to_object =
-      reinterpret_cast<const float4 *>(&shadingState->worldToObject);
+      reinterpret_cast<const float4 *>(&hit->instance->worldToObject);
   shadingState->state.ro_data_segment = nullptr;
   shadingState->state.text_coords =
       reinterpret_cast<const float3 *>(shadingState->textureCoords);

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -35,7 +35,6 @@
 #include "gpu/shadingState.h"
 
 #include <anari/anari_cpp/ext/linalg.h>
-#include <curand.h>
 #include <mi/neuraylib/target_code_types.h>
 #include <optix_device.h>
 #include <glm/ext/matrix_float2x4.hpp>
@@ -198,7 +197,7 @@ NextRay __direct_callable__nextRay(
     const MDLShadingState *shadingState, const Ray *ray, RandState *rs)
 {
   // Before anything, check for opacity. If below, then we just pass through
-  if (curand_uniform(rs) > mdlOpacity(&shadingState->state,
+  if (pcg_uniform(rs) > mdlOpacity(&shadingState->state,
           &shadingState->resData,
           shadingState->argBlock)) {
     return NextRay{ray->dir, vec3(1.0f), NEXT_RAY_CONTINUES_THROUGH_SURFACE};
@@ -214,10 +213,10 @@ NextRay __direct_callable__nextRay(
     sample_data.ior2 = make_float3(1.0f, 1.0f, 1.0f);
   }
   sample_data.k1 = make_float3(-ray->dir);
-  sample_data.xi = make_float4(curand_uniform(rs),
-      curand_uniform(rs),
-      curand_uniform(rs),
-      curand_uniform(rs));
+  sample_data.xi = make_float4(pcg_uniform(rs),
+      pcg_uniform(rs),
+      pcg_uniform(rs),
+      pcg_uniform(rs));
 
   mdlBsdf_sample(&sample_data,
       &shadingState->state,

--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -92,8 +92,9 @@ VISRTX_CALLABLE void __direct_callable__init(MDLShadingState *shadingState,
   auto tU = hit->tU;
   auto tV = hit->tV;
 
-  // The number of texture spaces we support. Matching the number of attributes
-  // ANARI exposes (4)
+  // One texture space per ANARI attribute0..3; matches kNumTextureSpaces in
+  // libmdl/MDLBackendConfig.h. Tangent frame is the geometry's; multi-UV
+  // materials reuse it for every slot (no per-attribute tangent track yet).
   shadingState->textureCoords[0] =
       readAttributeValue(MaterialAttribute::ATTRIB_0, *hit);
   shadingState->textureCoords[1] =
@@ -103,8 +104,6 @@ VISRTX_CALLABLE void __direct_callable__init(MDLShadingState *shadingState,
   shadingState->textureCoords[3] =
       readAttributeValue(MaterialAttribute::ATTRIB_3, *hit);
 
-  // Take some shortcut for now and use the same tangent space for all texture
-  // spaces.
   shadingState->textureTangentsU[0] = tU;
   shadingState->textureTangentsU[1] = tU;
   shadingState->textureTangentsU[2] = tU;

--- a/devices/rtx/device/material/shaders/MatteShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MatteShader_ptx.cu
@@ -60,7 +60,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
     const MatteShadingState *shadingState, const Ray *ray, RandState *rs)
 {
   // Before anything, check for opacity. If below, then we just pass through
-  if (curand_uniform(rs) > shadingState->opacity) {
+  if (pcg_uniform(rs) > shadingState->opacity) {
     return NextRay{ray->dir, vec3(1.0f), NEXT_RAY_CONTINUES_THROUGH_SURFACE};
   }
 

--- a/devices/rtx/device/material/shaders/MatteShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MatteShader_ptx.cu
@@ -107,6 +107,6 @@ VISRTX_CALLABLE vec3 __direct_callable__shadeSurface(
     const vec3 *outgoingDir)
 {
   float NdotL = fmaxf(0.0f, dot(hit->Ns, lightSample->dir));
-  return shadingState->baseColor * float(M_1_PI) * NdotL * lightSample->radiance
+  return shadingState->baseColor * kInvPi * NdotL * lightSample->radiance
       / lightSample->pdf;
 }

--- a/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
@@ -127,7 +127,7 @@ VISRTX_DEVICE float ggxD(float NdotH, float alpha2)
   // The fminf clamp keeps `1−x ≥ 0` against dot-product rounding above 1.
   const float NdotH2 = fminf(NdotH * NdotH, 1.0f);
   const float denom = alpha2 * NdotH2 + (1.0f - NdotH2);
-  return alpha2 / (float(M_PI) * denom * denom);
+  return alpha2 / (kPi * denom * denom);
 }
 
 // Heitz 2018 (https://jcgt.org/published/0007/04/01/) visible-normal sampling
@@ -141,7 +141,7 @@ VISRTX_DEVICE vec3 sampleGGXVNDF(
                                : vec3(1.0f, 0.0f, 0.0f);
   const vec3 T2 = glm::cross(Vh, T1);
   const float r = sqrtf(u1);
-  const float phi = 2.0f * float(M_PI) * u2;
+  const float phi = kTwoPi * u2;
   const float t1 = r * cosf(phi);
   float t2 = r * sinf(phi);
   const float s = 0.5f * (1.0f + Vh.z);
@@ -156,7 +156,7 @@ VISRTX_DEVICE float charlieD(float NdotH, float alpha)
 {
   const float invAlpha = 1.0f / fmaxf(alpha, 1e-4f);
   const float sin2 = fmaxf(0.0f, 1.0f - NdotH * NdotH);
-  return (2.0f + invAlpha) * powf(sin2, 0.5f * invAlpha) / (2.0f * float(M_PI));
+  return (2.0f + invAlpha) * powf(sin2, 0.5f * invAlpha) / (kTwoPi);
 }
 
 // Ashikhmin visibility term (Neubelt-Pettineo variant) used with Charlie D.
@@ -171,7 +171,7 @@ VISRTX_DEVICE float charlieV(float NdotV, float NdotL)
 // base with Schlick F0. See the spec's Appendix B for the math.
 VISRTX_DEVICE vec3 fresnel0ToIor(vec3 F0)
 {
-  const vec3 s = sqrt(glm::clamp(F0, vec3(0.0f), vec3(0.9999f)));
+  const vec3 s = glm::sqrt(glm::clamp(F0, vec3(0.0f), vec3(0.9999f)));
   return (vec3(1.0f) + s) / (vec3(1.0f) - s);
 }
 
@@ -193,14 +193,14 @@ VISRTX_DEVICE vec3 evalSensitivity(float opd, vec3 shift)
 {
   // Approximate spectral sensitivity of the standard observer as three
   // Gaussians (Belcour & Barla 2017, simplified) so the result stays in RGB.
-  const float phase = 2.0f * float(M_PI) * opd * 1e-9f;
+  const float phase = kTwoPi * opd * 1e-9f;
   const vec3 val = vec3(5.4856e-13f, 4.4201e-13f, 5.2481e-13f);
   const vec3 pos = vec3(1.6810e+06f, 1.7953e+06f, 2.2084e+06f);
   const vec3 var = vec3(4.3278e+09f, 9.3046e+09f, 6.6121e+09f);
 
-  vec3 xyz = val * sqrt(2.0f * float(M_PI) * var) * cos(pos * phase + shift)
-      * exp(-var * phase * phase);
-  xyz.x += 9.7470e-14f * sqrtf(2.0f * float(M_PI) * 4.5282e+09f)
+  vec3 xyz = val * glm::sqrt(kTwoPi * var) * glm::cos(pos * phase + shift)
+      * glm::exp(-var * phase * phase);
+  xyz.x += 9.7470e-14f * sqrtf(kTwoPi * 4.5282e+09f)
       * cosf(2.2399e+06f * phase + shift.x)
       * expf(-4.5282e+09f * phase * phase);
   xyz /= 1.0685e-7f;
@@ -233,23 +233,23 @@ VISRTX_DEVICE vec3 evalIridescence(float outsideIor,
   const float R0_12 = iorToFresnel0(iridescenceIorSafe, outsideIor);
   const float R12 = R0_12 + (1.0f - R0_12) * pow5(1.0f - cosTheta1);
   const float T121 = 1.0f - R12;
-  const float phi12 = iridescenceIorSafe < outsideIor ? float(M_PI) : 0.0f;
-  const float phi21 = float(M_PI) - phi12;
+  const float phi12 = iridescenceIorSafe < outsideIor ? kPi : 0.0f;
+  const float phi21 = kPi - phi12;
 
   // Second interface: film to base.
   const vec3 baseIor =
       fresnel0ToIor(glm::clamp(baseF0, vec3(0.f), vec3(0.9999f)));
   const vec3 R1 = iorToFresnel0(baseIor, iridescenceIorSafe);
   const vec3 R23 = R1 + (vec3(1.0f) - R1) * pow5(1.0f - cosTheta2);
-  const vec3 phi23 = vec3(baseIor.x < iridescenceIorSafe ? float(M_PI) : 0.0f,
-      baseIor.y < iridescenceIorSafe ? float(M_PI) : 0.0f,
-      baseIor.z < iridescenceIorSafe ? float(M_PI) : 0.0f);
+  const vec3 phi23 = vec3(baseIor.x < iridescenceIorSafe ? kPi : 0.0f,
+      baseIor.y < iridescenceIorSafe ? kPi : 0.0f,
+      baseIor.z < iridescenceIorSafe ? kPi : 0.0f);
 
   const float opd = 2.0f * iridescenceIorSafe * thickness * cosTheta2;
   const vec3 phi = vec3(phi21) + phi23;
 
   const vec3 R123 = glm::clamp(R12 * R23, vec3(1e-5f), vec3(0.9999f));
-  const vec3 r123 = sqrt(R123);
+  const vec3 r123 = glm::sqrt(R123);
   const vec3 Rs = pow2(T121) * R23 / (vec3(1.0f) - R123);
 
   // DC term.
@@ -444,7 +444,7 @@ VISRTX_CALLABLE vec3 __direct_callable__shadeSurface(
   // and transmission; metals have no diffuse).
   const vec3 diffuseColor =
       glm::mix(state->baseColor, vec3(0.0f), state->metallic);
-  const vec3 diffuseBRDF = (vec3(1.0f) - Fdiff) * float(M_1_PI) * diffuseColor
+  const vec3 diffuseBRDF = (vec3(1.0f) - Fdiff) * kInvPi * diffuseColor
       * state->occlusion * (1.0f - state->transmission);
 
   vec3 base = diffuseBRDF + specularBRDF;

--- a/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/PhysicallyBasedShader_ptx.cu
@@ -497,7 +497,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
     const PhysicallyBasedShadingState *state, const Ray *ray, RandState *rs)
 {
   // Opacity pass-through (stochastic alpha): the ray continues unaltered.
-  if (curand_uniform(rs) > state->opacity)
+  if (pcg_uniform(rs) > state->opacity)
     return NextRay{ray->dir, vec3(1.0f), NEXT_RAY_CONTINUES_THROUGH_SURFACE};
 
   const vec3 V = -ray->dir;
@@ -513,7 +513,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
   const float clearcoatPick =
       glm::clamp(state->clearcoat * FcV_world, 0.0f, 1.0f);
 
-  if (clearcoatPick > 0.0f && curand_uniform(rs) < clearcoatPick) {
+  if (clearcoatPick > 0.0f && pcg_uniform(rs) < clearcoatPick) {
     const mat3 toWorldC = computeOrthonormalBasis(Nc);
     const vec3 VlocalC = glm::transpose(toWorldC) * V;
     if (VlocalC.z <= 0.0f)
@@ -521,7 +521,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
     const float alphaC = fmaxf(pow2(state->clearcoatRoughness), 1e-4f);
     const float alphaC2 = alphaC * alphaC;
     const vec3 HlocalC = sampleGGXVNDF(
-        VlocalC, alphaC, curand_uniform(rs), curand_uniform(rs));
+        VlocalC, alphaC, pcg_uniform(rs), pcg_uniform(rs));
     const vec3 LlocalC = glm::reflect(-VlocalC, HlocalC);
     if (LlocalC.z <= 0.0f)
       return NextRay{Nc, vec3(0.0f)};
@@ -558,7 +558,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
   const float alpha = fmaxf(pow2(state->roughness), 1e-4f);
   const float alpha2 = alpha * alpha;
   const vec3 Hlocal =
-      sampleGGXVNDF(Vlocal, alpha, curand_uniform(rs), curand_uniform(rs));
+      sampleGGXVNDF(Vlocal, alpha, pcg_uniform(rs), pcg_uniform(rs));
 
   const float NdotV = Vlocal.z;
   const float VdotH = fmaxf(dot(Vlocal, Hlocal), 0.0f);
@@ -608,7 +608,7 @@ VISRTX_CALLABLE NextRay __direct_callable__nextRay(
   const float transmitProb = transmitStrength / combinedStrength;
   const float diffuseProb = diffuseStrength / combinedStrength;
 
-  const float u = curand_uniform(rs);
+  const float u = pcg_uniform(rs);
   if (u < reflectProb) {
     if (Lrefl.z <= 0.0f)
       return NextRay{N, vec3(0.0f)};

--- a/devices/rtx/device/renderer/Debug_ptx.cu
+++ b/devices/rtx/device/renderer/Debug_ptx.cu
@@ -235,7 +235,7 @@ VISRTX_GLOBAL void __raygen__()
     return;
   }
 
-  auto ray = makePrimaryRay(ss, true /*pixel centered*/);
+  auto ray = makePrimaryRay(ss, 0u, true /*pixel centered*/);
 
   vec3 color{0.f};
   if (vec3 hdri; getBackgroundLight(frameData, ray.dir, hdri)) {

--- a/devices/rtx/device/renderer/Fast_ptx.cu
+++ b/devices/rtx/device/renderer/Fast_ptx.cu
@@ -55,12 +55,20 @@ VISRTX_GLOBAL void __anyhit__shadow()
   SurfaceHit hit;
   ray::populateSurfaceHit(hit);
 
+  auto &o = ray::rayData<float>();
+
+  // Fully opaque material: skip the init/opacity callable chain.
+  if (hit.material->isFullyOpaque) {
+    o = 1.0f;
+    optixTerminateRay();
+    return;
+  }
+
   const auto &fd = frameData;
   const auto &md = *hit.material;
   MaterialShadingState shadingState;
   materialInitShading(&shadingState, fd, md, hit);
 
-  auto &o = ray::rayData<float>();
   accumulateValue(o, materialEvaluateOpacity(shadingState), o);
   if (o >= OPACITY_THRESHOLD)
     optixTerminateRay();

--- a/devices/rtx/device/renderer/Interactive_ptx.cu
+++ b/devices/rtx/device/renderer/Interactive_ptx.cu
@@ -123,17 +123,16 @@ struct InteractiveShadingPolicy
     contrib *= aoFactor;
 
     // Then proceed with single bounce ray for indirect lighting
-    SurfaceHit bounceHit = hit;
     NextRay nextRay = materialNextRay(shadingState, ray, ss.rs);
     if (glm::any(glm::greaterThan(
             nextRay.contributionWeight, glm::vec3(MIN_CONTRIBUTION_EPSILON)))) {
       const float side = continuesThroughSurface(nextRay) ? -1.0f : 1.0f;
-      Ray bounceRay = {
-          bounceHit.hitpoint + bounceHit.Ng * bounceHit.epsilon * side,
+      Ray bounceRay = {hit.hitpoint + hit.Ng * hit.epsilon * side,
           normalize(nextRay.direction)};
 
       // Only check for intersecting surfaces and background as secondary light
-      // interactions
+      // interactions.
+      SurfaceHit bounceHit;
       bounceHit.foundHit = false;
       intersectSurface(ss, bounceRay, RayType::PRIMARY, &bounceHit);
 

--- a/devices/rtx/device/renderer/Interactive_ptx.cu
+++ b/devices/rtx/device/renderer/Interactive_ptx.cu
@@ -181,11 +181,18 @@ VISRTX_GLOBAL void __anyhit__shadow()
     SurfaceHit hit;
     ray::populateSurfaceHit(hit);
 
+    auto &o = ray::rayData<float>();
+
+    // Fully opaque material: skip the init/opacity callable chain.
+    if (hit.material->isFullyOpaque) {
+      o = 1.0f;
+      optixTerminateRay();
+      return;
+    }
+
     MaterialShadingState shadingState;
     materialInitShading(&shadingState, frameData, *hit.material, hit);
     auto opacity = materialEvaluateOpacity(shadingState);
-
-    auto &o = ray::rayData<float>();
 
     accumulateValue(o, opacity, o);
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -303,7 +303,14 @@ VISRTX_GLOBAL void __raygen__()
 
   for (int i = 0; i < rendererParams.numIterations; ++i) {
     bool isVeryFirstRay = i == 0 && ss.frameData->fb.frameID == 0;
-    auto ray = makePrimaryRay(ss, isVeryFirstRay);
+    // Halton sample index: per-pixel ordinal across the whole frame's
+    // sample budget. Using `frameID * numIterations + i` keeps the
+    // per-pixel Halton indices contiguous [0, totalSpp), which is the
+    // optimal QMC stratification.
+    const uint32_t sampleIdx =
+        uint32_t(ss.frameData->fb.frameID) * uint32_t(rendererParams.numIterations)
+        + uint32_t(i);
+    auto ray = makePrimaryRay(ss, sampleIdx, isVeryFirstRay);
 
     applyCuttingPlane(rendererParams.cutPlane, ray);
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -192,11 +192,13 @@ VISRTX_DEVICE LightSample sampleLightsVolume(
 }
 
 VISRTX_DEVICE
-VolumeDistanceSample sampleVolumeDistance(ScreenSample &ss, Ray ray)
+VolumeDistanceSample sampleVolumeDistance(
+    ScreenSample &ss, Ray ray, bool needNormal)
 {
   VolumeDistanceSample volumeHit = {
       false, vec3(0.0f), ray.t.upper, vec3(0.0f), 0.0f, ~0u, ~0u};
 
+  // Skip the gradient-based normal computation on non-primary bounces.
   volumeHit.depth = sampleDistanceAllVolumes(ss,
       ray,
       RayType::PRIMARY,
@@ -206,7 +208,7 @@ VolumeDistanceSample sampleVolumeDistance(ScreenSample &ss, Ray ray)
       volumeHit.didScatter,
       volumeHit.objID,
       volumeHit.instID,
-      &volumeHit.normal);
+      needNormal ? &volumeHit.normal : nullptr);
   return volumeHit;
 }
 
@@ -311,7 +313,7 @@ VISRTX_GLOBAL void __raygen__()
       float volumeUpperBound = surfaceHit.foundHit ? surfaceHit.t : ray.t.upper;
       auto volumeRay = Ray{ray.org, ray.dir, {ray.t.lower, volumeUpperBound}};
 
-      auto volumeSample = sampleVolumeDistance(ss, volumeRay);
+      auto volumeSample = sampleVolumeDistance(ss, volumeRay, isFirstBounce);
 
       if (volumeSample.didScatter) {
         const vec3 scatterPos = ray.org + ray.dir * volumeSample.depth;

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -336,19 +336,27 @@ VISRTX_GLOBAL void __raygen__()
               sampleLightsVolume(ss, frameData, scatterPos);
           if (lightSample.pdf >= ATTENUATION_EPSILON
               && lightSample.dist > 0.0f) {
-            const float eps = VOLUME_SCATTER_EPSILON;
-            const Ray shadowRay = {
-                scatterPos + lightSample.dir * eps,
-                lightSample.dir,
-                {eps, lightSample.dist},
-            };
-            const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
-                * volumeShadowTransmittance(ss, shadowRay);
-
             constexpr float INV_4PI = 1.0f / (4.0f * kPi);
             const vec3 directLight = volumeSample.albedo * lightSample.radiance
                 * INV_4PI / lightSample.pdf;
-            sample.color += sampleContribution * directLight * attenuation;
+            const vec3 contribUpper = sampleContribution * directLight;
+            const float maxContrib = glm::max(
+                contribUpper.x, glm::max(contribUpper.y, contribUpper.z));
+            // Pre-shadow skip: a contribution below SHADOW_SKIP_EPSILON
+            // can't survive RGB quantisation even unattenuated. Costs nothing
+            // to skip the trace entirely.
+            constexpr float SHADOW_SKIP_EPSILON = 1.0e-5f;
+            if (maxContrib >= SHADOW_SKIP_EPSILON) {
+              const float eps = VOLUME_SCATTER_EPSILON;
+              const Ray shadowRay = {
+                  scatterPos + lightSample.dir * eps,
+                  lightSample.dir,
+                  {eps, lightSample.dist},
+              };
+              const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
+                  * volumeShadowTransmittance(ss, shadowRay);
+              sample.color += contribUpper * attenuation;
+            }
           }
         }
 
@@ -419,18 +427,23 @@ VISRTX_GLOBAL void __raygen__()
           // into the lit/unlit boundary at grazing light angles.
           const float lightDotNs = dot(lightSample.dir, surfaceHit.Ns);
           if (lightDotNs > 0.0f) {
-            const Ray shadowRay = {
-                shadowOrigin,
-                lightSample.dir,
-                {surfaceHit.epsilon, lightSample.dist},
-            };
-            const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
-                * volumeShadowTransmittance(ss, shadowRay);
             const vec3 directLight = materialShadeSurface(
                 shadingState, surfaceHit, lightSample, -ray.dir);
-
-            sample.color += sampleContribution * materialOpacity * directLight
-                * attenuation;
+            const vec3 contribUpper =
+                sampleContribution * materialOpacity * directLight;
+            const float maxContrib = glm::max(
+                contribUpper.x, glm::max(contribUpper.y, contribUpper.z));
+            constexpr float SHADOW_SKIP_EPSILON = 1.0e-5f;
+            if (maxContrib >= SHADOW_SKIP_EPSILON) {
+              const Ray shadowRay = {
+                  shadowOrigin,
+                  lightSample.dir,
+                  {surfaceHit.epsilon, lightSample.dist},
+              };
+              const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
+                  * volumeShadowTransmittance(ss, shadowRay);
+              sample.color += contribUpper * attenuation;
+            }
           }
         }
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -353,8 +353,14 @@ VISRTX_GLOBAL void __raygen__()
                   lightSample.dir,
                   {eps, lightSample.dist},
               };
+              // Adaptive RR knob: w in (0, 1] = maxContrib / 0.5. Dim rays
+              // raise the in-trace RR threshold so ratio-tracking kills them
+              // sooner. RR estimator stays unbiased; cap inside RR bounds
+              // amplification.
+              ss.shadowContribWeight = glm::min(1.0f, maxContrib * 2.0f);
               const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
                   * volumeShadowTransmittance(ss, shadowRay);
+              ss.shadowContribWeight = 1.0f;
               sample.color += contribUpper * attenuation;
             }
           }
@@ -440,8 +446,10 @@ VISRTX_GLOBAL void __raygen__()
                   lightSample.dir,
                   {surfaceHit.epsilon, lightSample.dist},
               };
+              ss.shadowContribWeight = glm::min(1.0f, maxContrib * 2.0f);
               const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
                   * volumeShadowTransmittance(ss, shadowRay);
+              ss.shadowContribWeight = 1.0f;
               sample.color += contribUpper * attenuation;
             }
           }

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -144,7 +144,7 @@ VISRTX_DEVICE LightSample sampleLights(ScreenSample &ss,
         rendererParams.ambientColor * rendererParams.ambientIntensity,
         dir,
         std::numeric_limits<float>::max(),
-        lightPickPdf * cosNs * float(M_1_PI),
+        lightPickPdf * cosNs * kInvPi,
     };
   } else {
     const auto &lightInstance = world.lightInstances[selectedIdx];
@@ -173,7 +173,7 @@ VISRTX_DEVICE LightSample sampleLightsVolume(
 
   if (selectedIdx == world.numLightInstances) {
     const auto &rendererParams = frameData.renderer;
-    constexpr float INV_4PI = 1.0f / (4.0f * float(M_PI));
+    constexpr float INV_4PI = 1.0f / (4.0f * kPi);
     const vec3 dir = randomDir(ss.rs);
     return LightSample{
         rendererParams.ambientColor * rendererParams.ambientIntensity,
@@ -330,7 +330,7 @@ VISRTX_GLOBAL void __raygen__()
             const auto attenuation = surfaceShadowTransmittance(ss, shadowRay)
                 * volumeShadowTransmittance(ss, shadowRay);
 
-            constexpr float INV_4PI = 1.0f / (4.0f * float(M_PI));
+            constexpr float INV_4PI = 1.0f / (4.0f * kPi);
             const vec3 directLight = volumeSample.albedo * lightSample.radiance
                 * INV_4PI / lightSample.pdf;
             sample.color += sampleContribution * directLight * attenuation;

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -242,6 +242,14 @@ VISRTX_GLOBAL void __anyhit__shadow()
     SurfaceHit hit;
     ray::populateSurfaceHit(hit);
 
+    // Fully opaque material: skip the init / opacity / transmission callable
+    // dispatch chain and just block the ray.
+    if (hit.material->isFullyOpaque) {
+      attenuation = vec3(0.0f);
+      optixTerminateRay();
+      return;
+    }
+
     auto ss = ray::screenSample();
     MaterialShadingState shadingState;
     materialInitShading(&shadingState, frameData, *hit.material, hit);

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -51,7 +51,12 @@ namespace visrtx {
 
 constexpr float PATH_CONTRIBUTION_EPSILON = 1.0e-8f;
 constexpr float ATTENUATION_EPSILON = std::numeric_limits<float>::epsilon();
+// RR start depth. Volume scatter engages earlier — throughput shrinks by
+// medium albedo each scatter, so dense regions need RR sooner. Surface
+// bounces don't shrink throughput so reliably; keep their conservative
+// threshold.
 constexpr int RUSSIAN_ROULETTE_START_DEPTH = 3;
+constexpr int RUSSIAN_ROULETTE_START_DEPTH_VOLUME = 1;
 constexpr float VOLUME_SCATTER_EPSILON = 1.0e-4f;
 
 DECLARE_FRAME_DATA(frameData)
@@ -92,18 +97,26 @@ VISRTX_DEVICE vec3 evaluateOpacity(const MaterialShadingState &shadingState)
       * (1.0f - materialEvaluateTransmission(shadingState));
 }
 
-VISRTX_DEVICE bool shouldTerminatePath(
-    ScreenSample &ss, int depth, vec3 &contribution, bool useRussianRoulette)
+VISRTX_DEVICE bool shouldTerminatePath(ScreenSample &ss,
+    int depth,
+    vec3 &contribution,
+    bool useRussianRoulette,
+    int rrStartDepth = RUSSIAN_ROULETTE_START_DEPTH,
+    float maxSurvivalProb = 0.95f)
 {
   if (glm::all(glm::lessThan(contribution, vec3(PATH_CONTRIBUTION_EPSILON))))
     return true;
 
-  if (!useRussianRoulette || depth < RUSSIAN_ROULETTE_START_DEPTH)
+  if (!useRussianRoulette || depth < rrStartDepth)
     return false;
 
+  // Survival cap. Surface default 0.95 keeps contributing paths alive
+  // (bouncing is cheap). White-smoke / dense-cloud volumes keep
+  // max(contribution) near 1 forever; the lower 0.5 cap forces probabilistic
+  // termination so the warp doesn't pin on the longest lane.
   const float maxContribution =
       glm::max(contribution.x, glm::max(contribution.y, contribution.z));
-  const float survivalProb = glm::min(0.95f, maxContribution);
+  const float survivalProb = glm::min(maxSurvivalProb, maxContribution);
   if (curand_uniform(&ss.rs) > survivalProb)
     return true;
 
@@ -341,7 +354,12 @@ VISRTX_GLOBAL void __raygen__()
 
         accumulateValue(sample.opacity, 1.0f, sample.opacity);
         sampleContribution *= volumeSample.albedo;
-        if (shouldTerminatePath(ss, d, sampleContribution, true))
+        if (shouldTerminatePath(ss,
+                d,
+                sampleContribution,
+                true,
+                RUSSIAN_ROULETTE_START_DEPTH_VOLUME,
+                /*maxSurvivalProb=*/0.5f))
           break;
 
         if (isFirstBounce) {

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -29,7 +29,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <curand_mtgp32_kernel.h>
 #include <optix_device.h>
 #include "gpu/createScreenSample.h"
 #include "gpu/evalShading.h"
@@ -117,7 +116,7 @@ VISRTX_DEVICE bool shouldTerminatePath(ScreenSample &ss,
   const float maxContribution =
       glm::max(contribution.x, glm::max(contribution.y, contribution.z));
   const float survivalProb = glm::min(maxSurvivalProb, maxContribution);
-  if (curand_uniform(&ss.rs) > survivalProb)
+  if (pcg_uniform(&ss.rs) > survivalProb)
     return true;
 
   contribution /= survivalProb;
@@ -136,10 +135,10 @@ VISRTX_DEVICE LightSample sampleLights(ScreenSample &ss,
   if (numLights == 0)
     return {};
 
-  // curand_uniform returns (0,1], invert to get [0,numLights).
-  // Clamp to handle float rounding when curand returns a subnormal.
+  // pcg_uniform * numLights ∈ [0, numLights). The glm::min clamp is
+  // defensive against float rounding to numLights at the boundary.
   const size_t selectedIdx =
-      glm::min(size_t((1.0f - curand_uniform(&ss.rs)) * float(numLights)),
+      glm::min(size_t(pcg_uniform(&ss.rs) * float(numLights)),
           numLights - 1);
 
   // Uniform light pick: P(light) = 1/numLights. Fold that into the returned
@@ -179,7 +178,7 @@ VISRTX_DEVICE LightSample sampleLightsVolume(
     return {};
 
   const size_t selectedIdx =
-      glm::min(size_t((1.0f - curand_uniform(&ss.rs)) * float(numLights)),
+      glm::min(size_t(pcg_uniform(&ss.rs) * float(numLights)),
           numLights - 1);
 
   const float lightPickPdf = 1.0f / float(numLights);

--- a/devices/rtx/device/renderer/Renderer.cpp
+++ b/devices/rtx/device/renderer/Renderer.cpp
@@ -569,6 +569,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleStructuredRegular";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_REGULAR_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceStructuredRegular";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_REGULAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceStructuredRegular";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_REGULAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeStructuredRegular";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_REGULAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // NanoVDB samplers
     samplerDesc.callables.moduleDC = state.fieldSamplers.nvdb;
@@ -593,6 +606,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbFp4";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP4_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Fp8
     samplerDesc.callables.entryFunctionNameDC =
@@ -603,6 +629,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbFp8";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP8_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Fp16
     samplerDesc.callables.entryFunctionNameDC =
@@ -613,6 +652,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbFp16";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP16_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // FpN
     samplerDesc.callables.entryFunctionNameDC =
@@ -623,6 +675,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbFpN";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FPN_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Float
     samplerDesc.callables.entryFunctionNameDC =
@@ -633,6 +698,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbFloat";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FLOAT_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // StructuredRectilinear sampler
     samplerDesc.callables.moduleDC = state.fieldSamplers.structuredRectilinear;
@@ -647,6 +725,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleStructuredRectilinear";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_RECTILINEAR_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceStructuredRectilinear";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_RECTILINEAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceStructuredRectilinear";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_RECTILINEAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeStructuredRectilinear";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_RECTILINEAR_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // NanoVDB rectilinear samplers
     samplerDesc.callables.moduleDC = state.fieldSamplers.nvdbRectilinear;
@@ -671,6 +762,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbRectilinearFp4";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP4_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbRectilinearFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbRectilinearFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbRectilinearFp4";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP4_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Fp8
     samplerDesc.callables.entryFunctionNameDC =
@@ -681,6 +785,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbRectilinearFp8";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP8_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbRectilinearFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbRectilinearFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbRectilinearFp8";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP8_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Fp16
     samplerDesc.callables.entryFunctionNameDC =
@@ -691,6 +808,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbRectilinearFp16";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP16_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbRectilinearFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbRectilinearFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbRectilinearFp16";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FP16_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // FpN
     samplerDesc.callables.entryFunctionNameDC =
@@ -701,6 +831,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbRectilinearFpN";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FPN_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbRectilinearFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbRectilinearFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbRectilinearFpN";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FPN_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Float
     samplerDesc.callables.entryFunctionNameDC =
@@ -711,6 +854,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleNvdbRectilinearFloat";
     callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FLOAT_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceNvdbRectilinearFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceNvdbRectilinearFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeNvdbRectilinearFloat";
+    callableDescs[SBT_CALLABLE_SPATIAL_FIELD_NVDB_REC_FLOAT_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
     // Custom field sampler (from devices/visrtx)
     // A single callable pair handles all custom field subtypes via type
@@ -727,6 +883,19 @@ void Renderer::initOptixPipeline()
         "__direct_callable__sampleCustom";
     callableDescs[SBT_CALLABLE_CUSTOM_OFFSET
         + int(SpatialFieldSamplerEntryPoints::Sample)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__sampleDistanceCustom";
+    callableDescs[SBT_CALLABLE_CUSTOM_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::SampleDistance)] = samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__ratioTrackTransmittanceCustom";
+    callableDescs[SBT_CALLABLE_CUSTOM_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RatioTrackTransmittance)] =
+        samplerDesc;
+    samplerDesc.callables.entryFunctionNameDC =
+        "__direct_callable__rayMarchVolumeCustom";
+    callableDescs[SBT_CALLABLE_CUSTOM_OFFSET
+        + int(SpatialFieldSamplerEntryPoints::RayMarchVolume)] = samplerDesc;
 
 #ifdef USE_MDL
     if (state.mdl) {

--- a/devices/rtx/device/renderer/Test_ptx.cu
+++ b/devices/rtx/device/renderer/Test_ptx.cu
@@ -55,7 +55,7 @@ VISRTX_GLOBAL void __raygen__()
   auto ss = createScreenSample(frameData);
   if (pixelOutOfFrame(ss.pixel, frameData.fb))
     return;
-  auto ray = makePrimaryRay(ss);
+  auto ray = makePrimaryRay(ss, 0u);
 
   setPixelIds(frameData.fb, ss.pixel, 1.0f, ~0u, ~0u, ~0u);
 

--- a/devices/rtx/device/spatial_field/CustomFieldSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/CustomFieldSampler_ptx.cu
@@ -18,7 +18,9 @@
 
 #include "gpu/gpu_decl.h"
 #include "gpu/gpu_objects.h"
+#include "gpu/sbt.h"
 #include "gpu/shadingState.h"
+#include "gpu/volumeIntegrationDetail.h"
 
 // Include custom field data definitions (provides CustomFieldType enum
 // and field-specific data structures)
@@ -70,4 +72,122 @@ VISRTX_CALLABLE float __direct_callable__sampleCustom(
 #else
   return 0.0f;
 #endif
+}
+
+//=============================================================================
+// Woodcock-body callables for custom fields. Because the inner sample()
+// implementation is user-supplied (compiled into __direct_callable__sampleCustom
+// in this same module), the Woodcock body dispatches via optixDirectCall to the
+// same module's Sample slot — callable-in-callable. Slower than the built-in
+// families' inline path but preserves the user-facing UX (custom-field authors
+// implement only init + sample).
+//=============================================================================
+
+VISRTX_CALLABLE float __direct_callable__sampleDistanceCustom(ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *albedo,
+    float *extinction,
+    bool *didScatter,
+    vec3 *normal)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  VolumeSamplingState samplerState;
+  samplerState.custom = field.data.custom;
+
+  const uint32_t baseIdx = uint32_t(field.samplerCallableIndex);
+  return detail::woodcockSampleDistance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *albedo,
+      *extinction,
+      *didScatter,
+      normal,
+      [baseIdx] __device__(const VolumeSamplingState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return optixDirectCall<float>(
+            baseIdx + uint32_t(SpatialFieldSamplerEntryPoints::Sample),
+            &s,
+            &p,
+            (vec3 *)nullptr);
+      },
+      [baseIdx] __device__(const VolumeSamplingState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) {
+        return optixDirectCall<float>(
+            baseIdx + uint32_t(SpatialFieldSamplerEntryPoints::Sample),
+            &s,
+            &p,
+            &g);
+      });
+}
+
+VISRTX_CALLABLE void __direct_callable__ratioTrackTransmittanceCustom(
+    ScreenSample *ss, const VolumeHit *hit, vec3 *attenuation)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  VolumeSamplingState samplerState;
+  samplerState.custom = field.data.custom;
+
+  const uint32_t baseIdx = uint32_t(field.samplerCallableIndex);
+  detail::woodcockRatioTrackTransmittance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *attenuation,
+      [baseIdx] __device__(const VolumeSamplingState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return optixDirectCall<float>(
+            baseIdx + uint32_t(SpatialFieldSamplerEntryPoints::Sample),
+            &s,
+            &p,
+            (vec3 *)nullptr);
+      });
+}
+
+VISRTX_CALLABLE float __direct_callable__rayMarchVolumeCustom(ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *color,
+    vec3 *normal,
+    float *opacity,
+    float invSamplingRate)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  VolumeSamplingState samplerState;
+  samplerState.custom = field.data.custom;
+
+  const uint32_t baseIdx = uint32_t(field.samplerCallableIndex);
+  return detail::latticeRayMarchVolume(*ss,
+      *hit,
+      samplerState,
+      field,
+      color,
+      normal,
+      *opacity,
+      invSamplingRate,
+      [baseIdx] __device__(const VolumeSamplingState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return optixDirectCall<float>(
+            baseIdx + uint32_t(SpatialFieldSamplerEntryPoints::Sample),
+            &s,
+            &p,
+            (vec3 *)nullptr);
+      },
+      [baseIdx] __device__(const VolumeSamplingState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) {
+        return optixDirectCall<float>(
+            baseIdx + uint32_t(SpatialFieldSamplerEntryPoints::Sample),
+            &s,
+            &p,
+            &g);
+      });
 }

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// NanoVDB rectilinear-grid sampler — inline device implementations.
+// See NvdbRegularSamplerInline.h for why these live in a header.
+
+#include "NvdbRegularSamplerInline.h" // for clampNvdb
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/shadingState.h"
+
+#include <driver_types.h>
+#include <nanovdb/math/Math.h>
+
+namespace visrtx {
+
+template <typename ValueType>
+VISRTX_DEVICE void initNvdbRectilinearSampler(
+    NvdbRectilinearSamplerState<ValueType> &state,
+    const SpatialFieldGPUData *field)
+{
+  using GridType = nanovdb::Grid<nanovdb::NanoTree<ValueType>>;
+  const auto *grid =
+      static_cast<const GridType *>(field->data.nvdbRectilinear.gridData);
+
+  state.grid = grid;
+  state.accessor = grid->getAccessor();
+  state.filter = field->data.nvdbRectilinear.filter;
+  if (state.filter == SpatialFieldFilter::Nearest) {
+    new (&state.nearestSampler)
+        typename NvdbRectilinearSamplerState<ValueType>::NearestSamplerType(
+            nanovdb::math::createSampler<0>(state.accessor));
+  } else {
+    new (&state.linearSampler)
+        typename NvdbRectilinearSamplerState<ValueType>::LinearSamplerType(
+            nanovdb::math::createSampler<1>(state.accessor));
+  }
+
+  const nanovdb::CoordBBox indexBBox = grid->indexBBox();
+  const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
+
+  state.scaleDown = 1.0f / dims;
+  state.scaleUp = dims - nanovdb::Vec3f(1.0f);
+  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
+  if (field->data.nvdbRectilinear.cellCentered) {
+    state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
+  } else {
+    state.offsetUp = state.offsetDown;
+  }
+  state.indexMin = nanovdb::Vec3f(indexBBox.min());
+  state.indexMax = nanovdb::Vec3f(indexBBox.max());
+
+  state.axisLUT[0] = field->data.nvdbRectilinear.axisLUT[0];
+  state.axisLUT[1] = field->data.nvdbRectilinear.axisLUT[1];
+  state.axisLUT[2] = field->data.nvdbRectilinear.axisLUT[2];
+
+  const auto &iavs = field->data.nvdbRectilinear.invAvgVoxelSize;
+  state.invAvgVoxelSize = nanovdb::Vec3f(iavs.x, iavs.y, iavs.z);
+}
+
+template <typename ValueType>
+VISRTX_DEVICE nanovdb::Vec3f worldToIndexRectilinear(
+    const NvdbRectilinearSamplerState<ValueType> &state, const vec3 *location)
+{
+  const auto indexPos0 = state.grid->worldToIndexF(
+      nanovdb::Vec3f(location->x, location->y, location->z));
+
+  const auto normalizedPos = (indexPos0 - state.offsetDown) * state.scaleDown;
+
+  const auto normalizedPosRect =
+      nanovdb::Vec3f(tex1D<float>(state.axisLUT[0], normalizedPos[0]),
+          tex1D<float>(state.axisLUT[1], normalizedPos[1]),
+          tex1D<float>(state.axisLUT[2], normalizedPos[2]));
+
+  return normalizedPosRect * state.scaleUp + state.offsetUp;
+}
+
+template <typename ValueType>
+VISRTX_DEVICE float sampleAtIndexRectilinear(
+    const NvdbRectilinearSamplerState<ValueType> &state,
+    const nanovdb::Vec3f &indexPos)
+{
+  const auto clamped = clampNvdb(indexPos, state.indexMin, state.indexMax);
+  if (state.filter == SpatialFieldFilter::Nearest)
+    return state.nearestSampler(clamped);
+  return state.linearSampler(clamped);
+}
+
+template <typename ValueType>
+VISRTX_DEVICE float sampleNvdbRectilinear(
+    const NvdbRectilinearSamplerState<ValueType> &state,
+    const vec3 *location,
+    vec3 *gradient)
+{
+  const auto indexPos = worldToIndexRectilinear(state, location);
+  const float value = sampleAtIndexRectilinear(state, indexPos);
+
+  if (gradient) {
+    const float sxp =
+        sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(1, 0, 0));
+    const float sxn =
+        sampleAtIndexRectilinear(state, indexPos - nanovdb::Vec3f(1, 0, 0));
+    const float syp =
+        sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(0, 1, 0));
+    const float syn =
+        sampleAtIndexRectilinear(state, indexPos - nanovdb::Vec3f(0, 1, 0));
+    const float szp =
+        sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(0, 0, 1));
+    const float szn =
+        sampleAtIndexRectilinear(state, indexPos - nanovdb::Vec3f(0, 0, 1));
+
+    *gradient = vec3(sxp - sxn, syp - syn, szp - szn)
+        * vec3(state.invAvgVoxelSize[0],
+            state.invAvgVoxelSize[1],
+            state.invAvgVoxelSize[2])
+        * 0.5f;
+  }
+
+  return value;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
@@ -55,7 +55,10 @@ VISRTX_DEVICE void initNvdbRectilinearSampler(
       static_cast<const GridType *>(field->data.nvdbRectilinear.gridData);
 
   state.grid = grid;
-  state.accessor = grid->getAccessor();
+  // Leaf-only accessor — see NvdbRegularSamplerInline.h for rationale.
+  state.accessor =
+      typename NvdbRectilinearSamplerState<ValueType>::AccessorType(
+          grid->tree().root());
   state.filter = field->data.nvdbRectilinear.filter;
   if (state.filter == SpatialFieldFilter::Nearest) {
     new (&state.nearestSampler)

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSampler_ptx.cu
@@ -29,135 +29,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <driver_types.h>
-#include <nanovdb/math/Math.h>
-#include "gpu/gpu_decl.h"
-#include "gpu/gpu_objects.h"
-#include "gpu/shadingState.h"
+// OptiX direct-callable entry points for the NanoVDB rectilinear-grid sampler.
+// Implementations live in NvdbRectilinearSamplerInline.h.
+
+#include "NvdbRectilinearSamplerInline.h"
+#include "gpu/volumeIntegrationDetail.h"
 
 using namespace visrtx;
-
-VISRTX_DEVICE nanovdb::Vec3f clamp(const nanovdb::Vec3f &v,
-    const nanovdb::Vec3f &min,
-    const nanovdb::Vec3f &max)
-{
-  return nanovdb::Vec3f(nanovdb::math::Clamp(v[0], min[0], max[0]),
-      nanovdb::math::Clamp(v[1], min[1], max[1]),
-      nanovdb::math::Clamp(v[2], min[2], max[2]));
-}
-
-template <typename ValueType>
-VISRTX_DEVICE void initNvdbRectilinearSampler(
-    NvdbRectilinearSamplerState<ValueType> &state,
-    const SpatialFieldGPUData *field)
-{
-  using GridType = nanovdb::Grid<nanovdb::NanoTree<ValueType>>;
-  const auto *grid =
-      static_cast<const GridType *>(field->data.nvdbRectilinear.gridData);
-
-  state.grid = grid;
-  state.accessor = grid->getAccessor();
-  state.filter = field->data.nvdbRectilinear.filter;
-  // Use placement new to construct sampler in-place, as we cannot assign
-  // because of deleted constructor of the nanovdb samplers
-  if (state.filter == SpatialFieldFilter::Nearest) {
-    new (&state.nearestSampler)
-        typename NvdbRectilinearSamplerState<ValueType>::NearestSamplerType(
-            nanovdb::math::createSampler<0>(state.accessor));
-  } else {
-    new (&state.linearSampler)
-        typename NvdbRectilinearSamplerState<ValueType>::LinearSamplerType(
-            nanovdb::math::createSampler<1>(state.accessor));
-  }
-
-  const nanovdb::CoordBBox indexBBox = grid->indexBBox();
-  const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
-
-  // NanoVDB samplers get exact values at 0, 1, ... N, which works for
-  // node centered data. For cell centered data, we need to offset by -0.5
-  // and clamp to artificially create the full voxel, extrapolating the
-  // outermost voxel values.
-  // ScaleDown moves from index space to normalized space [0, 1]
-  // ScaleUp moves from normalized space [0, 1] to index space - 1
-  state.scaleDown = 1.0f / dims;
-  state.scaleUp = dims - nanovdb::Vec3f(1.0f);
-  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
-  if (field->data.nvdbRectilinear.cellCentered) {
-    state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
-  } else {
-    state.offsetUp = state.offsetDown;
-  }
-  state.indexMin = nanovdb::Vec3f(indexBBox.min());
-  state.indexMax = nanovdb::Vec3f(indexBBox.max());
-
-  state.axisLUT[0] = field->data.nvdbRectilinear.axisLUT[0];
-  state.axisLUT[1] = field->data.nvdbRectilinear.axisLUT[1];
-  state.axisLUT[2] = field->data.nvdbRectilinear.axisLUT[2];
-
-  const auto &iavs = field->data.nvdbRectilinear.invAvgVoxelSize;
-  state.invAvgVoxelSize = nanovdb::Vec3f(iavs.x, iavs.y, iavs.z);
-}
-
-template <typename ValueType>
-VISRTX_DEVICE nanovdb::Vec3f worldToIndexRectilinear(
-    const NvdbRectilinearSamplerState<ValueType> &state, const vec3 *location)
-{
-  const auto indexPos0 = state.grid->worldToIndexF(
-      nanovdb::Vec3f(location->x, location->y, location->z));
-
-  // Recenter and normalize
-  const auto normalizedPos = (indexPos0 - state.offsetDown) * state.scaleDown;
-
-  // Apply rectilinear mapping
-  const auto normalizedPosRect =
-      nanovdb::Vec3f(tex1D<float>(state.axisLUT[0], normalizedPos[0]),
-          tex1D<float>(state.axisLUT[1], normalizedPos[1]),
-          tex1D<float>(state.axisLUT[2], normalizedPos[2]));
-
-  // Back to index space
-  return normalizedPosRect * state.scaleUp + state.offsetUp;
-}
-
-template <typename ValueType>
-VISRTX_DEVICE float sampleAtIndex(
-    const NvdbRectilinearSamplerState<ValueType> &state,
-    const nanovdb::Vec3f &indexPos)
-{
-  const auto clamped = clamp(indexPos, state.indexMin, state.indexMax);
-  if (state.filter == SpatialFieldFilter::Nearest)
-    return state.nearestSampler(clamped);
-  return state.linearSampler(clamped);
-}
-
-template <typename ValueType>
-VISRTX_DEVICE float sampleNvdbRectilinearWithGradient(
-    const NvdbRectilinearSamplerState<ValueType> &state,
-    const vec3 *location,
-    vec3 *gradient)
-{
-  // World-to-index coordinate transform
-  const auto indexPos = worldToIndexRectilinear(state, location);
-  const float value = sampleAtIndex(state, indexPos);
-
-  if (gradient) {
-    // Neighbor-voxel central differences at ±1 in index space
-    const float sxp = sampleAtIndex(state, indexPos + nanovdb::Vec3f(1, 0, 0));
-    const float sxn = sampleAtIndex(state, indexPos - nanovdb::Vec3f(1, 0, 0));
-    const float syp = sampleAtIndex(state, indexPos + nanovdb::Vec3f(0, 1, 0));
-    const float syn = sampleAtIndex(state, indexPos - nanovdb::Vec3f(0, 1, 0));
-    const float szp = sampleAtIndex(state, indexPos + nanovdb::Vec3f(0, 0, 1));
-    const float szn = sampleAtIndex(state, indexPos - nanovdb::Vec3f(0, 0, 1));
-
-    // Gradient in object space: scale by invAvgVoxelSize
-    *gradient = vec3(sxp - sxn, syp - syn, szp - szn)
-        * vec3(state.invAvgVoxelSize[0],
-            state.invAvgVoxelSize[1],
-            state.invAvgVoxelSize[2])
-        * 0.5f;
-  }
-
-  return value;
-}
 
 // Fp4 rectilinear sampler
 VISRTX_CALLABLE void __direct_callable__initNvdbRectilinearSamplerFp4(
@@ -171,7 +49,7 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbRectilinearFp4(
     const vec3 *location,
     vec3 *gradient)
 {
-  return sampleNvdbRectilinearWithGradient(
+  return sampleNvdbRectilinear(
       samplerState->nvdbRectilinearFp4, location, gradient);
 }
 
@@ -187,7 +65,7 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbRectilinearFp8(
     const vec3 *location,
     vec3 *gradient)
 {
-  return sampleNvdbRectilinearWithGradient(
+  return sampleNvdbRectilinear(
       samplerState->nvdbRectilinearFp8, location, gradient);
 }
 
@@ -203,7 +81,7 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbRectilinearFp16(
     const vec3 *location,
     vec3 *gradient)
 {
-  return sampleNvdbRectilinearWithGradient(
+  return sampleNvdbRectilinear(
       samplerState->nvdbRectilinearFp16, location, gradient);
 }
 
@@ -219,7 +97,7 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbRectilinearFpN(
     const vec3 *location,
     vec3 *gradient)
 {
-  return sampleNvdbRectilinearWithGradient(
+  return sampleNvdbRectilinear(
       samplerState->nvdbRectilinearFpN, location, gradient);
 }
 
@@ -235,6 +113,94 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbRectilinearFloat(
     const vec3 *location,
     vec3 *gradient)
 {
-  return sampleNvdbRectilinearWithGradient(
+  return sampleNvdbRectilinear(
       samplerState->nvdbRectilinearFloat, location, gradient);
 }
+
+// Woodcock-body callables — see NvdbRegularSampler_ptx.cu for the design rationale.
+#define VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(Suffix, ValueType)         \
+  VISRTX_CALLABLE float __direct_callable__sampleDistance##Suffix(            \
+      ScreenSample *ss,                                                       \
+      const VolumeHit *hit,                                                   \
+      vec3 *albedo,                                                           \
+      float *extinction,                                                      \
+      bool *didScatter,                                                       \
+      vec3 *normal)                                                           \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRectilinearSamplerState<ValueType>> stateBox;         \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbRectilinearSampler(samplerState, &field);                         \
+    return detail::woodcockSampleDistance(*ss,                                \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        *albedo,                                                              \
+        *extinction,                                                          \
+        *didScatter,                                                          \
+        normal,                                                               \
+        [] __device__(const NvdbRectilinearSamplerState<ValueType> &s,        \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdbRectilinear(s, &p, nullptr); }, \
+        [] __device__(const NvdbRectilinearSamplerState<ValueType> &s,        \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p,                                                    \
+            vec3 &g) { return sampleNvdbRectilinear(s, &p, &g); });           \
+  }                                                                           \
+                                                                              \
+  VISRTX_CALLABLE void __direct_callable__ratioTrackTransmittance##Suffix(    \
+      ScreenSample *ss, const VolumeHit *hit, vec3 *attenuation)              \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRectilinearSamplerState<ValueType>> stateBox;         \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbRectilinearSampler(samplerState, &field);                         \
+    detail::woodcockRatioTrackTransmittance(*ss,                              \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        *attenuation,                                                         \
+        [] __device__(const NvdbRectilinearSamplerState<ValueType> &s,        \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdbRectilinear(s, &p, nullptr); });\
+  }                                                                           \
+                                                                              \
+  VISRTX_CALLABLE float __direct_callable__rayMarchVolume##Suffix(            \
+      ScreenSample *ss,                                                       \
+      const VolumeHit *hit,                                                   \
+      vec3 *color,                                                            \
+      vec3 *normal,                                                           \
+      float *opacity,                                                         \
+      float invSamplingRate)                                                  \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRectilinearSamplerState<ValueType>> stateBox;         \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbRectilinearSampler(samplerState, &field);                         \
+    return detail::latticeRayMarchVolume(*ss,                                 \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        color,                                                                \
+        normal,                                                               \
+        *opacity,                                                             \
+        invSamplingRate,                                                      \
+        [] __device__(const NvdbRectilinearSamplerState<ValueType> &s,        \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdbRectilinear(s, &p, nullptr); }, \
+        [] __device__(const NvdbRectilinearSamplerState<ValueType> &s,        \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p,                                                    \
+            vec3 &g) { return sampleNvdbRectilinear(s, &p, &g); });           \
+  }
+
+VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(NvdbRectilinearFp4, nanovdb::Fp4)
+VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(NvdbRectilinearFp8, nanovdb::Fp8)
+VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(NvdbRectilinearFp16, nanovdb::Fp16)
+VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(NvdbRectilinearFpN, nanovdb::FpN)
+VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES(NvdbRectilinearFloat, float)
+
+#undef VISRTX_DEFINE_NVDB_RECT_WOODCOCK_CALLABLES

--- a/devices/rtx/device/spatial_field/NvdbRegularField.cpp
+++ b/devices/rtx/device/spatial_field/NvdbRegularField.cpp
@@ -174,6 +174,13 @@ SpatialFieldGPUData NvdbRegularField::gpuData() const
   sf.data.nvdbRegular.filter = (m_filter == "nearest")
       ? SpatialFieldFilter::Nearest
       : SpatialFieldFilter::Linear;
+  // Degenerate axis (zero voxel size) collapses the central-difference
+  // gradient on that axis; emit 0 instead of +inf so downstream normals
+  // stay finite rather than NaN-propagating into the framebuffer.
+  auto safeInvTwo = [](float v) { return v > 0.0f ? 1.0f / (2.0f * v) : 0.0f; };
+  sf.data.nvdbRegular.invTwoVoxelSize = vec3(safeInvTwo(m_voxelSize.x),
+      safeInvTwo(m_voxelSize.y),
+      safeInvTwo(m_voxelSize.z));
 
   sf.grid = m_uniformGrid.gpuData();
 

--- a/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
@@ -95,6 +95,11 @@ VISRTX_DEVICE void initNvdbSampler(
 
   state.indexMin = nanovdb::Vec3f(indexBBox.min());
   state.indexMax = nanovdb::Vec3f(indexBBox.max());
+
+  // Use host-precomputed invTwoVoxelSize — keeps Grid::voxelSize() (Vec3d)
+  // off the device init path.
+  const vec3 &iv = field->data.nvdbRegular.invTwoVoxelSize;
+  state.invTwoVoxelSize = nanovdb::Vec3f(iv.x, iv.y, iv.z);
 }
 
 template <typename ValueType>
@@ -115,7 +120,6 @@ VISRTX_DEVICE float sampleNvdb(
     const float value = state.nearestSampler(clamped);
     if (gradient) {
       // Central differences at ±1 voxel in index space
-      const auto voxelSize = state.grid->voxelSize();
       const float sxp = state.nearestSampler(clampNvdb(
           indexPos + nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
       const float sxn = state.nearestSampler(clampNvdb(
@@ -129,9 +133,10 @@ VISRTX_DEVICE float sampleNvdb(
       const float szn = state.nearestSampler(clampNvdb(
           indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
       // Convert from index space to object space
-      *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
-          (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
-          (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
+      *gradient =
+          vec3((sxp - sxn) * state.scale[0] * state.invTwoVoxelSize[0],
+              (syp - syn) * state.scale[1] * state.invTwoVoxelSize[1],
+              (szp - szn) * state.scale[2] * state.invTwoVoxelSize[2]);
     }
     return value;
   }
@@ -150,10 +155,9 @@ VISRTX_DEVICE float sampleNvdb(
         indexPos + nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
     const float szn = state.linearSampler(clampNvdb(
         indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
-    const auto voxelSize = state.grid->voxelSize();
-    *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
-        (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
-        (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
+    *gradient = vec3((sxp - sxn) * state.scale[0] * state.invTwoVoxelSize[0],
+        (syp - syn) * state.scale[1] * state.invTwoVoxelSize[1],
+        (szp - szn) * state.scale[2] * state.invTwoVoxelSize[2]);
   }
   return value;
 }

--- a/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// NanoVDB regular-grid sampler — inline device implementations.
+// Lives in a header so the volume integrator can call sampleNvdb directly,
+// bypassing the OptiX direct-callable dispatch on hot paths. The matching
+// __direct_callable__ entry points stay in NvdbRegularSampler_ptx.cu for
+// renderers that go through the SBT slot.
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/shadingState.h"
+
+#include <nanovdb/math/Math.h>
+
+namespace visrtx {
+
+VISRTX_DEVICE nanovdb::Vec3f clampNvdb(const nanovdb::Vec3f &v,
+    const nanovdb::Vec3f &min,
+    const nanovdb::Vec3f &max)
+{
+  return nanovdb::Vec3f(nanovdb::math::Clamp(v[0], min[0], max[0]),
+      nanovdb::math::Clamp(v[1], min[1], max[1]),
+      nanovdb::math::Clamp(v[2], min[2], max[2]));
+}
+
+template <typename ValueType>
+VISRTX_DEVICE void initNvdbSampler(
+    NvdbRegularSamplerState<ValueType> &state, const SpatialFieldGPUData *field)
+{
+  using GridType = nanovdb::Grid<nanovdb::NanoTree<ValueType>>;
+  const auto *grid =
+      static_cast<const GridType *>(field->data.nvdbRegular.gridData);
+
+  state.grid = grid;
+  state.accessor = grid->getAccessor();
+  state.filter = field->data.nvdbRegular.filter;
+  // Use placement new to construct sampler in-place, as we cannot assign
+  // because of deleted constructor of the nanovdb samplers
+  if (state.filter == SpatialFieldFilter::Nearest) {
+    new (&state.nearestSampler)
+        typename NvdbRegularSamplerState<ValueType>::NearestSamplerType(
+            nanovdb::math::createSampler<0>(state.accessor));
+  } else {
+    new (&state.linearSampler)
+        typename NvdbRegularSamplerState<ValueType>::LinearSamplerType(
+            nanovdb::math::createSampler<1>(state.accessor));
+  }
+
+  const nanovdb::CoordBBox indexBBox = grid->indexBBox();
+  const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
+  // NanoVDB samplers get exact values at 0, 1, ... N, which works for
+  // node centered data. For cell centered data, we need to offset by -0.5
+  // and clamp to artificially create the full voxel, extrapolating the
+  // outermost voxel values.
+  // Scale moves from index space to index space - 1
+  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
+  if (field->data.nvdbRegular.cellCentered) {
+    state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
+    state.scale = nanovdb::Vec3f(1.0f);
+  } else {
+    state.offsetUp = state.offsetDown;
+    state.scale = (dims - nanovdb::Vec3f(1.0f)) / dims;
+  }
+
+  state.indexMin = nanovdb::Vec3f(indexBBox.min());
+  state.indexMax = nanovdb::Vec3f(indexBBox.max());
+}
+
+template <typename ValueType>
+VISRTX_DEVICE float sampleNvdb(
+    const NvdbRegularSamplerState<ValueType> &state,
+    const vec3 *location,
+    vec3 *gradient)
+{
+  const auto indexPos0 = state.grid->worldToIndexF(
+      nanovdb::Vec3f(location->x, location->y, location->z));
+
+  const auto indexPos =
+      (indexPos0 - state.offsetDown) * state.scale + state.offsetUp;
+
+  const auto clamped = clampNvdb(indexPos, state.indexMin, state.indexMax);
+
+  if (state.filter == SpatialFieldFilter::Nearest) {
+    const float value = state.nearestSampler(clamped);
+    if (gradient) {
+      // Central differences at ±1 voxel in index space
+      const auto voxelSize = state.grid->voxelSize();
+      const float sxp = state.nearestSampler(clampNvdb(
+          indexPos + nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
+      const float sxn = state.nearestSampler(clampNvdb(
+          indexPos - nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
+      const float syp = state.nearestSampler(clampNvdb(
+          indexPos + nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
+      const float syn = state.nearestSampler(clampNvdb(
+          indexPos - nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
+      const float szp = state.nearestSampler(clampNvdb(
+          indexPos + nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
+      const float szn = state.nearestSampler(clampNvdb(
+          indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
+      // Convert from index space to object space
+      *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
+          (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
+          (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
+    }
+    return value;
+  }
+
+  const float value = state.linearSampler(clamped);
+  if (gradient) {
+    const float sxp = state.linearSampler(clampNvdb(
+        indexPos + nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
+    const float sxn = state.linearSampler(clampNvdb(
+        indexPos - nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
+    const float syp = state.linearSampler(clampNvdb(
+        indexPos + nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
+    const float syn = state.linearSampler(clampNvdb(
+        indexPos - nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
+    const float szp = state.linearSampler(clampNvdb(
+        indexPos + nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
+    const float szn = state.linearSampler(clampNvdb(
+        indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
+    const auto voxelSize = state.grid->voxelSize();
+    *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
+        (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
+        (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
+  }
+  return value;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
@@ -63,7 +63,11 @@ VISRTX_DEVICE void initNvdbSampler(
       static_cast<const GridType *>(field->data.nvdbRegular.gridData);
 
   state.grid = grid;
-  state.accessor = grid->getAccessor();
+  // Construct the (leaf-only) accessor directly from the tree root —
+  // grid->getAccessor() would return the 3-level DefaultReadAccessor and
+  // mismatch our AccessorType typedef.
+  state.accessor = typename NvdbRegularSamplerState<ValueType>::AccessorType(
+      grid->tree().root());
   state.filter = field->data.nvdbRegular.filter;
   // Use placement new to construct sampler in-place, as we cannot assign
   // because of deleted constructor of the nanovdb samplers

--- a/devices/rtx/device/spatial_field/NvdbRegularSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/NvdbRegularSampler_ptx.cu
@@ -29,126 +29,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gpu/gpu_decl.h"
-#include "gpu/gpu_objects.h"
-#include "gpu/shadingState.h"
+// OptiX direct-callable entry points for the NanoVDB regular-grid sampler.
+// The actual implementations live in NvdbRegularSamplerInline.h so the volume
+// integrator can call them inline on hot paths; this file only registers them
+// against the SBT slots for the fallback dispatch path.
 
-#include <nanovdb/math/Math.h>
+#include "NvdbRegularSamplerInline.h"
+#include "gpu/volumeIntegrationDetail.h"
 
 using namespace visrtx;
-
-VISRTX_DEVICE nanovdb::Vec3f clamp(const nanovdb::Vec3f &v,
-    const nanovdb::Vec3f &min,
-    const nanovdb::Vec3f &max)
-{
-  return nanovdb::Vec3f(nanovdb::math::Clamp(v[0], min[0], max[0]),
-      nanovdb::math::Clamp(v[1], min[1], max[1]),
-      nanovdb::math::Clamp(v[2], min[2], max[2]));
-}
-
-template <typename ValueType>
-VISRTX_DEVICE void initNvdbSampler(
-    NvdbRegularSamplerState<ValueType> &state, const SpatialFieldGPUData *field)
-{
-  using GridType = nanovdb::Grid<nanovdb::NanoTree<ValueType>>;
-  const auto *grid =
-      static_cast<const GridType *>(field->data.nvdbRegular.gridData);
-
-  state.grid = grid;
-  state.accessor = grid->getAccessor();
-  state.filter = field->data.nvdbRegular.filter;
-  // Use placement new to construct sampler in-place, as we cannot assign
-  // because of deleted constructor of the nanovdb samplers
-  if (state.filter == SpatialFieldFilter::Nearest) {
-    new (&state.nearestSampler)
-        typename NvdbRegularSamplerState<ValueType>::NearestSamplerType(
-            nanovdb::math::createSampler<0>(state.accessor));
-  } else {
-    new (&state.linearSampler)
-        typename NvdbRegularSamplerState<ValueType>::LinearSamplerType(
-            nanovdb::math::createSampler<1>(state.accessor));
-  }
-
-  const nanovdb::CoordBBox indexBBox = grid->indexBBox();
-  const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
-  // NanoVDB samplers get exact values at 0, 1, ... N, which works for
-  // node centered data. For cell centered data, we need to offset by -0.5
-  // and clamp to artificially create the full voxel, extrapolating the
-  // outermost voxel values.
-  // Scale moves from index space to index space - 1
-  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
-  if (field->data.nvdbRegular.cellCentered) {
-    state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
-    state.scale = nanovdb::Vec3f(1.0f);
-  } else {
-    state.offsetUp = state.offsetDown;
-    state.scale = (dims - nanovdb::Vec3f(1.0f)) / dims;
-  }
-
-  state.indexMin = nanovdb::Vec3f(indexBBox.min());
-  state.indexMax = nanovdb::Vec3f(indexBBox.max());
-}
-
-template <typename ValueType>
-VISRTX_DEVICE float sampleNvdb(
-    const NvdbRegularSamplerState<ValueType> &state,
-    const vec3 *location,
-    vec3 *gradient)
-{
-  const auto indexPos0 = state.grid->worldToIndexF(
-      nanovdb::Vec3f(location->x, location->y, location->z));
-
-  const auto indexPos =
-      (indexPos0 - state.offsetDown) * state.scale + state.offsetUp;
-
-  const auto clamped = clamp(indexPos, state.indexMin, state.indexMax);
-
-  if (state.filter == SpatialFieldFilter::Nearest) {
-    const float value = state.nearestSampler(clamped);
-    if (gradient) {
-      // Central differences at ±1 voxel in index space
-      const auto voxelSize = state.grid->voxelSize();
-      const float sxp = state.nearestSampler(clamp(
-          indexPos + nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
-      const float sxn = state.nearestSampler(clamp(
-          indexPos - nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
-      const float syp = state.nearestSampler(clamp(
-          indexPos + nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
-      const float syn = state.nearestSampler(clamp(
-          indexPos - nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
-      const float szp = state.nearestSampler(clamp(
-          indexPos + nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
-      const float szn = state.nearestSampler(clamp(
-          indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
-      // Convert from index space to object space
-      *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
-          (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
-          (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
-    }
-    return value;
-  }
-
-  const float value = state.linearSampler(clamped);
-  if (gradient) {
-    const float sxp = state.linearSampler(clamp(
-        indexPos + nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
-    const float sxn = state.linearSampler(clamp(
-        indexPos - nanovdb::Vec3f(1, 0, 0), state.indexMin, state.indexMax));
-    const float syp = state.linearSampler(clamp(
-        indexPos + nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
-    const float syn = state.linearSampler(clamp(
-        indexPos - nanovdb::Vec3f(0, 1, 0), state.indexMin, state.indexMax));
-    const float szp = state.linearSampler(clamp(
-        indexPos + nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
-    const float szn = state.linearSampler(clamp(
-        indexPos - nanovdb::Vec3f(0, 0, 1), state.indexMin, state.indexMax));
-    const auto voxelSize = state.grid->voxelSize();
-    *gradient = vec3((sxp - sxn) * state.scale[0] / (2.f * voxelSize[0]),
-        (syp - syn) * state.scale[1] / (2.f * voxelSize[1]),
-        (szp - szn) * state.scale[2] / (2.f * voxelSize[2]));
-  }
-  return value;
-}
 
 // Fp4 sampler
 VISRTX_CALLABLE void __direct_callable__initNvdbSamplerFp4(
@@ -219,3 +108,94 @@ VISRTX_CALLABLE float __direct_callable__sampleNvdbFloat(
 {
   return sampleNvdb(samplerState->nvdbFloat, location, gradient);
 }
+
+// Woodcock-body callables — one per variant. Each stack-allocates the typed
+// sampler state, inits it once, then runs the shared body from
+// volumeIntegrationDetail.h with __device__ lambdas resolving to the
+// variant's inline sampleNvdb<T>.
+#define VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(Suffix, ValueType)              \
+  VISRTX_CALLABLE float __direct_callable__sampleDistance##Suffix(            \
+      ScreenSample *ss,                                                       \
+      const VolumeHit *hit,                                                   \
+      vec3 *albedo,                                                           \
+      float *extinction,                                                      \
+      bool *didScatter,                                                       \
+      vec3 *normal)                                                           \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRegularSamplerState<ValueType>> stateBox;             \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbSampler(samplerState, &field);                                    \
+    return detail::woodcockSampleDistance(*ss,                                \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        *albedo,                                                              \
+        *extinction,                                                          \
+        *didScatter,                                                          \
+        normal,                                                               \
+        [] __device__(const NvdbRegularSamplerState<ValueType> &s,            \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdb(s, &p, nullptr); },            \
+        [] __device__(const NvdbRegularSamplerState<ValueType> &s,            \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p,                                                    \
+            vec3 &g) { return sampleNvdb(s, &p, &g); });                      \
+  }                                                                           \
+                                                                              \
+  VISRTX_CALLABLE void __direct_callable__ratioTrackTransmittance##Suffix(    \
+      ScreenSample *ss, const VolumeHit *hit, vec3 *attenuation)              \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRegularSamplerState<ValueType>> stateBox;             \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbSampler(samplerState, &field);                                    \
+    detail::woodcockRatioTrackTransmittance(*ss,                              \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        *attenuation,                                                         \
+        [] __device__(const NvdbRegularSamplerState<ValueType> &s,            \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdb(s, &p, nullptr); });           \
+  }                                                                           \
+                                                                              \
+  VISRTX_CALLABLE float __direct_callable__rayMarchVolume##Suffix(            \
+      ScreenSample *ss,                                                       \
+      const VolumeHit *hit,                                                   \
+      vec3 *color,                                                            \
+      vec3 *normal,                                                           \
+      float *opacity,                                                         \
+      float invSamplingRate)                                                  \
+  {                                                                           \
+    const auto &field = getSpatialFieldData(                                  \
+        *ss->frameData, hit->volume->data.tf1d.field);                        \
+    SamplerStateBox<NvdbRegularSamplerState<ValueType>> stateBox;             \
+    auto &samplerState = stateBox.state;                                      \
+    initNvdbSampler(samplerState, &field);                                    \
+    return detail::latticeRayMarchVolume(*ss,                                 \
+        *hit,                                                                 \
+        samplerState,                                                         \
+        field,                                                                \
+        color,                                                                \
+        normal,                                                               \
+        *opacity,                                                             \
+        invSamplingRate,                                                      \
+        [] __device__(const NvdbRegularSamplerState<ValueType> &s,            \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p) { return sampleNvdb(s, &p, nullptr); },            \
+        [] __device__(const NvdbRegularSamplerState<ValueType> &s,            \
+            const SpatialFieldGPUData &,                                      \
+            const vec3 &p,                                                    \
+            vec3 &g) { return sampleNvdb(s, &p, &g); });                      \
+  }
+
+VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(NvdbFp4, nanovdb::Fp4)
+VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(NvdbFp8, nanovdb::Fp8)
+VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(NvdbFp16, nanovdb::Fp16)
+VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(NvdbFpN, nanovdb::FpN)
+VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES(NvdbFloat, float)
+
+#undef VISRTX_DEFINE_NVDB_WOODCOCK_CALLABLES

--- a/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Structured rectilinear-grid sampler — inline device implementations.
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/shadingState.h"
+
+namespace visrtx {
+
+VISRTX_DEVICE void initStructuredRectilinearSampler(
+    StructuredRectilinearSamplerState &state,
+    const SpatialFieldGPUData *field)
+{
+  const auto &data = field->data.structuredRectilinear;
+
+  state.texObj = data.texObj;
+  state.dims = data.dims - vec3(1);
+  state.offset = vec3(data.cellCentered ? 0.0f : 0.5f);
+  state.axisLUT[0] = data.axisLUT[0];
+  state.axisLUT[1] = data.axisLUT[1];
+  state.axisLUT[2] = data.axisLUT[2];
+  state.axisBoundsMin = data.axisBoundsMin;
+  state.axisBoundsMax = data.axisBoundsMax;
+
+  const vec3 extent = data.axisBoundsMax - data.axisBoundsMin;
+  state.invAvgVoxelSpacing =
+      data.cellCentered ? (state.dims + vec3(1)) / extent : state.dims / extent;
+}
+
+VISRTX_DEVICE float sampleStructuredRectilinear(
+    const StructuredRectilinearSamplerState &state,
+    const vec3 *location,
+    vec3 *gradient)
+{
+  vec3 normalizedPos = (*location - state.axisBoundsMin)
+      / (state.axisBoundsMax - state.axisBoundsMin);
+  normalizedPos = vec3(tex1D<float>(state.axisLUT[0], normalizedPos.x),
+      tex1D<float>(state.axisLUT[1], normalizedPos.y),
+      tex1D<float>(state.axisLUT[2], normalizedPos.z));
+  const auto sampleCoord = normalizedPos * state.dims + state.offset;
+
+  const float value =
+      tex3D<float>(state.texObj, sampleCoord.x, sampleCoord.y, sampleCoord.z);
+
+  if (gradient) {
+    const auto px = sampleCoord + vec3(1, 0, 0);
+    const auto nx = sampleCoord - vec3(1, 0, 0);
+    const auto py = sampleCoord + vec3(0, 1, 0);
+    const auto ny = sampleCoord - vec3(0, 1, 0);
+    const auto pz = sampleCoord + vec3(0, 0, 1);
+    const auto nz = sampleCoord - vec3(0, 0, 1);
+
+    const float sxp = tex3D<float>(state.texObj, px.x, px.y, px.z);
+    const float sxn = tex3D<float>(state.texObj, nx.x, nx.y, nx.z);
+    const float syp = tex3D<float>(state.texObj, py.x, py.y, py.z);
+    const float syn = tex3D<float>(state.texObj, ny.x, ny.y, ny.z);
+    const float szp = tex3D<float>(state.texObj, pz.x, pz.y, pz.z);
+    const float szn = tex3D<float>(state.texObj, nz.x, nz.y, nz.z);
+
+    *gradient =
+        vec3(sxp - sxn, syp - syn, szp - szn) * state.invAvgVoxelSpacing * 0.5f;
+  }
+
+  return value;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/spatial_field/StructuredRectilinearSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearSampler_ptx.cu
@@ -29,30 +29,19 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gpu/gpu_decl.h"
-#include "gpu/gpu_objects.h"
-#include "gpu/shadingState.h"
+// OptiX direct-callable entry points for the structured rectilinear sampler.
+// Implementations live in StructuredRectilinearSamplerInline.h.
 
-namespace visrtx {
+#include "StructuredRectilinearSamplerInline.h"
+#include "gpu/volumeIntegrationDetail.h"
+
+using namespace visrtx;
 
 VISRTX_CALLABLE void __direct_callable__initStructuredRectilinearSampler(
     VolumeSamplingState *samplerState, const SpatialFieldGPUData *field)
 {
-  auto &state = samplerState->structuredRectilinear;
-  const auto &data = field->data.structuredRectilinear;
-
-  state.texObj = data.texObj;
-  state.dims = data.dims - vec3(1);
-  state.offset = vec3(data.cellCentered ? 0.0f : 0.5f);
-  state.axisLUT[0] = data.axisLUT[0];
-  state.axisLUT[1] = data.axisLUT[1];
-  state.axisLUT[2] = data.axisLUT[2];
-  state.axisBoundsMin = data.axisBoundsMin;
-  state.axisBoundsMax = data.axisBoundsMax;
-
-  const vec3 extent = data.axisBoundsMax - data.axisBoundsMin;
-  state.invAvgVoxelSpacing =
-      data.cellCentered ? (state.dims + vec3(1)) / extent : state.dims / extent;
+  initStructuredRectilinearSampler(
+      samplerState->structuredRectilinear, field);
 }
 
 VISRTX_CALLABLE float __direct_callable__sampleStructuredRectilinear(
@@ -60,41 +49,91 @@ VISRTX_CALLABLE float __direct_callable__sampleStructuredRectilinear(
     const vec3 *location,
     vec3 *gradient)
 {
-  const auto &state = samplerState->structuredRectilinear;
-
-  // World-to-texel coordinate transform
-  vec3 normalizedPos = (*location - state.axisBoundsMin)
-      / (state.axisBoundsMax - state.axisBoundsMin);
-  normalizedPos = vec3(tex1D<float>(state.axisLUT[0], normalizedPos.x),
-      tex1D<float>(state.axisLUT[1], normalizedPos.y),
-      tex1D<float>(state.axisLUT[2], normalizedPos.z));
-  const auto sampleCoord = normalizedPos * state.dims + state.offset;
-
-  const float value =
-      tex3D<float>(state.texObj, sampleCoord.x, sampleCoord.y, sampleCoord.z);
-
-  if (gradient) {
-    // Neighbor-voxel central differences at ±1 texel offset
-    const auto px = sampleCoord + vec3(1, 0, 0);
-    const auto nx = sampleCoord - vec3(1, 0, 0);
-    const auto py = sampleCoord + vec3(0, 1, 0);
-    const auto ny = sampleCoord - vec3(0, 1, 0);
-    const auto pz = sampleCoord + vec3(0, 0, 1);
-    const auto nz = sampleCoord - vec3(0, 0, 1);
-
-    const float sxp = tex3D<float>(state.texObj, px.x, px.y, px.z);
-    const float sxn = tex3D<float>(state.texObj, nx.x, nx.y, nx.z);
-    const float syp = tex3D<float>(state.texObj, py.x, py.y, py.z);
-    const float syn = tex3D<float>(state.texObj, ny.x, ny.y, ny.z);
-    const float szp = tex3D<float>(state.texObj, pz.x, pz.y, pz.z);
-    const float szn = tex3D<float>(state.texObj, nz.x, nz.y, nz.z);
-
-    // Gradient in object space: scale by invAvgVoxelSpacing
-    *gradient =
-        vec3(sxp - sxn, syp - syn, szp - szn) * state.invAvgVoxelSpacing * 0.5f;
-  }
-
-  return value;
+  return sampleStructuredRectilinear(
+      samplerState->structuredRectilinear, location, gradient);
 }
 
-} // namespace visrtx
+VISRTX_CALLABLE float
+__direct_callable__sampleDistanceStructuredRectilinear(ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *albedo,
+    float *extinction,
+    bool *didScatter,
+    vec3 *normal)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRectilinearSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRectilinearSampler(samplerState, &field);
+  return detail::woodcockSampleDistance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *albedo,
+      *extinction,
+      *didScatter,
+      normal,
+      [] __device__(const StructuredRectilinearSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return sampleStructuredRectilinear(s, &p, nullptr);
+      },
+      [] __device__(const StructuredRectilinearSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) { return sampleStructuredRectilinear(s, &p, &g); });
+}
+
+VISRTX_CALLABLE void
+__direct_callable__ratioTrackTransmittanceStructuredRectilinear(
+    ScreenSample *ss, const VolumeHit *hit, vec3 *attenuation)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRectilinearSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRectilinearSampler(samplerState, &field);
+  detail::woodcockRatioTrackTransmittance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *attenuation,
+      [] __device__(const StructuredRectilinearSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return sampleStructuredRectilinear(s, &p, nullptr);
+      });
+}
+
+VISRTX_CALLABLE float __direct_callable__rayMarchVolumeStructuredRectilinear(
+    ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *color,
+    vec3 *normal,
+    float *opacity,
+    float invSamplingRate)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRectilinearSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRectilinearSampler(samplerState, &field);
+  return detail::latticeRayMarchVolume(*ss,
+      *hit,
+      samplerState,
+      field,
+      color,
+      normal,
+      *opacity,
+      invSamplingRate,
+      [] __device__(const StructuredRectilinearSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) {
+        return sampleStructuredRectilinear(s, &p, nullptr);
+      },
+      [] __device__(const StructuredRectilinearSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) { return sampleStructuredRectilinear(s, &p, &g); });
+}

--- a/devices/rtx/device/spatial_field/StructuredRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/StructuredRegularSamplerInline.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Structured regular-grid sampler — inline device implementations.
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/shadingState.h"
+
+namespace visrtx {
+
+VISRTX_DEVICE void initStructuredRegularSampler(
+    StructuredRegularSamplerState &state, const SpatialFieldGPUData *field)
+{
+  state.texObj = field->data.structuredRegular.texObj;
+  state.origin = field->data.structuredRegular.origin;
+  state.invDims = field->data.structuredRegular.invDims;
+  state.invSpacing = field->data.structuredRegular.invSpacing;
+  state.offset =
+      vec3(field->data.structuredRegular.cellCentered ? 0.0f : 0.5f);
+}
+
+VISRTX_DEVICE float sampleStructuredRegular(
+    const StructuredRegularSamplerState &state,
+    const vec3 *location,
+    vec3 *gradient)
+{
+  const auto texelCoords = (*location - state.origin) * state.invSpacing;
+  const auto coords = texelCoords + state.offset;
+  const float value = tex3D<float>(state.texObj, coords.x, coords.y, coords.z);
+
+  if (gradient) {
+    const auto px = coords + vec3(1, 0, 0);
+    const auto nx = coords - vec3(1, 0, 0);
+    const auto py = coords + vec3(0, 1, 0);
+    const auto ny = coords - vec3(0, 1, 0);
+    const auto pz = coords + vec3(0, 0, 1);
+    const auto nz = coords - vec3(0, 0, 1);
+
+    const float sxp = tex3D<float>(state.texObj, px.x, px.y, px.z);
+    const float sxn = tex3D<float>(state.texObj, nx.x, nx.y, nx.z);
+    const float syp = tex3D<float>(state.texObj, py.x, py.y, py.z);
+    const float syn = tex3D<float>(state.texObj, ny.x, ny.y, ny.z);
+    const float szp = tex3D<float>(state.texObj, pz.x, pz.y, pz.z);
+    const float szn = tex3D<float>(state.texObj, nz.x, nz.y, nz.z);
+
+    *gradient = vec3(sxp - sxn, syp - syn, szp - szn) * state.invSpacing * 0.5f;
+  }
+
+  return value;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/spatial_field/StructuredRegularSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/StructuredRegularSampler_ptx.cu
@@ -29,23 +29,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "gpu/gpu_decl.h"
-#include "gpu/gpu_objects.h"
-#include "gpu/shadingState.h"
+// OptiX direct-callable entry points for the structured regular sampler.
+// Implementations live in StructuredRegularSamplerInline.h.
+
+#include "StructuredRegularSamplerInline.h"
+#include "gpu/volumeIntegrationDetail.h"
 
 using namespace visrtx;
 
 VISRTX_CALLABLE void __direct_callable__initStructuredRegularSampler(
     VolumeSamplingState *samplerState, const SpatialFieldGPUData *field)
 {
-  samplerState->structuredRegular.texObj = field->data.structuredRegular.texObj;
-  samplerState->structuredRegular.origin = field->data.structuredRegular.origin;
-  samplerState->structuredRegular.invDims =
-      field->data.structuredRegular.invDims;
-  samplerState->structuredRegular.invSpacing =
-      field->data.structuredRegular.invSpacing;
-  samplerState->structuredRegular.offset =
-      vec3(field->data.structuredRegular.cellCentered ? 0.0f : 0.5f);
+  initStructuredRegularSampler(samplerState->structuredRegular, field);
 }
 
 VISRTX_CALLABLE float __direct_callable__sampleStructuredRegular(
@@ -53,30 +48,86 @@ VISRTX_CALLABLE float __direct_callable__sampleStructuredRegular(
     const vec3 *location,
     vec3 *gradient)
 {
-  const auto &state = samplerState->structuredRegular;
-  const auto texelCoords = (*location - state.origin) * state.invSpacing;
-  const auto coords = texelCoords + state.offset;
-  const float value = tex3D<float>(state.texObj, coords.x, coords.y, coords.z);
+  return sampleStructuredRegular(
+      samplerState->structuredRegular, location, gradient);
+}
 
-  if (gradient) {
-    // Neighbor-voxel central differences at ±1 texel offset
-    const auto px = coords + vec3(1, 0, 0);
-    const auto nx = coords - vec3(1, 0, 0);
-    const auto py = coords + vec3(0, 1, 0);
-    const auto ny = coords - vec3(0, 1, 0);
-    const auto pz = coords + vec3(0, 0, 1);
-    const auto nz = coords - vec3(0, 0, 1);
+// Woodcock-body callables — single variant, no macro fan-out.
+VISRTX_CALLABLE float __direct_callable__sampleDistanceStructuredRegular(
+    ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *albedo,
+    float *extinction,
+    bool *didScatter,
+    vec3 *normal)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRegularSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRegularSampler(samplerState, &field);
+  return detail::woodcockSampleDistance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *albedo,
+      *extinction,
+      *didScatter,
+      normal,
+      [] __device__(const StructuredRegularSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) { return sampleStructuredRegular(s, &p, nullptr); },
+      [] __device__(const StructuredRegularSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) { return sampleStructuredRegular(s, &p, &g); });
+}
 
-    const float sxp = tex3D<float>(state.texObj, px.x, px.y, px.z);
-    const float sxn = tex3D<float>(state.texObj, nx.x, nx.y, nx.z);
-    const float syp = tex3D<float>(state.texObj, py.x, py.y, py.z);
-    const float syn = tex3D<float>(state.texObj, ny.x, ny.y, ny.z);
-    const float szp = tex3D<float>(state.texObj, pz.x, pz.y, pz.z);
-    const float szn = tex3D<float>(state.texObj, nz.x, nz.y, nz.z);
+VISRTX_CALLABLE void
+__direct_callable__ratioTrackTransmittanceStructuredRegular(
+    ScreenSample *ss, const VolumeHit *hit, vec3 *attenuation)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRegularSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRegularSampler(samplerState, &field);
+  detail::woodcockRatioTrackTransmittance(*ss,
+      *hit,
+      samplerState,
+      field,
+      *attenuation,
+      [] __device__(const StructuredRegularSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) { return sampleStructuredRegular(s, &p, nullptr); });
+}
 
-    // Gradient in object space: scale by invSpacing (texels → object units)
-    *gradient = vec3(sxp - sxn, syp - syn, szp - szn) * state.invSpacing * 0.5f;
-  }
-
-  return value;
+VISRTX_CALLABLE float __direct_callable__rayMarchVolumeStructuredRegular(
+    ScreenSample *ss,
+    const VolumeHit *hit,
+    vec3 *color,
+    vec3 *normal,
+    float *opacity,
+    float invSamplingRate)
+{
+  const auto &field =
+      getSpatialFieldData(*ss->frameData, hit->volume->data.tf1d.field);
+  SamplerStateBox<StructuredRegularSamplerState> stateBox;
+  auto &samplerState = stateBox.state;
+  initStructuredRegularSampler(samplerState, &field);
+  return detail::latticeRayMarchVolume(*ss,
+      *hit,
+      samplerState,
+      field,
+      color,
+      normal,
+      *opacity,
+      invSamplingRate,
+      [] __device__(const StructuredRegularSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p) { return sampleStructuredRegular(s, &p, nullptr); },
+      [] __device__(const StructuredRegularSamplerState &s,
+          const SpatialFieldGPUData &,
+          const vec3 &p,
+          vec3 &g) { return sampleStructuredRegular(s, &p, &g); });
 }

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
@@ -63,26 +63,21 @@ __global__ void computeOpacityBoundsGPU(float2 *opacityBounds,
     return;
   }
 
-  float normalizedLo = (valueRange.lower - xfRange.lower) / xfRangeSize;
-  float normalizedHi = (valueRange.upper - xfRange.lower) / xfRangeSize;
+  const float normalizedLo = (valueRange.lower - xfRange.lower) / xfRangeSize;
+  const float normalizedHi = (valueRange.upper - xfRange.lower) / xfRangeSize;
 
-  const float tfEntrySize = 1.0f / float(numColors);
-  normalizedLo -= tfEntrySize;
-  normalizedHi += tfEntrySize;
-
-  int lo =
-      glm::clamp(int(normalizedLo * (numColors - 1)), 0, int(numColors - 1));
-  int hi = glm::clamp(
-      int(normalizedHi * (numColors - 1)) + 1, 0, int(numColors - 1));
-
-  // The scan range plus 1-bin TF margin and 1-voxel field margin makes both
-  // bounds conservative (max ≥ true max, min ≤ true min) for the
-  // linear-filter TF lookup over the cell.
+  // Tight texel range under linear filtering: any sample t ∈ [Lo, Hi] blends
+  // texels floor(t·N − 0.5) .. ceil(t·N − 0.5).
+  const float N = float(numColors);
+  const int lo =
+      glm::clamp(int(::floorf(normalizedLo * N - 0.5f)), 0, int(numColors - 1));
+  const int hi =
+      glm::clamp(int(::ceilf(normalizedHi * N - 0.5f)), 0, int(numColors - 1));
   float minOpacity = 1.f;
   float maxOpacity = 0.f;
   for (int i = lo; i <= hi; ++i) {
-    float tc = (i + .5f) / numColors;
-    float a = tex1D<::float4>(colorMap, tc).w;
+    // Sample at the texel center: linear filter weight is 1.0 on texel i.
+    float a = tex1D<::float4>(colorMap, (i + 0.5f) / N).w;
     minOpacity = fminf(minOpacity, a);
     maxOpacity = fmaxf(maxOpacity, a);
   }

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
@@ -38,8 +38,7 @@
 
 namespace visrtx {
 
-__global__ void computeOpacityBoundsGPU(float *minOpacities,
-    float *maxOpacities,
+__global__ void computeOpacityBoundsGPU(float2 *opacityBounds,
     const box1 *valueRanges,
     cudaTextureObject_t colorMap,
     size_t numMCs,
@@ -54,15 +53,13 @@ __global__ void computeOpacityBoundsGPU(float *minOpacities,
   box1 valueRange = valueRanges[threadID];
 
   if (valueRange.upper < valueRange.lower) {
-    minOpacities[threadID] = 0.f;
-    maxOpacities[threadID] = 0.f;
+    opacityBounds[threadID] = float2{0.f, 0.f};
     return;
   }
 
   const float xfRangeSize = xfRange.upper - xfRange.lower;
   if (xfRangeSize <= 0.f) {
-    minOpacities[threadID] = 0.f;
-    maxOpacities[threadID] = 0.f;
+    opacityBounds[threadID] = float2{0.f, 0.f};
     return;
   }
 
@@ -90,8 +87,7 @@ __global__ void computeOpacityBoundsGPU(float *minOpacities,
     maxOpacity = fmaxf(maxOpacity, a);
   }
 
-  minOpacities[threadID] = minOpacity;
-  maxOpacities[threadID] = maxOpacity;
+  opacityBounds[threadID] = float2{minOpacity, maxOpacity};
 }
 
 template <typename VoxelAccessor>
@@ -162,12 +158,10 @@ void UniformGrid::init(ivec3 dims, box3 objectBounds)
   size_t n = numCells();
 
   cudaFree(m_valueRanges);
-  cudaFree(m_minOpacities);
-  cudaFree(m_maxOpacities);
+  cudaFree(m_opacityBounds);
 
   cudaMalloc(&m_valueRanges, n * sizeof(box1));
-  cudaMalloc(&m_minOpacities, n * sizeof(float));
-  cudaMalloc(&m_maxOpacities, n * sizeof(float));
+  cudaMalloc(&m_opacityBounds, n * sizeof(float2));
 }
 
 void UniformGrid::computeValueRanges(const SpatialFieldGPUData &sfgd)
@@ -233,12 +227,10 @@ void UniformGrid::computeValueRanges(const SpatialFieldGPUData &sfgd)
 void UniformGrid::cleanup()
 {
   cudaFree(m_valueRanges);
-  cudaFree(m_minOpacities);
-  cudaFree(m_maxOpacities);
+  cudaFree(m_opacityBounds);
 
   m_valueRanges = nullptr;
-  m_minOpacities = nullptr;
-  m_maxOpacities = nullptr;
+  m_opacityBounds = nullptr;
 }
 
 UniformGridData UniformGrid::gpuData() const
@@ -247,8 +239,7 @@ UniformGridData UniformGrid::gpuData() const
   grid.dims = m_dims;
   grid.objectBounds = m_objectBounds;
   grid.valueRanges = m_valueRanges;
-  grid.minOpacities = m_minOpacities;
-  grid.maxOpacities = m_maxOpacities;
+  grid.opacityBounds = m_opacityBounds;
   return grid;
 }
 
@@ -258,7 +249,7 @@ void UniformGrid::computeOpacityBounds(
   size_t n = numCells();
   size_t numThreads = 1024;
   computeOpacityBoundsGPU<<<iDivUp(n, numThreads), numThreads, 0, stream>>>(
-      m_minOpacities, m_maxOpacities, m_valueRanges, cm, n, cmSize, cmRange);
+      m_opacityBounds, m_valueRanges, cm, n, cmSize, cmRange);
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
@@ -36,7 +36,7 @@
 
 namespace visrtx {
 
-constexpr int MACROCELL_SIZE = 16;
+constexpr int MACROCELL_SIZE = 8;
 
 struct UniformGrid
 {

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.h
@@ -57,8 +57,7 @@ struct UniformGrid
   size_t numCells() const;
 
   box1 *m_valueRanges = nullptr;
-  float *m_minOpacities = nullptr;
-  float *m_maxOpacities = nullptr;
+  float2 *m_opacityBounds = nullptr; // .x = min, .y = max
   ivec3 m_dims;
   ivec3 m_fieldDims;
   box3 m_objectBounds;

--- a/devices/rtx/device/world/World.cpp
+++ b/devices/rtx/device/world/World.cpp
@@ -40,6 +40,8 @@
 #include "optix_visrtx.h"
 #include "utility/AnariTypeHelpers.h"
 
+#include <glm/gtc/matrix_inverse.hpp>
+
 #ifdef USE_MDL
 #include "geometry/ComputeTangent.h"
 #include "material/MDL.h"
@@ -414,26 +416,43 @@ void World::buildInstanceSurfaceGPUData()
 
     for (size_t t = 0; t < inst->numTransforms(); t++) {
       auto id = inst->userID(t);
+
+      const mat4 o2wMat4 = mat4(inst->xfm(t));
+      const mat3x4 o2w = glm::transpose(mat4x3(o2wMat4));
+      const mat3x4 w2o =
+          glm::transpose(mat4x3(glm::affineInverse(o2wMat4)));
+
+      auto assignXfm = [&](InstanceSurfaceGPUData &g) {
+        g.objectToWorld = o2w;
+        g.worldToObject = w2o;
+      };
+
       if (group->containsTriangleGeometry()) {
-        sd[instID++] =
+        sd[instID] =
             makeInstanceGPUData(group->surfaceTriangleGPUIndices().data(),
                 inst->uniformAttributes(),
                 id,
                 t);
+        assignXfm(sd[instID]);
+        ++instID;
       }
       if (group->containsCurveGeometry()) {
-        sd[instID++] =
+        sd[instID] =
             makeInstanceGPUData(group->surfaceCurveGPUIndices().data(),
                 inst->uniformAttributes(),
                 id,
                 t);
+        assignXfm(sd[instID]);
+        ++instID;
       }
       if (group->containsUserGeometry()) {
-        sd[instID++] =
+        sd[instID] =
             makeInstanceGPUData(group->surfaceUserGPUIndices().data(),
                 inst->uniformAttributes(),
                 id,
                 t);
+        assignXfm(sd[instID]);
+        ++instID;
       }
     }
   });
@@ -451,8 +470,20 @@ void World::buildInstanceVolumeGPUData()
     auto *vd = m_instanceVolumeGPUData.dataHost();
     for (size_t t = 0; t < inst->numTransforms(); t++) {
       auto id = inst->userID(t);
-      if (group->containsVolumes())
-        vd[instID++] = {group->volumeGPUIndices().data(), id};
+      if (!group->containsVolumes())
+        continue;
+
+      const mat4 o2wMat4 = mat4(inst->xfm(t));
+      const mat3x4 o2w = glm::transpose(mat4x3(o2wMat4));
+      const mat3x4 w2o =
+          glm::transpose(mat4x3(glm::affineInverse(o2wMat4)));
+
+      InstanceVolumeGPUData g;
+      g.objectToWorld = o2w;
+      g.worldToObject = w2o;
+      g.volumes = group->volumeGPUIndices().data();
+      g.id = id;
+      vd[instID++] = g;
     }
   });
 

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "Core.h"
+#include "MDLBackendConfig.h"
 
 #include <fmt/core.h>
 #include <fmt/std.h>
@@ -421,16 +422,10 @@ const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
 
   auto distilledMaterial = make_handle(getDistilledToDiffuse(compiledMaterial));
 
-  // ANARI attributes 0 to 3
-  const int numTextureSpaces = 4;
-  // Number of actually supported textures. MDL's default, let's assume this is
-  // enough for now
-  const int numTextureResults = 32;
-
   ptxBackend->set_option(
-      "num_texture_spaces", std::to_string(numTextureSpaces).c_str());
+      "num_texture_spaces", std::to_string(kNumTextureSpaces).c_str());
   ptxBackend->set_option(
-      "num_texture_results", std::to_string(numTextureResults).c_str());
+      "num_texture_results", std::to_string(kNumTextureResults).c_str());
   ptxBackend->set_option_binary("llvm_renderer_module", nullptr, 0);
   ptxBackend->set_option("visible_functions", "");
 

--- a/devices/rtx/libmdl/MDLBackendConfig.h
+++ b/devices/rtx/libmdl/MDLBackendConfig.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace visrtx::libmdl {
+
+// MDL backend codegen sizing. These match the shadingState.h declarations of
+// MDLShadingState::textureCoords / textureTangentsU / textureTangentsV
+// (sized by kNumTextureSpaces) and MDLShadingState::textureResults (sized by
+// kNumTextureResults). The MDL backend is told these values at PTX-generation
+// time via the `num_texture_spaces` / `num_texture_results` options; the
+// generated PTX then indexes the corresponding arrays in MDLShadingState. The
+// two sides MUST agree, so keep them defined in one place.
+//
+// kNumTextureSpaces sized to MDL's default upper bound: any material whose
+// source references `state::texture_coordinate(i)` with i in [0, 4) generates
+// PTX that indexes textureCoords[i]. Shrinking this below 4 would let such a
+// material read past the array — there is no asset-loader check that rejects
+// multi-UV materials, so the codegen budget must cover them.
+constexpr int kNumTextureSpaces = 4;
+constexpr int kNumTextureResults = 8;
+
+} // namespace visrtx::libmdl


### PR DESCRIPTION
## Summary

Rework the overall volume rendering and render backends to try and decrease register spill, direct callable usage in hot loops and double precision operations.

## Optimization levers

- **Volume Woodcock sampler** — per-sampler direct-callable dispatch (frees raygen registers); leaf-only NanoVDB `ReadAccessor` in sampler state; halved macrocell size; opacity min/max packed into `float2`; strict-bound macrocell TF via a point-filtered sibling texture.
- **Quality-path RR / shadow culling** — adaptive RR for NEE shadow rays; skip Quality shadow trace below an epsilon contribution; volume RR depth tuned + survival capped; skip volume normal compute on Quality bounces ≥ 1.
- **RNG / camera sampling** — PCG-XSH-RR-32 replaces curand Philox; camera sampling switched to Halton; drops the `CUDA::curand` link.
- **MDL footprint** — `textureResults` shrunk to 8; MDL sampler table aliased (drops the 128 B inline copy).
- **Shadow anyhit gating** — `MaterialGPUData::isFullyOpaque` precomputed; opaque shadow anyhits skipped.
- **Hit / instance data** — `(Surface|Volume)Hit` transforms relocated to `Instance(Surface|Volume)GPUData`; `SurfaceHit` copy dropped in Interactive bounce raygen
- **CDF build** — conditional-CDF construction batched into single thrust launches.
- **Device codegen** — `--use_fast_math` enabled for OptiX device kernels; spurious `double` arithmetic trimmed.

## Wall-clock

tsdRender of some test scenes, PR vs baseline, mean ms, 5 runs

| scene  | renderer       | baseline | PR    | speedup  |
|---------|----------|---------:|--------:|---------:|
| test2 |quality           |   7997.5 |  2014.6 |   3.97×  |
| test1  |quality           |   4724.0 |  1215.9 |   3.89×  |
| dragon | quality     |   6595.9 |  2055.2 |   3.21×  |
| dragon | interactive |   2823.6 |   952.5 |   2.96×  |
| villa | quality      |   2971.3 |  2021.4 |   1.47×  |
| villa |interactive  |   1569.7 |  1349.9 |   1.16×  |
