### PR TITLE
tsd: eliminate garbage/blank/distortion on viewport resize

### DIFF
--- a/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/AnariSceneRenderPass.cpp
@@ -272,6 +272,10 @@ void AnariSceneRenderPass::updateSize()
   m_buffers.instanceId = detail::allocate<uint32_t>(totalSize);
   m_buffers.albedo = detail::allocate<tsd::math::float3>(totalSize);
   m_buffers.normal = detail::allocate<tsd::math::float3>(totalSize);
+
+  // Render the new size synchronously so the first frame displayed after a
+  // resize is valid.
+  restartFrame();
 }
 
 void AnariSceneRenderPass::updateCameraAspect()

--- a/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/BaseViewport.cpp
@@ -24,7 +24,17 @@ BaseViewport::~BaseViewport()
 void BaseViewport::buildUI()
 {
   ImVec2 viewportSize = ImGui::GetContentRegionAvail();
-  viewport_reshape({int(viewportSize.x), int(viewportSize.y)});
+  const tsd::math::int2 requested(int(viewportSize.x), int(viewportSize.y));
+
+  // Debounce window resizes. While the viewport is actively being dragged the
+  // requested size changes every frame.
+  // Defer rendering until it is settled.
+  const bool firstSize = m_viewport.size.x <= 0 || m_viewport.size.y <= 0;
+  const bool sizeSettled = requested == m_viewport.pendingSize;
+  m_viewport.pendingSize = requested;
+
+  if (requested != m_viewport.size && (sizeSettled || firstSize))
+    viewport_reshape(requested);
 }
 
 void BaseViewport::setManipulator(tsd::rendering::Manipulator *m)
@@ -610,8 +620,8 @@ void BaseViewport::ui_menubar_Camera()
       }
 
       ImGui::Separator();
-      if (ImGui::Checkbox("Use Implicit Aspect Ratio",
-              &m_camera.useImplicitAspectRatio))
+      if (ImGui::Checkbox(
+              "Use Implicit Aspect Ratio", &m_camera.useImplicitAspectRatio))
         camera_setUseImplicitAspectRatio(m_camera.useImplicitAspectRatio);
       ImGui::Separator();
       tsd::ui::buildUI_object(*m_camera.current, scene, true);

--- a/tsd/src/tsd/ui/imgui/windows/BaseViewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/BaseViewport.h
@@ -84,6 +84,7 @@ struct BaseViewport : public Window
     bool active{false};
     tsd::math::int2 size{0, 0};
     tsd::math::int2 renderSize{0, 0};
+    tsd::math::int2 pendingSize{0, 0}; // size requested last frame (resize debounce)
     float resolutionScale{1.f};
   } m_viewport;
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -93,8 +93,24 @@ void Viewport::buildUI()
   ImGui::BeginDisabled(!BaseViewport::viewport_isActive());
 
   if (BaseViewport::viewport_isActive()) {
+    // Fit the rendered texture into the available region preserving its aspect
+    // ratio. It enables keeping the same correct image on viewport interactive
+    // resize, without having to render a new frame each size change.
+    const ImVec2 avail = ImGui::GetContentRegionAvail();
+    const tsd::math::int2 texSize = m_viewport.renderSize;
+    ImVec2 imageSize = avail;
+    if (texSize.x > 0 && texSize.y > 0 && avail.x > 0.f && avail.y > 0.f) {
+      const float texAspect = float(texSize.x) / float(texSize.y);
+      if (avail.x / avail.y > texAspect)
+        imageSize.x = avail.y * texAspect;
+      else
+        imageSize.y = avail.x / texAspect;
+      const ImVec2 cursor = ImGui::GetCursorPos();
+      ImGui::SetCursorPos(ImVec2(cursor.x + (avail.x - imageSize.x) * 0.5f,
+          cursor.y + (avail.y - imageSize.y) * 0.5f));
+    }
     ImGui::Image((ImTextureID)m_outputPass->getTexture(),
-        ImGui::GetContentRegionAvail(),
+        imageSize,
         ImVec2(0, 1),
         ImVec2(1, 0));
   }


### PR DESCRIPTION
The viewport flashed uninitialized framebuffer contents while a window resize was in progress.

New behaviour is about:
- debouncing resizes
- displaying the last known good frame preserving its aspect ratio
until the new size settles.