### PR TITLE
rtx: Mdl fixes

### DIFF
--- a/devices/rtx/device/array/Array.h
+++ b/devices/rtx/device/array/Array.h
@@ -104,10 +104,8 @@ struct Array : public UploadableArray
   template <typename T>
   void throwIfDifferentElementType() const;
 
-  mutable cudaArray_t m_cuArrayFloat{};
-  size_t m_arrayRefCountFloat{0};
-  mutable cudaArray_t m_cuArrayUint8{};
-  size_t m_arrayRefCountUint8{0};
+  mutable cudaArray_t m_cuArray{};
+  size_t m_arrayRefCount{0};
 
  private:
   void on_NoInternalReferences() override;

--- a/devices/rtx/device/array/Array1D.cpp
+++ b/devices/rtx/device/array/Array1D.cpp
@@ -90,53 +90,31 @@ const void *Array1D::end(AddressSpace as) const
   return p + (s * m_end);
 }
 
-cudaArray_t Array1D::acquireCUDAArrayFloat()
+cudaArray_t Array1D::acquireCUDAArray()
 {
-  if (!m_cuArrayFloat)
-    makeCudaArrayFloat(m_cuArrayFloat, *this, {totalSize(), 1});
-  m_arrayRefCountFloat++;
-  return m_cuArrayFloat;
+  if (!m_cuArray)
+    makeCudaArray(m_cuArray, *this, {totalSize(), 1});
+  m_arrayRefCount++;
+  return m_cuArray;
 }
 
-void Array1D::releaseCUDAArrayFloat()
+void Array1D::releaseCUDAArray()
 {
-  if (m_arrayRefCountFloat == 0)
+  if (m_arrayRefCount == 0)
     return;
 
-  m_arrayRefCountFloat--;
-  if (m_arrayRefCountFloat == 0) {
-    cudaFreeArray(m_cuArrayFloat);
-    m_cuArrayFloat = {};
-  }
-}
-
-cudaArray_t Array1D::acquireCUDAArrayUint8()
-{
-  if (!m_cuArrayUint8)
-    makeCudaArrayUint8(m_cuArrayUint8, *this, {totalSize(), 1});
-  m_arrayRefCountUint8++;
-  return m_cuArrayUint8;
-}
-
-void Array1D::releaseCUDAArrayUint8()
-{
-  if (m_arrayRefCountUint8 == 0)
-    return;
-
-  m_arrayRefCountUint8--;
-  if (m_arrayRefCountUint8 == 0) {
-    cudaFreeArray(m_cuArrayUint8);
-    m_cuArrayUint8 = {};
+  m_arrayRefCount--;
+  if (m_arrayRefCount == 0) {
+    cudaFreeArray(m_cuArray);
+    m_cuArray = {};
   }
 }
 
 void Array1D::uploadArrayData() const
 {
   Array::uploadArrayData();
-  if (m_cuArrayFloat)
-    makeCudaArrayFloat(m_cuArrayFloat, *this, {totalSize(), 1});
-  if (m_cuArrayUint8)
-    makeCudaArrayUint8(m_cuArrayUint8, *this, {totalSize(), 1});
+  if (m_cuArray)
+    makeCudaArray(m_cuArray, *this, {totalSize(), 1});
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/array/Array1D.h
+++ b/devices/rtx/device/array/Array1D.h
@@ -62,11 +62,8 @@ struct Array1D : public Array
   template <typename T>
   const T *valueAt(size_t i) const;
 
-  cudaArray_t acquireCUDAArrayFloat();
-  void releaseCUDAArrayFloat();
-
-  cudaArray_t acquireCUDAArrayUint8();
-  void releaseCUDAArrayUint8();
+  cudaArray_t acquireCUDAArray();
+  void releaseCUDAArray();
 
   void uploadArrayData() const override;
 

--- a/devices/rtx/device/array/Array2D.cpp
+++ b/devices/rtx/device/array/Array2D.cpp
@@ -51,47 +51,28 @@ anari::math::uint2 Array2D::size() const
   return anari::math::uint2(uint32_t(size(0)), uint32_t(size(1)));
 }
 
-cudaArray_t Array2D::acquireCUDAArrayFloat()
+cudaArray_t Array2D::acquireCUDAArray()
 {
-  if (!m_cuArrayFloat)
-    makeCudaArrayFloat(m_cuArrayFloat, *this, uvec2(size().x, size().y));
-  m_arrayRefCountFloat++;
-  return m_cuArrayFloat;
+  if (!m_cuArray)
+    makeCudaArray(m_cuArray, *this, uvec2(size().x, size().y));
+  m_arrayRefCount++;
+  return m_cuArray;
 }
 
-void Array2D::releaseCUDAArrayFloat()
+void Array2D::releaseCUDAArray()
 {
-  m_arrayRefCountFloat--;
-  if (m_arrayRefCountFloat == 0) {
-    cudaFreeArray(m_cuArrayFloat);
-    m_cuArrayFloat = {};
-  }
-}
-
-cudaArray_t Array2D::acquireCUDAArrayUint8()
-{
-  if (!m_cuArrayUint8)
-    makeCudaArrayUint8(m_cuArrayUint8, *this, uvec2(size().x, size().y));
-  m_arrayRefCountUint8++;
-  return m_cuArrayUint8;
-}
-
-void Array2D::releaseCUDAArrayUint8()
-{
-  m_arrayRefCountUint8--;
-  if (m_arrayRefCountUint8 == 0) {
-    cudaFreeArray(m_cuArrayUint8);
-    m_cuArrayUint8 = {};
+  m_arrayRefCount--;
+  if (m_arrayRefCount == 0) {
+    cudaFreeArray(m_cuArray);
+    m_cuArray = {};
   }
 }
 
 void Array2D::uploadArrayData() const
 {
   Array::uploadArrayData();
-  if (m_cuArrayFloat)
-    makeCudaArrayFloat(m_cuArrayFloat, *this, uvec2(size().x, size().y));
-  if (m_cuArrayUint8)
-    makeCudaArrayUint8(m_cuArrayUint8, *this, uvec2(size().x, size().y));
+  if (m_cuArray)
+    makeCudaArray(m_cuArray, *this, uvec2(size().x, size().y));
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/array/Array2D.h
+++ b/devices/rtx/device/array/Array2D.h
@@ -46,11 +46,8 @@ struct Array2D : public Array
   size_t size(int dim) const;
   anari::math::uint2 size() const;
 
-  cudaArray_t acquireCUDAArrayFloat();
-  void releaseCUDAArrayFloat();
-
-  cudaArray_t acquireCUDAArrayUint8();
-  void releaseCUDAArrayUint8();
+  cudaArray_t acquireCUDAArray();
+  void releaseCUDAArray();
 
   void uploadArrayData() const override;
 

--- a/devices/rtx/device/array/Array3D.cpp
+++ b/devices/rtx/device/array/Array3D.cpp
@@ -53,53 +53,28 @@ anari::math::uint3 Array3D::size() const
       uint32_t(size(0)), uint32_t(size(1)), uint32_t(size(2)));
 }
 
-cudaArray_t Array3D::acquireCUDAArrayFloat()
+cudaArray_t Array3D::acquireCUDAArray()
 {
-  if (!m_cuArrayFloat)
-    makeCudaArrayFloat(
-        m_cuArrayFloat, *this, uvec3(size().x, size().y, size().z));
-  m_arrayRefCountFloat++;
-  return m_cuArrayFloat;
+  if (!m_cuArray)
+    makeCudaArray(m_cuArray, *this, uvec3(size().x, size().y, size().z));
+  m_arrayRefCount++;
+  return m_cuArray;
 }
 
-void Array3D::releaseCUDAArrayFloat()
+void Array3D::releaseCUDAArray()
 {
-  m_arrayRefCountFloat--;
-  if (m_arrayRefCountFloat == 0) {
-    cudaFreeArray(m_cuArrayFloat);
-    m_cuArrayFloat = {};
-  }
-}
-
-cudaArray_t Array3D::acquireCUDAArrayUint8()
-{
-  if (!m_cuArrayUint8)
-    makeCudaArrayUint8(
-        m_cuArrayUint8, *this, uvec3(size().x, size().y, size().z));
-  m_arrayRefCountUint8++;
-  return m_cuArrayUint8;
-}
-
-void Array3D::releaseCUDAArrayUint8()
-{
-  m_arrayRefCountUint8--;
-  if (m_arrayRefCountUint8 == 0) {
-    cudaFreeArray(m_cuArrayUint8);
-    m_cuArrayUint8 = {};
+  m_arrayRefCount--;
+  if (m_arrayRefCount == 0) {
+    cudaFreeArray(m_cuArray);
+    m_cuArray = {};
   }
 }
 
 void Array3D::uploadArrayData() const
 {
   Array::uploadArrayData();
-  if (m_cuArrayFloat) {
-    makeCudaArrayFloat(
-        m_cuArrayFloat, *this, uvec3(size().x, size().y, size().z));
-  }
-  if (m_cuArrayUint8) {
-    makeCudaArrayUint8(
-        m_cuArrayUint8, *this, uvec3(size().x, size().y, size().z));
-  }
+  if (m_cuArray)
+    makeCudaArray(m_cuArray, *this, uvec3(size().x, size().y, size().z));
 }
 
 } // namespace visrtx

--- a/devices/rtx/device/array/Array3D.h
+++ b/devices/rtx/device/array/Array3D.h
@@ -46,11 +46,8 @@ struct Array3D : public Array
   size_t size(int dim) const;
   anari::math::uint3 size() const;
 
-  cudaArray_t acquireCUDAArrayFloat();
-  void releaseCUDAArrayFloat();
-
-  cudaArray_t acquireCUDAArrayUint8();
-  void releaseCUDAArrayUint8();
+  cudaArray_t acquireCUDAArray();
+  void releaseCUDAArray();
 
   void uploadArrayData() const override;
 

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -125,7 +125,11 @@ struct TextureHandler : mi::neuraylib::Texture_handler_base
 using ShadingStateMaterial = mi::neuraylib::Shading_state_material;
 using ResourceData = mi::neuraylib::Resource_data;
 
-struct alignas(8) MDLShadingState
+// 16-byte aligned: MDL's generated PTX writes textureResults with 16-byte
+// vector stores (st.local.v4.f32). An under-aligned (8-byte) local instance
+// makes those stores misaligned -> illegal __local__ access -> the render
+// kernel faults and the frame's completion event never signals.
+struct alignas(16) MDLShadingState
 {
   const char *argBlock;
 
@@ -136,7 +140,7 @@ struct alignas(8) MDLShadingState
   // Sized to match the MDL backend's num_texture_spaces / num_texture_results
   // options — see libmdl/MDLBackendConfig.h. The two sides must agree because
   // MDL's generated PTX indexes these arrays directly.
-  glm::vec4 textureResults[libmdl::kNumTextureResults];
+  alignas(16) glm::vec4 textureResults[libmdl::kNumTextureResults];
   glm::vec3 textureCoords[libmdl::kNumTextureSpaces];
   glm::vec3 textureTangentsU[libmdl::kNumTextureSpaces];
   glm::vec3 textureTangentsV[libmdl::kNumTextureSpaces];

--- a/devices/rtx/device/light/HDRI.cpp
+++ b/devices/rtx/device/light/HDRI.cpp
@@ -99,12 +99,8 @@ void HDRI::finalize()
 
     cleanup();
 
-    cudaArray_t cuArray = {};
     const bool isFp = isFloat(m_radiance->elementType());
-    if (isFp)
-      cuArray = m_radiance->acquireCUDAArrayFloat();
-    else
-      cuArray = m_radiance->acquireCUDAArrayUint8();
+    cudaArray_t cuArray = m_radiance->acquireCUDAArray();
 
     m_size = {m_radiance->size(0), m_radiance->size(1)};
 
@@ -164,10 +160,7 @@ void HDRI::cleanup()
 {
   if (m_radiance && m_radianceTex) {
     cudaDestroyTextureObject(m_radianceTex);
-    if (isFloat(m_radiance->elementType()))
-      m_radiance->releaseCUDAArrayFloat();
-    else
-      m_radiance->releaseCUDAArrayUint8();
+    m_radiance->releaseCUDAArray();
   }
 
 #ifdef VISRTX_ENABLE_HDRI_SAMPLING_DEBUG

--- a/devices/rtx/device/material/MDL.cpp
+++ b/devices/rtx/device/material/MDL.cpp
@@ -318,8 +318,8 @@ void MDL::syncParameters()
           if (colorspaceStr != "raw" && colorspaceStr != "srgb") {
             reportMessage(ANARI_SEVERITY_WARNING,
                 "Unknown colorspace type %s for %s. Falling back to srgb",
-                colorspaceStr,
-                name);
+                colorspaceStr.c_str(),
+                name.c_str());
             colorspaceStr = "srgb"s;
           }
           if (colorspaceStr == "raw"sv) {

--- a/devices/rtx/device/mdl/MaterialRegistry.cpp
+++ b/devices/rtx/device/mdl/MaterialRegistry.cpp
@@ -214,9 +214,17 @@ MaterialRegistry::acquireMaterial(
       textureDesc.url =
           fmt::format("bsdf_data_{}", fmt::ptr(textureDesc.bsdf.data));
     } else {
-      auto moduleOwner = targetCode->get_texture_owner_module(i);
+      // Relative resource paths (e.g. "Textures/foo.png") resolve against the
+      // owner module's directory. Pass the compiled module's on-disk path so
+      // resolution doesn't depend on the owner module name being reachable
+      // through the MDL search paths.
+      auto moduleOwner = std::string(targetCode->get_texture_owner_module(i));
+      auto ownerName =
+          moduleOwner.empty() ? std::string(moduleName) : moduleOwner;
+      const char *moduleFile = module->get_filename();
       auto url = std::string(targetCode->get_texture_url(i));
-      url = m_core->resolveResource(url.c_str(), moduleOwner);
+      url = m_core->resolveResource(
+          url.c_str(), ownerName, moduleFile ? moduleFile : "");
       if (url.empty()) {
         m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
             "Failed to resolve texture resource {} for material {}",

--- a/devices/rtx/device/mdl/SamplerRegistry.cpp
+++ b/devices/rtx/device/mdl/SamplerRegistry.cpp
@@ -486,10 +486,21 @@ Sampler *SamplerRegistry::loadFromTextureDesc(
   return {};
 }
 
+// The same image file can be requested in different color spaces (e.g. a map
+// used as both sRGB base color and raw data). The decoded sampler differs, so
+// the color space must be part of the cache key.
+static std::string samplerCacheKey(
+    std::string_view url, libmdl::ColorSpace colorSpace)
+{
+  return (colorSpace == libmdl::ColorSpace::sRGB ? "srgb:" : "linear:")
+      + std::string(url);
+}
+
 Sampler *SamplerRegistry::acquireSampler(
     const std::string &filePath, libmdl::ColorSpace colorSpace)
 {
-  if (auto it = m_dbToSampler.find(filePath); it != end(m_dbToSampler)) {
+  auto key = samplerCacheKey(filePath, colorSpace);
+  if (auto it = m_dbToSampler.find(key); it != end(m_dbToSampler)) {
     it->second->refInc();
     return it->second;
   }
@@ -499,7 +510,7 @@ Sampler *SamplerRegistry::acquireSampler(
     sampler->refInc();
     sampler->refDec(helium::PUBLIC); // Drop the implicit public refcount that
                                      // we don't rely on.
-    m_dbToSampler.insert({filePath, sampler});
+    m_dbToSampler.insert({key, sampler});
   } else {
     m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Unable to create sampler for texture `{}`",
@@ -512,7 +523,8 @@ Sampler *SamplerRegistry::acquireSampler(
 Sampler *SamplerRegistry::acquireSampler(
     const libmdl::TextureDescriptor &textureDesc)
 {
-  if (auto it = m_dbToSampler.find(textureDesc.url); it != end(m_dbToSampler)) {
+  auto key = samplerCacheKey(textureDesc.url, textureDesc.colorSpace);
+  if (auto it = m_dbToSampler.find(key); it != end(m_dbToSampler)) {
     it->second->refInc();
     return it->second;
   }
@@ -522,7 +534,7 @@ Sampler *SamplerRegistry::acquireSampler(
     sampler->refInc();
     sampler->refDec(helium::PUBLIC); // Drop the implicit public refcount that
                                      // we don't rely on.
-    m_dbToSampler.insert({textureDesc.url, sampler});
+    m_dbToSampler.insert({key, sampler});
   } else {
     m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Unable to create sampler for texture db name `{}`",

--- a/devices/rtx/device/mdl/SamplerRegistry.cpp
+++ b/devices/rtx/device/mdl/SamplerRegistry.cpp
@@ -256,11 +256,19 @@ Sampler *SamplerRegistry::loadFromDDS(
           filePath);
     }
 
+    // Move the file bytes to the heap and hand them to the array (CAPTURED)
+    // instead of borrowing the soon-freed local `buffer` (SHARED), which would
+    // force helium to privatize a host copy + log "making private copy of
+    // shared host array". appMemory is an offset into the buffer, so the array
+    // can't own it directly; pass the owning vector as deleterPtr and free that.
+    auto *owned = new std::vector<char>(std::move(buffer));
     Array1DMemoryDescriptor desc = {
         {
             dds::getDataPointer(dds),
-            nullptr,
-            nullptr,
+            [](const void *userPtr, const void * /*appMemory*/) {
+              delete static_cast<const std::vector<char> *>(userPtr);
+            },
+            owned,
             ANARI_UINT8,
         },
         static_cast<uint64_t>(linearSize),
@@ -282,11 +290,16 @@ Sampler *SamplerRegistry::loadFromDDS(
   } else if (format) {
     anari::DataType texelType = ANARI_UNKNOWN;
 
+    // See the compressed branch: own the file bytes (CAPTURED) rather than
+    // borrowing the local buffer, to avoid the per-texture privatize copy.
+    auto *owned = new std::vector<char>(std::move(buffer));
     Array2DMemoryDescriptor desc = {
         {
             dds::getDataPointer(dds),
-            nullptr,
-            nullptr,
+            [](const void *userPtr, const void * /*appMemory*/) {
+              delete static_cast<const std::vector<char> *>(userPtr);
+            },
+            owned,
             ANARI_UFIXED8_VEC4,
         },
         dds->header.width,
@@ -354,10 +367,18 @@ Sampler *SamplerRegistry::loadFromImage(
         : (colorSpace == libmdl::ColorSpace::Linear ? ANARI_UFIXED8
                                                     : ANARI_UFIXED8_R_SRGB);
 
+  // Hand the stb_image allocation to the Array2D (CAPTURED ownership) instead
+  // of borrowing it (SHARED). Borrowing forces helium to privatize a host copy
+  // when the public ref is dropped while the sampler still references it -- a
+  // per-texture deep copy + "making private copy of shared host array" warning,
+  // and it also leaked `data` (nothing freed the stb buffer). With a deleter
+  // the array owns and frees it: no copy, no warning, no leak.
   Array2DMemoryDescriptor desc = {
       {
           data,
-          nullptr,
+          [](const void * /*userPtr*/, const void *appMemory) {
+            stbi_image_free(const_cast<void *>(appMemory));
+          },
           nullptr,
           texelType,
       },
@@ -428,10 +449,16 @@ Sampler *SamplerRegistry::loadFromTextureDesc(
       texelType = ANARI_UFIXED8_VEC3;
     }
 
+    // df_data is MDL-SDK-owned, process-stable built-in table data shared
+    // across materials (the registry caches the sampler by this data pointer).
+    // Borrowing it with a null deleter (SHARED) made helium privatize a
+    // redundant host copy + log "making private copy of shared host array". A
+    // no-op deleter marks it CAPTURED so no copy is made; we must NOT free
+    // SDK-owned memory, hence the empty deleter rather than free/delete.
     Array3DMemoryDescriptor desc = {
         {
             textureDesc.bsdf.data,
-            nullptr,
+            [](const void *, const void *) {},
             nullptr,
             texelType,
         },

--- a/devices/rtx/device/mdl/SamplerRegistry.cpp
+++ b/devices/rtx/device/mdl/SamplerRegistry.cpp
@@ -309,7 +309,9 @@ Sampler *SamplerRegistry::loadFromDDS(
     auto array2d = new Array2D(m_deviceState, desc);
     array2d->commitParameters();
     array2d->finalize();
-    array2d->uploadArrayData();
+    // No uploadArrayData(): the linear device buffer is never sampled. Image2D
+    // builds its cudaArray from the host data, so uploading a redundant linear
+    // copy just doubles this texture's VRAM footprint.
     auto image2d = new Image2D(m_deviceState);
     image2d->setParam("image", array2d);
     array2d->refDec(helium::PUBLIC);
@@ -388,8 +390,10 @@ Sampler *SamplerRegistry::loadFromImage(
 
   auto array2d = new Array2D(m_deviceState, desc);
   array2d->commitParameters();
-  array2d->uploadArrayData();
   array2d->finalize();
+  // No uploadArrayData(): the linear device buffer is never sampled. Image2D
+  // builds its cudaArray from the host data, so uploading a redundant linear
+  // copy just doubles this texture's VRAM footprint.
   auto image2d = new Image2D(m_deviceState);
   image2d->setParam("image", array2d);
   image2d->commitParameters();

--- a/devices/rtx/device/renderer/Renderer.cpp
+++ b/devices/rtx/device/renderer/Renderer.cpp
@@ -43,6 +43,7 @@
 
 #include "gpu/gpu_decl.h"
 #include "gpu/shadingState.h"
+#include "utility/AnariTypeHelpers.h"
 
 // std
 #include <optix_types.h>
@@ -207,8 +208,22 @@ void Renderer::finalize()
 {
   cleanup();
   if (m_backgroundImage) {
-    auto cuArray = m_backgroundImage->acquireCUDAArrayUint8();
-    m_backgroundTexture = makeCudaTextureObject2D(cuArray, true, "linear");
+    const ANARIDataType fmt = m_backgroundImage->elementType();
+    if (numANARIChannels(fmt) == 0) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+          "invalid background image element type (%s); ignoring",
+          anari::toString(fmt));
+      return; // m_backgroundTexture stays null -> COLOR background fallback
+    }
+    const bool isFp = isFloat(fmt);
+    auto cuArray = m_backgroundImage->acquireCUDAArray();
+    m_backgroundTexture = makeCudaTextureObject2D(cuArray,
+        !isFp,
+        "linear",
+        "clampToEdge",
+        "clampToEdge",
+        vec4(0.f),
+        isSrgb8(fmt));
   }
 }
 
@@ -224,7 +239,7 @@ Span<std::string> Renderer::missSbtNames() const
 
 void Renderer::populateFrameData(FrameGPUData &fd) const
 {
-  if (m_backgroundImage) {
+  if (m_backgroundImage && m_backgroundTexture) {
     fd.renderer.backgroundMode = BackgroundMode::IMAGE;
     fd.renderer.background.texobj = m_backgroundTexture;
   } else {
@@ -1068,7 +1083,7 @@ void Renderer::cleanup()
   if (m_backgroundImage) {
     if (m_backgroundTexture) {
       cudaDestroyTextureObject(m_backgroundTexture);
-      m_backgroundImage->releaseCUDAArrayUint8();
+      m_backgroundImage->releaseCUDAArray();
     }
   }
 }

--- a/devices/rtx/device/renderer/Renderer.cpp
+++ b/devices/rtx/device/renderer/Renderer.cpp
@@ -887,6 +887,11 @@ void Renderer::initOptixPipeline()
 
         auto pipelineCompileOptions = makeVisRTXOptixPipelineCompileOptions();
 
+        // optix*Create writes the actual log length back into sizeof_log (which
+        // can exceed sizeof(log) on a verbose material). Reset it to the buffer
+        // capacity before every call, or a later call in this per-material loop
+        // would treat the stale (>2048) value as the capacity and overflow log.
+        sizeof_log = sizeof(log);
         OPTIX_CHECK(optixModuleCreate(state.optixContext,
             &moduleCompileOptions,
             &pipelineCompileOptions,

--- a/devices/rtx/device/sampler/Image1D.cpp
+++ b/devices/rtx/device/sampler/Image1D.cpp
@@ -70,17 +70,15 @@ void Image1D::finalize()
     return;
   }
 
-  cudaArray_t cuArray = {};
-  bool isFp = isFloat(m_image->elementType());
-  if (isFp)
-    cuArray = m_image->acquireCUDAArrayFloat();
-  else
-    cuArray = m_image->acquireCUDAArrayUint8();
+  const bool isFp = isFloat(m_image->elementType());
+  cudaArray_t cuArray = m_image->acquireCUDAArray();
 
   cleanupImageTextureObjects();
 
-  m_texture =
-      makeCudaTextureObject1D(cuArray, !isFp, m_filter, m_wrap1, m_borderColor);
+  // sRGB data is kept as raw bytes; the sampler does sRGB->linear in hardware.
+  const bool sRGB = isSrgb8(m_image->elementType());
+  m_texture = makeCudaTextureObject1D(
+      cuArray, !isFp, m_filter, m_wrap1, m_borderColor, sRGB);
   m_texels =
       makeCudaTexelObject1D(cuArray, !isFp, "nearest", m_wrap1, m_borderColor);
 
@@ -115,10 +113,7 @@ void Image1D::cleanupImageCudaArray()
   if (!m_image)
     return;
 
-  if (isFloat(m_image->elementType()))
-    m_image->releaseCUDAArrayFloat();
-  else
-    m_image->releaseCUDAArrayUint8();
+  m_image->releaseCUDAArray();
 }
 
 void Image1D::cleanupImageTextureObjects()

--- a/devices/rtx/device/sampler/Image2D.cpp
+++ b/devices/rtx/device/sampler/Image2D.cpp
@@ -71,17 +71,15 @@ void Image2D::finalize()
     return;
   }
 
-  cudaArray_t cuArray = {};
-  bool isFp = isFloat(m_image->elementType());
-  if (isFp)
-    cuArray = m_image->acquireCUDAArrayFloat();
-  else
-    cuArray = m_image->acquireCUDAArrayUint8();
+  const bool isFp = isFloat(m_image->elementType());
+  cudaArray_t cuArray = m_image->acquireCUDAArray();
 
   cleanupImageTextureObjects();
 
+  // sRGB data is kept as raw bytes; the sampler does sRGB->linear in hardware.
+  const bool sRGB = isSrgb8(m_image->elementType());
   m_texture = makeCudaTextureObject2D(
-      cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_borderColor);
+      cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_borderColor, sRGB);
   m_texels = makeCudaTexelObject2D(
       cuArray, !isFp, "nearest", m_wrap1, m_wrap2, m_borderColor);
 
@@ -122,10 +120,7 @@ void Image2D::cleanupImageCudaArray()
   if (!m_image)
     return;
 
-  if (isFloat(m_image->elementType()))
-    m_image->releaseCUDAArrayFloat();
-  else
-    m_image->releaseCUDAArrayUint8();
+  m_image->releaseCUDAArray();
 }
 
 void Image2D::cleanupImageTextureObjects()

--- a/devices/rtx/device/sampler/Image3D.cpp
+++ b/devices/rtx/device/sampler/Image3D.cpp
@@ -67,12 +67,8 @@ void Image3D::finalize()
     return;
   }
 
-  cudaArray_t cuArray = {};
-  bool isFp = isFloat(m_image->elementType());
-  if (isFp)
-    cuArray = m_image->acquireCUDAArrayFloat();
-  else
-    cuArray = m_image->acquireCUDAArrayUint8();
+  const bool isFp = isFloat(m_image->elementType());
+  cudaArray_t cuArray = m_image->acquireCUDAArray();
 
   cleanupImageTextureObjects();
 
@@ -85,8 +81,16 @@ void Image3D::finalize()
     return;
   }
 
-  m_texture = makeCudaTextureObject3D(
-      cuArray, !isFp, m_filter, m_wrap1, m_wrap2, m_wrap3, m_borderColor);
+  // sRGB data is kept as raw bytes; the sampler does sRGB->linear in hardware.
+  const bool sRGB = isSrgb8(format);
+  m_texture = makeCudaTextureObject3D(cuArray,
+      !isFp,
+      m_filter,
+      m_wrap1,
+      m_wrap2,
+      m_wrap3,
+      m_borderColor,
+      sRGB);
   m_texels = makeCudaTexelObject3D(
       cuArray, !isFp, "nearest", m_wrap1, m_wrap2, m_wrap3, m_borderColor);
 
@@ -141,10 +145,7 @@ void Image3D::cleanupImageCudaArray()
   if (!m_image)
     return;
 
-  if (isFloat(m_image->elementType()))
-    m_image->releaseCUDAArrayFloat();
-  else
-    m_image->releaseCUDAArrayUint8();
+  m_image->releaseCUDAArray();
 }
 
 void Image3D::cleanupImageTextureObjects()

--- a/devices/rtx/device/utility/AnariTypeHelpers.h
+++ b/devices/rtx/device/utility/AnariTypeHelpers.h
@@ -65,9 +65,23 @@ constexpr bool isFloat64(ANARIDataType format)
   return false;
 }
 
+constexpr bool isFloat16(ANARIDataType format)
+{
+  switch (format) {
+  case ANARI_FLOAT16_VEC4:
+  case ANARI_FLOAT16_VEC3:
+  case ANARI_FLOAT16_VEC2:
+  case ANARI_FLOAT16:
+    return true;
+  default:
+    break;
+  }
+  return false;
+}
+
 constexpr bool isFloat(ANARIDataType format)
 {
-  return isFloat32(format) || isFloat64(format);
+  return isFloat16(format) || isFloat32(format) || isFloat64(format);
 }
 
 constexpr bool isFixed32(ANARIDataType format)
@@ -171,9 +185,9 @@ constexpr int numANARIChannels(ANARIDataType format)
 
 constexpr int bytesPerChannel(ANARIDataType format)
 {
-  if (isFloat(format) || isFixed32(format))
+  if (isFloat32(format) || isFixed32(format))
     return 4;
-  else if (isFixed16(format))
+  else if (isFloat16(format) || isFixed16(format))
     return 2;
   else
     return 1;

--- a/devices/rtx/device/utility/CudaImageTexture.cpp
+++ b/devices/rtx/device/utility/CudaImageTexture.cpp
@@ -38,78 +38,6 @@
 
 namespace visrtx {
 
-// Private helper functions ///////////////////////////////////////////////////
-
-template <bool SRGB, typename T>
-static uint8_t convertComponentUint8(T c)
-{
-  if constexpr (std::is_same_v<T, float>)
-    return uint8_t(c * 255);
-  else if constexpr (std::is_same_v<T, uint16_t>) {
-    constexpr auto maxVal = float(std::numeric_limits<uint16_t>::max());
-    return uint8_t((c / maxVal) * 255);
-  } else if constexpr (std::is_same_v<T, uint32_t>) {
-    constexpr auto maxVal = float(std::numeric_limits<uint32_t>::max());
-    return uint8_t((c / maxVal) * 255);
-  } else if constexpr (SRGB) // uint8_t
-    return uint8_t(glm::convertSRGBToLinear(vec1(c / 255.f)).x * 255);
-  else // uint8_t, linear
-    return c;
-}
-
-template <bool SRGB, typename T>
-static float convertComponentFloat(T c)
-{
-  if constexpr (std::is_same_v<T, float>)
-    return c;
-  else if constexpr (std::is_same_v<T, uint16_t>) {
-    constexpr auto maxVal = float(std::numeric_limits<uint16_t>::max());
-    return c / maxVal;
-  } else if constexpr (std::is_same_v<T, uint32_t>) {
-    constexpr auto maxVal = float(std::numeric_limits<uint32_t>::max());
-    return c / maxVal;
-  } else if constexpr (SRGB) // uint8_t
-    return glm::convertSRGBToLinear(vec1(float(c) / 255.f)).x;
-  else // uint8_t, linear
-    return c / 255.f;
-}
-
-template <int IN_NC /*num components*/,
-    typename IN_COMP_T /*component type*/,
-    bool SRGB = false>
-static void transformToStagingBufferUint8(
-    const Array &image, uint8_t *stagingBuffer)
-{
-  auto *begin = (const IN_COMP_T *)image.data();
-  auto *end = begin + (image.totalSize() * IN_NC);
-  size_t out = 0;
-  std::for_each(begin, end, [&](const IN_COMP_T &c) {
-    stagingBuffer[out++] = convertComponentUint8<SRGB>(c);
-    if constexpr (IN_NC == 3) {
-      if (out % 4 == 3)
-        stagingBuffer[out++] = 255;
-    }
-  });
-}
-
-template <int IN_NC /*num components*/,
-    typename IN_COMP_T /*component type*/,
-    bool SRGB = false>
-static void transformToStagingBufferFloat(
-    const Array &image, float *stagingBuffer)
-{
-  auto *begin = (const IN_COMP_T *)image.data();
-  auto *end = begin + (image.totalSize() * IN_NC);
-  size_t out = 0;
-  std::for_each(begin, end, [&](const IN_COMP_T &c) {
-    stagingBuffer[out++] = convertComponentFloat<SRGB>(c);
-    if constexpr (IN_NC == 3) {
-      if (out % 4 == 3)
-        stagingBuffer[out++] = 1.f;
-    }
-  });
-}
-
 // Function definitions ///////////////////////////////////////////////////////
 
 int countCudaChannels(const cudaChannelFormatDesc &desc)
@@ -138,33 +66,6 @@ cudaTextureAddressMode stringToAddressMode(const std::string &str)
     return cudaAddressModeClamp;
 }
 
-void makeCudaArrayUint8(
-    cudaArray_t &cuArray, int nc, const uint8_t *data, uvec3 size)
-{
-  if (!cuArray) {
-    auto desc = cudaCreateChannelDesc(nc >= 1 ? 8 : 0,
-        nc >= 2 ? 8 : 0,
-        nc >= 3 ? 8 : 0,
-        nc >= 4 ? 8 : 0,
-        cudaChannelFormatKindUnsigned);
-
-    cudaMalloc3DArray(&cuArray,
-        &desc,
-        make_cudaExtent(size.x, size.y, size.z <= 1 ? 0 : size.z));
-  }
-
-  cudaMemcpy3DParms p = {};
-  p.dstArray = cuArray;
-  p.srcPtr = make_cudaPitchedPtr(const_cast<uint8_t *>(data),
-      size.x * nc * sizeof(uint8_t),
-      size.x,
-      size.y);
-  p.srcPos = p.dstPos = make_cudaPos(0, 0, 0);
-  p.extent = make_cudaExtent(size.x, size.y, size.z);
-  p.kind = cudaMemcpyHostToDevice;
-  cudaMemcpy3D(&p);
-}
-
 void makeCudaArrayFloat(
     cudaArray_t &cuArray, int nc, const float *data, uvec3 size)
 {
@@ -191,154 +92,107 @@ void makeCudaArrayFloat(
   cudaMemcpy3D(&p);
 }
 
-void makeCudaArrayUint8(cudaArray_t &cuArray, const Array &array, uint32_t size)
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uint32_t size)
 {
-  makeCudaArrayUint8(cuArray, array, uvec3(size, 1, 1));
+  makeCudaArray(cuArray, array, uvec3(size, 1, 1));
 }
 
-void makeCudaArrayUint8(cudaArray_t &cuArray, const Array &array, uvec2 size)
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uvec2 size)
 {
-  makeCudaArrayUint8(cuArray, array, uvec3(size, 1));
+  makeCudaArray(cuArray, array, uvec3(size, 1));
 }
 
-void makeCudaArrayUint8(cudaArray_t &cuArray, const Array &array, uvec3 size)
+namespace {
+
+// IEEE-754 half-precision encoding of 1.0 (FLOAT16 is stored as raw uint16_t).
+constexpr uint16_t kHalfOne = 0x3C00;
+
+// Expand a 3-channel image to 4 channels (CUDA has no 3-channel cudaArray),
+// padding the added alpha so it samples as opaque/1.0. This is the only data
+// transform applied to a texture; every other format is copied verbatim.
+template <typename T>
+static void expandRGBtoRGBA(const Array &array, void *dstRaw, T pad)
+{
+  const T *src = static_cast<const T *>(array.data());
+  T *dst = static_cast<T *>(dstRaw);
+  const size_t texels = array.totalSize();
+  for (size_t i = 0; i < texels; ++i) {
+    dst[4 * i + 0] = src[3 * i + 0];
+    dst[4 * i + 1] = src[3 * i + 1];
+    dst[4 * i + 2] = src[3 * i + 2];
+    dst[4 * i + 3] = pad;
+  }
+}
+
+// Build a cudaArray whose channel kind and bit depth mirror the ANARI element
+// type, then copy the data verbatim. 8/16/32-bit unsigned and 16/32-bit float
+// are kept in their native form; sRGB stays as raw 8-bit bytes (the sampler
+// does sRGB->linear). The sole transform is 3->4 channel expansion, which CUDA
+// forces. Integer arrays are read back with normalized read mode, so keeping
+// them at native depth (not promoted to float) is both correct and compact.
+static void buildNativeCudaArray(
+    cudaArray_t &cuArray, const Array &array, uvec3 size)
 {
   const ANARIDataType format = array.elementType();
-  auto nc = numANARIChannels(format);
+  const int nc = numANARIChannels(format);
+  const size_t compBytes = bytesPerChannel(format);
+  const int bits = int(compBytes) * 8;
+  const cudaChannelFormatKind kind = isFloat(format)
+      ? cudaChannelFormatKindFloat
+      : cudaChannelFormatKindUnsigned;
+  const int storedNc = (nc == 3) ? 4 : nc;
 
-  // Create CUDA texture //
-
-  std::vector<uint8_t> stagingBuffer(array.totalSize() * 4);
-
-  if (nc == 4) {
-    if (isFloat(format))
-      transformToStagingBufferUint8<4, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferUint8<4, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferUint8<4, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferUint8<4, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferUint8<4, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 3) {
-    if (isFloat(format))
-      transformToStagingBufferUint8<3, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferUint8<3, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferUint8<3, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferUint8<3, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferUint8<3, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 2) {
-    if (isFloat(format))
-      transformToStagingBufferUint8<2, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferUint8<2, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferUint8<2, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferUint8<2, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferUint8<2, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 1) {
-    if (isFloat(format))
-      transformToStagingBufferUint8<1, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferUint8<1, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferUint8<1, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferUint8<1, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferUint8<1, uint8_t, true>(
-          array, stagingBuffer.data());
+  if (!cuArray) {
+    auto desc = cudaCreateChannelDesc(storedNc >= 1 ? bits : 0,
+        storedNc >= 2 ? bits : 0,
+        storedNc >= 3 ? bits : 0,
+        storedNc >= 4 ? bits : 0,
+        kind);
+    cudaMalloc3DArray(&cuArray,
+        &desc,
+        make_cudaExtent(size.x, size.y, size.z <= 1 ? 0 : size.z));
   }
 
-  if (nc == 3)
-    nc = 4;
-
-  makeCudaArrayUint8(cuArray, nc, stagingBuffer.data(), size);
-}
-
-void makeCudaArrayFloat(cudaArray_t &cuArray, const Array &array, uint32_t size)
-{
-  makeCudaArrayFloat(cuArray, array, uvec3(size, 1, 1));
-}
-
-void makeCudaArrayFloat(cudaArray_t &cuArray, const Array &array, uvec2 size)
-{
-  makeCudaArrayFloat(cuArray, array, uvec3(size, 1));
-}
-
-void makeCudaArrayFloat(cudaArray_t &cuArray, const Array &array, uvec3 size)
-{
-  const ANARIDataType format = array.elementType();
-  auto nc = numANARIChannels(format);
-
-  // Create CUDA texture //
-
-  std::vector<float> stagingBuffer(array.totalSize() * 4);
-
-  if (nc == 4) {
-    if (isFloat(format))
-      transformToStagingBufferFloat<4, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferFloat<4, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferFloat<4, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferFloat<4, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferFloat<4, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 3) {
-    if (isFloat(format))
-      transformToStagingBufferFloat<3, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferFloat<3, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferFloat<3, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferFloat<3, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferFloat<3, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 2) {
-    if (isFloat(format))
-      transformToStagingBufferFloat<2, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferFloat<2, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferFloat<2, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferFloat<2, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferFloat<2, uint8_t, true>(
-          array, stagingBuffer.data());
-  } else if (nc == 1) {
-    if (isFloat(format))
-      transformToStagingBufferFloat<1, float>(array, stagingBuffer.data());
-    else if (isFixed32(format))
-      transformToStagingBufferFloat<1, uint32_t>(array, stagingBuffer.data());
-    else if (isFixed16(format))
-      transformToStagingBufferFloat<1, uint16_t>(array, stagingBuffer.data());
-    else if (isFixed8(format))
-      transformToStagingBufferFloat<1, uint8_t>(array, stagingBuffer.data());
-    else if (isSrgb8(format))
-      transformToStagingBufferFloat<1, uint8_t, true>(
-          array, stagingBuffer.data());
+  // Expand RGB->RGBA when needed; otherwise copy the host data straight in.
+  std::vector<uint8_t> staging;
+  const void *src = array.data();
+  size_t srcChannels = size_t(nc);
+  if (nc == 3) {
+    staging.resize(array.totalSize() * 4 * compBytes);
+    if (isFloat32(format))
+      expandRGBtoRGBA<float>(array, staging.data(), 1.0f);
+    else if (isFloat16(format))
+      expandRGBtoRGBA<uint16_t>(array, staging.data(), kHalfOne);
+    else if (compBytes == 4)
+      expandRGBtoRGBA<uint32_t>(
+          array, staging.data(), std::numeric_limits<uint32_t>::max());
+    else if (compBytes == 2)
+      expandRGBtoRGBA<uint16_t>(
+          array, staging.data(), std::numeric_limits<uint16_t>::max());
+    else
+      expandRGBtoRGBA<uint8_t>(
+          array, staging.data(), std::numeric_limits<uint8_t>::max());
+    src = staging.data();
+    srcChannels = 4;
   }
 
-  if (nc == 3)
-    nc = 4;
+  cudaMemcpy3DParms p = {};
+  p.dstArray = cuArray;
+  p.srcPos = p.dstPos = make_cudaPos(0, 0, 0);
+  p.srcPtr = make_cudaPitchedPtr(const_cast<void *>(src),
+      size.x * srcChannels * compBytes,
+      size.x,
+      size.y);
+  p.extent = make_cudaExtent(size.x, size.y, size.z < 1 ? 1 : size.z);
+  p.kind = cudaMemcpyHostToDevice;
+  cudaMemcpy3D(&p);
+}
 
-  makeCudaArrayFloat(cuArray, nc, stagingBuffer.data(), size);
+} // namespace
+
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uvec3 size)
+{
+  buildNativeCudaArray(cuArray, array, size);
 }
 
 cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
@@ -348,7 +202,8 @@ cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
     const std::string &wrap2,
     const std::string &wrap3,
     bool normalizedCoords,
-    const vec4 &borderColor)
+    const vec4 &borderColor,
+    bool sRGB)
 {
   cudaResourceDesc resDesc;
   memset(&resDesc, 0, sizeof(resDesc));
@@ -365,6 +220,10 @@ cudaTextureObject_t makeCudaTextureObject(cudaArray_t cuArray,
   texDesc.readMode = readModeNormalizedFloat ? cudaReadModeNormalizedFloat
                                              : cudaReadModeElementType;
   texDesc.normalizedCoords = normalizedCoords;
+  // Hardware sRGB->linear on sample for raw sRGB8 data (valid for 8-bit unorm).
+  // Lets the texture stay in its native sRGB bytes instead of being linearized
+  // into 8-bit on the CPU (which bands the dark end).
+  texDesc.sRGB = sRGB;
   texDesc.borderColor[0] = borderColor.x;
   texDesc.borderColor[1] = borderColor.y;
   texDesc.borderColor[2] = borderColor.z;
@@ -575,7 +434,8 @@ cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
     const std::string &filter,
     const std::string &wrap,
-    const vec4 &borderColor)
+    const vec4 &borderColor,
+    bool sRGB)
 {
   return makeCudaTextureObject(cuArray,
       readModeNormalizedFloat,
@@ -584,7 +444,8 @@ cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
       wrap,
       wrap,
       true,
-      borderColor);
+      borderColor,
+      sRGB);
 }
 
 cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
@@ -592,7 +453,8 @@ cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
     const std::string &filter,
     const std::string &wrap1,
     const std::string &wrap2,
-    const vec4 &borderColor)
+    const vec4 &borderColor,
+    bool sRGB)
 {
   return makeCudaTextureObject(cuArray,
       readModeNormalizedFloat,
@@ -601,7 +463,8 @@ cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
       wrap2,
       wrap2,
       true,
-      borderColor);
+      borderColor,
+      sRGB);
 }
 
 cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
@@ -610,7 +473,8 @@ cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap1,
     const std::string &wrap2,
     const std::string &wrap3,
-    const vec4 &borderColor)
+    const vec4 &borderColor,
+    bool sRGB)
 {
   return makeCudaTextureObject(cuArray,
       readModeNormalizedFloat,
@@ -619,7 +483,8 @@ cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
       wrap2,
       wrap3,
       true,
-      borderColor);
+      borderColor,
+      sRGB);
 }
 
 cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
@@ -635,7 +500,8 @@ cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
       wrap,
       wrap,
       false,
-      borderColor);
+      borderColor,
+      false);
 }
 
 cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
@@ -652,7 +518,8 @@ cudaTextureObject_t makeCudaTexelObject2D(cudaArray_t cuArray,
       wrap2,
       wrap2,
       false,
-      borderColor);
+      borderColor,
+      false);
 }
 
 cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
@@ -670,7 +537,8 @@ cudaTextureObject_t makeCudaTexelObject3D(cudaArray_t cuArray,
       wrap2,
       wrap3,
       false,
-      borderColor);
+      borderColor,
+      false);
 }
 
 cudaTextureObject_t makeCudaCompressedTextureObject1D(cudaArray_t cuArray,

--- a/devices/rtx/device/utility/CudaImageTexture.h
+++ b/devices/rtx/device/utility/CudaImageTexture.h
@@ -58,21 +58,15 @@ using byte_chunk_t = std::array<uint8_t, SIZE>;
 int countCudaChannels(const cudaChannelFormatDesc &desc);
 cudaTextureAddressMode stringToAddressMode(const std::string &str);
 
-void makeCudaArrayUint8(
-    cudaArray_t &cuArray, int nc, const uint8_t *data, uvec3 size);
 void makeCudaArrayFloat(
     cudaArray_t &cuArray, int nc, const float *data, uvec3 size);
 
-void makeCudaArrayUint8(
-    cudaArray_t &cuArray, const Array &array, uint32_t size);
-void makeCudaArrayFloat(
-    cudaArray_t &cuArray, const Array &array, uint32_t size);
-
-void makeCudaArrayUint8(cudaArray_t &cuArray, const Array &array, uvec2 size);
-void makeCudaArrayFloat(cudaArray_t &cuArray, const Array &array, uvec2 size);
-
-void makeCudaArrayUint8(cudaArray_t &cuArray, const Array &array, uvec3 size);
-void makeCudaArrayFloat(cudaArray_t &cuArray, const Array &array, uvec3 size);
+// Build a cudaArray that mirrors the ANARI element type natively (channel kind,
+// bit depth), copying the data verbatim; the only transform is 3->4 channel
+// expansion, which CUDA forces. sRGB stays raw (sampler does sRGB->linear).
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uint32_t size);
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uvec2 size);
+void makeCudaArray(cudaArray_t &cuArray, const Array &array, uvec3 size);
 
 void makeCudaCompressedTextureArray(cudaArray_t &cuArray,
     const uvec2 &size,
@@ -83,14 +77,16 @@ cudaTextureObject_t makeCudaTextureObject1D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
     const std::string &filter,
     const std::string &wrap = "clampToEdge",
-    const vec4 &borderColor = vec4(0.f));
+    const vec4 &borderColor = vec4(0.f),
+    bool sRGB = false);
 
 cudaTextureObject_t makeCudaTextureObject2D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
     const std::string &filter,
     const std::string &wrap1 = "clampToEdge",
     const std::string &wrap2 = "clampToEdge",
-    const vec4 &borderColor = vec4(0.f));
+    const vec4 &borderColor = vec4(0.f),
+    bool sRGB = false);
 
 cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,
@@ -98,7 +94,8 @@ cudaTextureObject_t makeCudaTextureObject3D(cudaArray_t cuArray,
     const std::string &wrap1 = "clampToEdge",
     const std::string &wrap2 = "clampToEdge",
     const std::string &wrap3 = "clampToEdge",
-    const vec4 &borderColor = vec4(0.f));
+    const vec4 &borderColor = vec4(0.f),
+    bool sRGB = false);
 
 cudaTextureObject_t makeCudaTexelObject1D(cudaArray_t cuArray,
     bool readModeNormalizedFloat,

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -39,6 +39,7 @@
 #include <mi/neuraylib/ivalue.h>
 #include <mi/neuraylib/iversion.h>
 
+#include <filesystem>
 #include <string>
 
 #ifdef MI_PLATFORM_WINDOWS
@@ -321,13 +322,82 @@ const mi::neuraylib::IModule *Core::loadModule(
 
   if (impexpApi->load_module(
           transaction, moduleName.c_str(), executionContext.get())
-      < 0)
-    return {};
+      < 0) {
+    // A scene may ship a .mdl without its resources (e.g. a vMaterials module
+    // copied without its ./textures), so the local copy fails to compile. A
+    // complete copy usually exists on the MDL search path -- recover it by
+    // canonical name before giving up.
+    return loadModuleByCanonicalName(moduleOrFileName, transaction);
+  }
 
   // Get the database name for the module we loaded
   auto moduleDbName = make_handle(
       m_mdlFactory->get_db_module_name(std::string(moduleName).c_str()));
   return transaction->access<mi::neuraylib::IModule>(moduleDbName->get_c_str());
+}
+
+const mi::neuraylib::IModule *Core::loadModuleByCanonicalName(
+    std::string_view filePath, mi::neuraylib::ITransaction *transaction)
+{
+  std::string path(filePath);
+  if (path.find('/') == std::string::npos)
+    return {}; // already a module name, nothing to recover
+
+  auto impexpApi = make_handle(
+      m_neuray->get_api_component<mi::neuraylib::IMdl_impexp_api>());
+  auto mdlConfiguration = make_handle(
+      m_neuray->get_api_component<mi::neuraylib::IMdl_configuration>());
+
+  // If the failing path passes through a directory whose basename matches a
+  // search root (e.g. ".../vMaterials_2/Concrete/Concrete_Precast.mdl" with a
+  // "/data/mdl/vMaterials_2" root), the canonical module name is the tail after
+  // it ("::Concrete::Concrete_Precast"). Loading that by name lets the entity
+  // resolver pick a complete copy on the search path.
+  auto pathsCount = mdlConfiguration->get_mdl_paths_length();
+  for (auto i = decltype(pathsCount)(0); i < pathsCount; ++i) {
+    auto rootName =
+        std::filesystem::path(
+            make_handle(mdlConfiguration->get_mdl_path(i))->get_c_str())
+            .filename()
+            .string();
+    if (rootName.empty())
+      continue;
+
+    auto marker = "/" + rootName + "/";
+    auto pos = path.rfind(marker);
+    if (pos == std::string::npos)
+      continue;
+
+    auto tail = path.substr(pos + marker.size());
+    if (auto n = tail.size(); n > 4 && tail.substr(n - 4) == ".mdl")
+      tail = tail.substr(0, n - 4);
+    if (tail.empty())
+      continue;
+
+    std::string moduleName = "::";
+    for (char c : tail)
+      moduleName += (c == '/') ? "::"s : std::string(1, c);
+
+    auto executionContext =
+        make_handle(m_mdlFactory->clone(m_executionContext.get()));
+    if (impexpApi->load_module(
+            transaction, moduleName.c_str(), executionContext.get())
+        < 0)
+      continue;
+
+    auto moduleDbName =
+        make_handle(m_mdlFactory->get_db_module_name(moduleName.c_str()));
+    if (auto *module = transaction->access<mi::neuraylib::IModule>(
+            moduleDbName->get_c_str())) {
+      logMessage(mi::base::MESSAGE_SEVERITY_INFO,
+          "Recovered '{}' from the MDL search path as '{}'",
+          path,
+          moduleName);
+      return module;
+    }
+  }
+
+  return {};
 }
 
 const mi::neuraylib::IFunction_definition *Core::getFunctionDefinition(

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -544,16 +544,21 @@ auto Core::setMdlResourceSearchPaths(nonstd::span<std::filesystem::path> paths)
   }
 }
 
-auto Core::resolveResource(
-    std::string_view resourceId, std::string_view ownerId) -> std::string
+auto Core::resolveResource(std::string_view resourceId,
+    std::string_view ownerName,
+    std::string_view ownerFilePath) -> std::string
 {
   auto mdlConfiguration = make_handle(
       m_neuray->get_api_component<mi::neuraylib::IMdl_configuration>());
   auto entityResolver = make_handle(mdlConfiguration->get_entity_resolver());
+  // Relative resource paths (e.g. "Textures/foo.png") resolve against the
+  // owner module. ownerName is the owner's absolute *name*, ownerFilePath its
+  // on-disk path; the latter lets resolution work without relying on the MDL
+  // search paths. They occupy distinct argument slots and must not be swapped.
   auto resolvedResource = make_handle(
       entityResolver->resolve_resource(std::string(resourceId).c_str(),
-          ownerId.empty() ? nullptr : std::string(ownerId).c_str(),
-          nullptr,
+          ownerFilePath.empty() ? nullptr : std::string(ownerFilePath).c_str(),
+          ownerName.empty() ? nullptr : std::string(ownerName).c_str(),
           0,
           0));
 

--- a/devices/rtx/libmdl/Core.h
+++ b/devices/rtx/libmdl/Core.h
@@ -117,8 +117,9 @@ class Core
       const mi::neuraylib::ICompiled_material *compiledMaterial,
       mi::neuraylib::ITransaction *transaction);
 
-  std::string resolveResource(
-      std::string_view resourceId, std::string_view ownerId = {});
+  std::string resolveResource(std::string_view resourceId,
+      std::string_view ownerName = {},
+      std::string_view ownerFilePath = {});
   std::string resolveModule(std::string_view moduleId);
 
  private:

--- a/devices/rtx/libmdl/Core.h
+++ b/devices/rtx/libmdl/Core.h
@@ -102,6 +102,15 @@ class Core
   const mi::neuraylib::IModule *loadModule(std::string_view moduleOrFileName,
       mi::neuraylib::ITransaction *transaction);
 
+  // Fallback for a path-based load that failed (e.g. a scene shipped a .mdl
+  // without its ./textures). If the path passes through a directory whose
+  // basename matches an MDL search root, derive the canonical module name from
+  // the tail and load it by name so the entity resolver finds a complete copy
+  // on the search path with resources co-located. Returns null if nothing
+  // matches or the named module still fails.
+  const mi::neuraylib::IModule *loadModuleByCanonicalName(
+      std::string_view filePath, mi::neuraylib::ITransaction *transaction);
+
   const mi::neuraylib::IFunction_definition *getFunctionDefinition(
       const mi::neuraylib::IModule *module,
       std::string_view functionName,


### PR DESCRIPTION
Misc MDL related fixes.

Noteworthy change: textures are not pre-converting their content anymore. Typed access happens on the device through
the usual texture access functions.