### PR TITLE
Fix window scaling on MacOS

### DIFF
--- a/devices/rtx/device/material/MDL.cpp
+++ b/devices/rtx/device/material/MDL.cpp
@@ -345,9 +345,11 @@ void MDL::syncParameters()
         if (sampler) {
           // Find a valid slot for out sampler.
           // Check if this input if already bound and then release it
-          auto it = std::find_if(begin(m_samplers), end(m_samplers), [&name](const SamplerDesc &desc) {
-            return desc.name == name;
-          });
+          auto it = std::find_if(begin(m_samplers),
+              end(m_samplers),
+              [&paramName = name](const SamplerDesc &desc) {
+                return desc.name == paramName;
+              });
           if (it != end(m_samplers)) {
             // Found, release
             if (it->sampler) {

--- a/tsd/src/tsd/ui/imgui/Application.cpp
+++ b/tsd/src/tsd/ui/imgui/Application.cpp
@@ -178,9 +178,8 @@ void Application::showImportObjectFileDialog(
   m_objectFileDialog->showImport(fileType, importRoot);
 }
 
-void Application::showExportObjectFileDialog(TSDObjectFileType fileType,
-    anari::DataType objectType,
-    size_t objectIndex)
+void Application::showExportObjectFileDialog(
+    TSDObjectFileType fileType, anari::DataType objectType, size_t objectIndex)
 {
   m_objectFileDialog->showExport(fileType, objectType, objectIndex);
 }
@@ -374,7 +373,6 @@ WindowArray Application::setupWindows()
 
   auto *window = sdlWindow();
   SDL_MaximizeWindow(window);
-  m_uiConfig.fontScale = SDL_GetWindowDisplayScale(window);
 
   setupImGuiStyle();
 
@@ -1207,8 +1205,8 @@ void Application::AppImpl::init(Uint32 windowFlags)
 
   SDL_ShowWindow(sdlWindow);
 
-  const float scale = SDL_GetWindowPixelDensity(sdlWindow);
-  SDL_SetRenderScale(sdlRenderer, scale, scale);
+  float pixelDensity = SDL_GetWindowPixelDensity(sdlWindow);
+  SDL_SetRenderScale(sdlRenderer, pixelDensity, pixelDensity);
 
   ImGui::CreateContext();
   ImGui::StyleColorsDark();
@@ -1219,6 +1217,7 @@ void Application::AppImpl::init(Uint32 windowFlags)
   ImGuiIO &io = ImGui::GetIO();
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+  io.DisplayFramebufferScale = ImVec2(pixelDensity, pixelDensity);
 
   ImGuiStyle &style = ImGui::GetStyle();
   if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)

--- a/tsd/src/tsd/ui/imgui/ExtensionManager.h
+++ b/tsd/src/tsd/ui/imgui/ExtensionManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Use SDL renderer scaling instead of font scaling. Font scaling is still available and defaults to 1.
Plus misc compilation and warning fixes

<table>
<tr><th>before</th><th>after</th></tr>
<tr><td>
<img width="1622" height="1119" alt="Screenshot 2026-06-05 at 20 29 16" src="https://github.com/user-attachments/assets/0dad6342-7835-4074-8413-7cfe62006a96" />
</td><td>
<img width="1622" height="1119" alt="Screenshot 2026-06-05 at 20 28 27" src="https://github.com/user-attachments/assets/92374422-daa9-4398-b5ba-bf65f75b07a5" />
</td></tr>
</table>
