### PR TITLE
rtx: mdl source types

### DIFF
--- a/devices/rtx/device/material/MDL.cpp
+++ b/devices/rtx/device/material/MDL.cpp
@@ -36,6 +36,7 @@
 #include "libmdl/ArgumentBlockDescriptor.h"
 #include "libmdl/ArgumentBlockInstance.h"
 #include "libmdl/helpers.h"
+#include "libmdl/source_name_utils.h"
 #include "material/Material.h"
 #include "mdl/MaterialRegistry.h"
 #include "optix_visrtx.h"
@@ -120,39 +121,79 @@ void MDL::syncSource()
 {
   auto sourceType = getParamString("sourceType", "module");
   auto source = getParamString("source", "::visrtx::default::diffuseWhite");
+  std::optional<std::string> materialName;
+  if (hasParam("materialName"))
+    materialName = getParamString("materialName", "main");
+
+  // A change to any selection input triggers a full material reload.
+  if (source == m_source && sourceType == m_sourceType
+      && materialName == m_materialName)
+    return;
 
   auto &materialRegistry = deviceState()->mdl->materialRegistry;
   auto &samplerRegistry = deviceState()->mdl->samplerRegistry;
 
-  // A source change implies a full material change; nothing to do otherwise.
-  if (source == m_source && sourceType == m_sourceType)
-    return;
-
   auto uuid = libmdl::Uuid{};
   auto argumentBlockDescriptor = libmdl::ArgumentBlockDescriptor{};
 
-  if (sourceType == "module") {
-    auto &&[moduleName, materialName] =
-        libmdl::parseMaterialSourceName(source, &deviceState()->mdl->core);
-    if (moduleName.empty() || materialName.empty()) {
+  const bool isMdle = libmdl::endsWith(source, ".mdle");
+
+  if (sourceType == "code") {
+    if (!hasParam("source")) {
+      reportMessage(ANARI_SEVERITY_ERROR,
+          "MDL::syncSource(): sourceType 'code' requires a 'source' parameter");
+    } else {
+      std::tie(uuid, argumentBlockDescriptor) =
+          materialRegistry.acquireMaterialFromCode(
+              source, materialName.value_or("main"));
+      if (uuid == libmdl::Uuid{})
+        reportMessage(ANARI_SEVERITY_ERROR,
+            "MDL::syncSource(): failed to compile inline 'code' material");
+    }
+  } else if (sourceType == "mdle" || isMdle) {
+    // .mdle sources funnel here regardless of sourceType, so there is one
+    // validation path and one diagnostic for MDLE.
+    if (!isMdle) {
+      reportMessage(ANARI_SEVERITY_ERROR,
+          "MDL::syncSource(): sourceType 'mdle' requires a '.mdle' source, got '%s'",
+          source.c_str());
+    } else if (materialName && *materialName != "main") {
+      reportMessage(ANARI_SEVERITY_ERROR,
+          "MDL::syncSource(): MDLE modules only expose 'main', got materialName '%s'",
+          materialName->c_str());
+    } else {
+      std::tie(uuid, argumentBlockDescriptor) =
+          materialRegistry.acquireMaterial(source, "main");
+      if (uuid == libmdl::Uuid{})
+        reportMessage(ANARI_SEVERITY_ERROR,
+            "MDL::syncSource(): failed to acquire MDLE material '%s'",
+            source.c_str());
+    }
+  } else if (sourceType == "module") {
+    std::string moduleName;
+    std::string material;
+    if (materialName) {
+      moduleName = libmdl::normalizeModuleName(source);
+      material = *materialName;
+    } else {
+      std::tie(moduleName, material) =
+          libmdl::parseMaterialSourceName(source, &deviceState()->mdl->core);
+    }
+    if (moduleName.empty() || material.empty()) {
       reportMessage(ANARI_SEVERITY_ERROR,
           "MDL::syncSource(): could not parse material source name '%s'",
           source.c_str());
     } else {
       std::tie(uuid, argumentBlockDescriptor) =
-          materialRegistry.acquireMaterial(moduleName, materialName);
-      if (uuid == libmdl::Uuid{}) {
+          materialRegistry.acquireMaterial(moduleName, material);
+      if (uuid == libmdl::Uuid{})
         reportMessage(ANARI_SEVERITY_ERROR,
             "MDL::syncSource(): failed to acquire material '%s'",
             source.c_str());
-      }
     }
-  } else if (sourceType == "code") {
-    reportMessage(ANARI_SEVERITY_ERROR,
-        "MDL::syncSource(): sourceType 'code' is not supported yet");
   } else {
     reportMessage(ANARI_SEVERITY_ERROR,
-        "MDL::syncSource(): sourceType must be either 'module' or 'code', got '%s'",
+        "MDL::syncSource(): sourceType must be 'module', 'mdle' or 'code', got '%s'",
         sourceType.c_str());
   }
 
@@ -165,8 +206,14 @@ void MDL::syncSource()
         materialRegistry.acquireMaterial("::visrtx::default", "diffuseWhite");
   }
 
+  // Record the requested values on every path: an identical re-commit is then a
+  // cheap no-op, while changing any input re-triggers a load.
+  m_source = source;
+  m_sourceType = sourceType;
+  m_materialName = materialName;
+
   if (uuid == libmdl::Uuid{}) {
-    // Even the fallback failed; keep the previous (possibly empty) state.
+    // Even the fallback failed; keep the previous argument block (if any).
     reportMessage(ANARI_SEVERITY_ERROR,
         "MDL::syncSource(): failed to acquire fallback material");
     return;
@@ -199,9 +246,6 @@ void MDL::syncSource()
     }
     m_samplers[textureDesc.knownIndex] = {sampler, textureDesc.url, true};
   }
-
-  m_source = source;
-  m_sourceType = sourceType;
 }
 
 void MDL::syncParameters()
@@ -210,8 +254,9 @@ void MDL::syncParameters()
     auto &argumentBlockInstance = *m_argumentBlockInstance;
     for (auto param = params_begin(); param != params_end(); ++param) {
       const auto &name = param->first;
-      if (name == "source"sv || name == "sourceType"sv) {
-        // Skip these two parameters, they are not part of the argument block
+      if (name == "source"sv || name == "sourceType"sv
+          || name == "materialName"sv) {
+        // Skip these control parameters, they are not part of the argument block
         continue;
       }
 

--- a/devices/rtx/device/material/MDL.cpp
+++ b/devices/rtx/device/material/MDL.cpp
@@ -102,8 +102,13 @@ void MDL::finalize()
   syncImplementationIndex();
   syncParameters();
 
-  if (const auto &argBlockData = m_argumentBlockInstance->getArgumentBlockData(); !argBlockData.empty()) {
+  if (m_argumentBlockInstance.has_value()) {
+    if (const auto &argBlockData = m_argumentBlockInstance->getArgumentBlockData();
+        !argBlockData.empty()) {
       m_argBlockBuffer.upload(data(argBlockData), size(argBlockData));
+    } else {
+      m_argBlockBuffer.reset();
+    }
   } else {
     m_argBlockBuffer.reset();
   }
@@ -115,71 +120,88 @@ void MDL::syncSource()
 {
   auto sourceType = getParamString("sourceType", "module");
   auto source = getParamString("source", "::visrtx::default::diffuseWhite");
-  auto uuid = libmdl::Uuid{};
-  auto argumentBlockDescriptor = libmdl::ArgumentBlockDescriptor{};
 
   auto &materialRegistry = deviceState()->mdl->materialRegistry;
   auto &samplerRegistry = deviceState()->mdl->samplerRegistry;
 
-  // Handle source changes separately as it probably implies a full material
-  // change.
-  if (source != m_source || sourceType != m_sourceType) {
-    if (sourceType == "module") {
-      auto &&[moduleName, materialName] =
-          libmdl::parseMaterialSourceName(source, &deviceState()->mdl->core);
-      if (!moduleName.empty() && !materialName.empty()) {
-        std::tie(uuid, argumentBlockDescriptor) = materialRegistry.acquireMaterial(moduleName, materialName);
-        if (uuid == libmdl::Uuid{}) {
-          reportMessage(ANARI_SEVERITY_ERROR,
-              "Failed to acquire material %s, falling back to %s",
-              source.c_str(),
-              "diffuseWhite");
-          std::tie(uuid, argumentBlockDescriptor) =
-            materialRegistry.acquireMaterial(
-                "::visrtx::default", "diffuseWhite");
-        }
-      }
-    } else if (sourceType == "code") {
+  // A source change implies a full material change; nothing to do otherwise.
+  if (source == m_source && sourceType == m_sourceType)
+    return;
+
+  auto uuid = libmdl::Uuid{};
+  auto argumentBlockDescriptor = libmdl::ArgumentBlockDescriptor{};
+
+  if (sourceType == "module") {
+    auto &&[moduleName, materialName] =
+        libmdl::parseMaterialSourceName(source, &deviceState()->mdl->core);
+    if (moduleName.empty() || materialName.empty()) {
       reportMessage(ANARI_SEVERITY_ERROR,
-          "MDL::commitParameters(): sourceType 'code' not supported yet");
+          "MDL::syncSource(): could not parse material source name '%s'",
+          source.c_str());
     } else {
-      reportMessage(ANARI_SEVERITY_ERROR,
-          "MDL::commitParameters(): sourceType must be either 'module' or 'code'");
-    }
-
-    if (uuid != libmdl::Uuid{}) {
-      // We have successfully loaded a material, release the previous one and
-      // use it instead.
-      if (m_uuid != libmdl::Uuid{}) {
-        materialRegistry.releaseMaterial(m_uuid);
-      }
-      m_argumentBlockInstance =
-          materialRegistry.createArgumentBlock(argumentBlockDescriptor);
-      m_uuid = uuid;
-
-      clearSamplers();
-
-      for (auto textureDesc :
-          argumentBlockDescriptor.m_defaultAndBodyTextureDescriptors) {
-        auto sampler = samplerRegistry.acquireSampler(textureDesc);
-        if (!sampler) {
-          reportMessage(ANARI_SEVERITY_WARNING,
-              "Failed to acquire default texture '%s' for material %s",
-              textureDesc.url.c_str(),
-              source.c_str());
-          continue;
-        }
-        auto index = textureDesc.knownIndex;
-        if (m_samplers.size() <= index) {
-          m_samplers.resize(index + 1);
-        }
-        m_samplers[textureDesc.knownIndex] = {sampler, textureDesc.url, true};
+      std::tie(uuid, argumentBlockDescriptor) =
+          materialRegistry.acquireMaterial(moduleName, materialName);
+      if (uuid == libmdl::Uuid{}) {
+        reportMessage(ANARI_SEVERITY_ERROR,
+            "MDL::syncSource(): failed to acquire material '%s'",
+            source.c_str());
       }
     }
-
-    m_source = source;
-    m_sourceType = sourceType;
+  } else if (sourceType == "code") {
+    reportMessage(ANARI_SEVERITY_ERROR,
+        "MDL::syncSource(): sourceType 'code' is not supported yet");
+  } else {
+    reportMessage(ANARI_SEVERITY_ERROR,
+        "MDL::syncSource(): sourceType must be either 'module' or 'code', got '%s'",
+        sourceType.c_str());
   }
+
+  // Any failure path falls back to the default material so a committed MDL
+  // material always ends up with a valid argument block.
+  if (uuid == libmdl::Uuid{}) {
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "MDL::syncSource(): falling back to ::visrtx::default::diffuseWhite");
+    std::tie(uuid, argumentBlockDescriptor) =
+        materialRegistry.acquireMaterial("::visrtx::default", "diffuseWhite");
+  }
+
+  if (uuid == libmdl::Uuid{}) {
+    // Even the fallback failed; keep the previous (possibly empty) state.
+    reportMessage(ANARI_SEVERITY_ERROR,
+        "MDL::syncSource(): failed to acquire fallback material");
+    return;
+  }
+
+  // We have successfully loaded a material, release the previous one and
+  // use it instead.
+  if (m_uuid != libmdl::Uuid{}) {
+    materialRegistry.releaseMaterial(m_uuid);
+  }
+  m_argumentBlockInstance =
+      materialRegistry.createArgumentBlock(argumentBlockDescriptor);
+  m_uuid = uuid;
+
+  clearSamplers();
+
+  for (auto textureDesc :
+      argumentBlockDescriptor.m_defaultAndBodyTextureDescriptors) {
+    auto sampler = samplerRegistry.acquireSampler(textureDesc);
+    if (!sampler) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+          "Failed to acquire default texture '%s' for material %s",
+          textureDesc.url.c_str(),
+          source.c_str());
+      continue;
+    }
+    auto index = textureDesc.knownIndex;
+    if (m_samplers.size() <= index) {
+      m_samplers.resize(index + 1);
+    }
+    m_samplers[textureDesc.knownIndex] = {sampler, textureDesc.url, true};
+  }
+
+  m_source = source;
+  m_sourceType = sourceType;
 }
 
 void MDL::syncParameters()

--- a/devices/rtx/device/material/MDL.h
+++ b/devices/rtx/device/material/MDL.h
@@ -70,6 +70,7 @@ struct MDL : public Material
 
   std::string m_source;
   std::string m_sourceType;
+  std::optional<std::string> m_materialName;
   struct SamplerDesc {
     Sampler* sampler = nullptr;
     std::string name;

--- a/devices/rtx/device/mdl/MaterialRegistry.cpp
+++ b/devices/rtx/device/mdl/MaterialRegistry.cpp
@@ -37,6 +37,7 @@
 #include "libmdl/ArgumentBlockInstance.h"
 #include "libmdl/TimeStamp.h"
 #include "libmdl/ptx.h"
+#include "libmdl/source_name_utils.h"
 #include "material/PhysicallyBasedMDL.h"
 
 #include <mi/base/enums.h>
@@ -88,57 +89,47 @@ MaterialRegistry::~MaterialRegistry()
   m_core->removeScope(m_scope.get());
 }
 
-std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor>
-MaterialRegistry::acquireMaterial(
-    std::string_view moduleName, std::string_view materialName)
+std::optional<MaterialRegistry::AcquiredMaterial>
+MaterialRegistry::reuseCompiledMaterial(const std::string &fullMaterialName)
+{
+  auto uuidIt = m_materialNameToUuid.find(fullMaterialName);
+  if (uuidIt == cend(m_materialNameToUuid))
+    return std::nullopt;
+
+  auto indexIt = m_uuidToIndex.find(std::get<0>(uuidIt->second));
+  if (indexIt == cend(m_uuidToIndex))
+    return std::nullopt;
+
+  m_core->logMessage(mi::base::MESSAGE_SEVERITY_DEBUG,
+      "Reusing compiled material {}",
+      fullMaterialName);
+  m_targetCodes[indexIt->second].refCount++;
+  return uuidIt->second;
+}
+
+std::optional<MaterialRegistry::AcquiredMaterial>
+MaterialRegistry::compileAndCacheMaterial(const std::string &fullMaterialName,
+    std::string_view moduleName,
+    std::string_view materialName,
+    const mi::neuraylib::IModule *module,
+    mi::neuraylib::ITransaction *transaction)
 {
   using mi::base::make_handle;
 
-  // First check if the material has already been compiled.
-  auto fullMaterialName = fmt::format("{}::{}", moduleName, materialName);
-  m_core->logMessage(mi::base::MESSAGE_SEVERITY_INFO,
-      "Acquiring material {}",
-      fullMaterialName);
-
-  if (auto uuidIt = m_materialNameToUuid.find(fullMaterialName);
-      uuidIt != cend(m_materialNameToUuid)) {
-    if (auto indexIt = m_uuidToIndex.find(std::get<0>(uuidIt->second));
-        indexIt != cend(m_uuidToIndex)) {
-      m_core->logMessage(mi::base::MESSAGE_SEVERITY_DEBUG,
-          "Reusing compiled material {}",
-          fullMaterialName);
-      m_targetCodes[indexIt->second].refCount++;
-      return uuidIt->second;
-    }
-  }
-
-  // If not, try and get a compiled version of it.
-  auto transaction = make_handle(m_core->createTransaction(m_scope.get()));
-  bool doCommit = false;
-  auto finalizeTransaction =
-      nonstd::make_scope_exit([transaction, &doCommit]() {
-        if (doCommit) {
-          transaction->commit();
-        } else {
-          transaction->abort();
-        }
-      });
-
-  auto module = make_handle(m_core->loadModule(moduleName, transaction.get()));
-  if (!module.is_valid_interface()) {
+  if (!module) {
     m_core->logMessage(
         mi::base::MESSAGE_SEVERITY_ERROR, "Cannot find module {}", moduleName);
-    return {};
+    return std::nullopt;
   }
 
   auto functionDef = make_handle(m_core->getFunctionDefinition(
-      module.get(), materialName, transaction.get()));
+      module, materialName, transaction));
   if (!functionDef.is_valid_interface()) {
     m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Cannot find function {} definition in module {}",
         materialName,
         moduleName);
-    return {};
+    return std::nullopt;
   }
 
   auto compiledMaterial =
@@ -148,20 +139,20 @@ MaterialRegistry::acquireMaterial(
         "Failed compiling material {} for module {}",
         materialName,
         moduleName);
-    return {};
+    return std::nullopt;
   }
 
   // Get the compiled material hash and its target code. Get the default and
   // body resources state from that.
   auto uuid = compiledMaterial->get_hash();
   auto targetCode = make_handle(
-      m_core->getPtxTargetCode(compiledMaterial.get(), transaction.get()));
+      m_core->getPtxTargetCode(compiledMaterial.get(), transaction));
   std::vector<libmdl::TextureDescriptor> textureDescs;
   if (!targetCode.is_valid_interface()) {
     m_core->logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Failed generating PTX target code for material {}",
         fullMaterialName);
-    return {};
+    return std::nullopt;
   }
 
   for (auto i = 1ul; i < targetCode->get_texture_count(); ++i) {
@@ -266,7 +257,7 @@ MaterialRegistry::acquireMaterial(
   // already have it.
   if (auto it = m_uuidToIndex.find(uuid); it != std::cend(m_uuidToIndex)) {
     ++m_targetCodes[it->second].refCount;
-    return {uuid, argBlockDesc};
+    return AcquiredMaterial{uuid, argBlockDesc};
   }
 
   // First time we hit this. Build a complete PTX shader from the generated
@@ -300,7 +291,6 @@ MaterialRegistry::acquireMaterial(
 
   m_lastUpdateTS = libmdl::newTimeStamp();
 
-  // Make sure we commit the transaction.
   m_core->logMessage(mi::base::MESSAGE_SEVERITY_DEBUG,
       "Acquired material {} with uuid {:04x}-{:04x}-{:04x}-{:04x}",
       fullMaterialName,
@@ -308,8 +298,68 @@ MaterialRegistry::acquireMaterial(
       uuid.m_id2,
       uuid.m_id3,
       uuid.m_id4);
-  doCommit = true;
-  return {uuid, argBlockDesc};
+  return AcquiredMaterial{uuid, argBlockDesc};
+}
+
+std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor>
+MaterialRegistry::acquireMaterial(
+    std::string_view moduleName, std::string_view materialName)
+{
+  using mi::base::make_handle;
+
+  auto fullMaterialName = fmt::format("{}::{}", moduleName, materialName);
+  m_core->logMessage(mi::base::MESSAGE_SEVERITY_INFO,
+      "Acquiring material {}",
+      fullMaterialName);
+  if (auto cached = reuseCompiledMaterial(fullMaterialName))
+    return *cached;
+
+  auto transaction = make_handle(m_core->createTransaction(m_scope.get()));
+  bool doCommit = false;
+  auto finalizeTransaction = nonstd::make_scope_exit([&] {
+    if (doCommit)
+      transaction->commit();
+    else
+      transaction->abort();
+  });
+
+  auto module =
+      make_handle(m_core->loadModule(moduleName, transaction.get()));
+  auto material = compileAndCacheMaterial(
+      fullMaterialName, moduleName, materialName, module.get(), transaction.get());
+  doCommit = material.has_value();
+  return material.value_or(AcquiredMaterial{});
+}
+
+std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor>
+MaterialRegistry::acquireMaterialFromCode(
+    std::string_view source, std::string_view materialName)
+{
+  using mi::base::make_handle;
+
+  auto moduleName = libmdl::makeInlineModuleName(source);
+  auto fullMaterialName = fmt::format("{}::{}", moduleName, materialName);
+  m_core->logMessage(mi::base::MESSAGE_SEVERITY_INFO,
+      "Acquiring material {}",
+      fullMaterialName);
+  if (auto cached = reuseCompiledMaterial(fullMaterialName))
+    return *cached;
+
+  auto transaction = make_handle(m_core->createTransaction(m_scope.get()));
+  bool doCommit = false;
+  auto finalizeTransaction = nonstd::make_scope_exit([&] {
+    if (doCommit)
+      transaction->commit();
+    else
+      transaction->abort();
+  });
+
+  auto module = make_handle(
+      m_core->loadModuleFromString(moduleName, source, transaction.get()));
+  auto material = compileAndCacheMaterial(
+      fullMaterialName, moduleName, materialName, module.get(), transaction.get());
+  doCommit = material.has_value();
+  return material.value_or(AcquiredMaterial{});
 }
 
 std::optional<libmdl::ArgumentBlockInstance>

--- a/devices/rtx/device/mdl/MaterialRegistry.h
+++ b/devices/rtx/device/mdl/MaterialRegistry.h
@@ -72,6 +72,12 @@ class MaterialRegistry
   // Material code
   std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor> acquireMaterial(
       std::string_view moduleName, std::string_view materialName);
+  // Compile a material from inline MDL module source. The module is registered
+  // under a synthetic, content-addressed name and shares the same compile/cache
+  // path as acquireMaterial.
+  std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor>
+  acquireMaterialFromCode(
+      std::string_view source, std::string_view materialName);
   void releaseMaterial(const Uuid &uuid);
 
   // For SBT management
@@ -107,6 +113,23 @@ class MaterialRegistry
       const libmdl::ArgumentBlockDescriptor &uuid) const;
 
  private:
+  using AcquiredMaterial =
+      std::tuple<libmdl::Uuid, libmdl::ArgumentBlockDescriptor>;
+
+  // Return a previously compiled material, bumping its refcount. Empty on a
+  // cache miss. No transaction needed -- the lookup is keyed on the name.
+  std::optional<AcquiredMaterial> reuseCompiledMaterial(
+      const std::string &fullMaterialName);
+
+  // Compile `module` (already loaded in `transaction`), cache it under
+  // `fullMaterialName`, and return it. Empty on failure.
+  std::optional<AcquiredMaterial> compileAndCacheMaterial(
+      const std::string &fullMaterialName,
+      std::string_view moduleName,
+      std::string_view materialName,
+      const mi::neuraylib::IModule *module,
+      mi::neuraylib::ITransaction *transaction);
+
   libmdl::Core *m_core;
   mi::base::Handle<mi::neuraylib::IScope> m_scope;
 

--- a/devices/rtx/device/visrtx_material_mdl.json
+++ b/devices/rtx/device/visrtx_material_mdl.json
@@ -15,13 +15,22 @@
                     "name": "sourceType",
                     "types": ["ANARI_STRING"],
                     "tags": [],
-                    "description": "The type of the source parameter. Might be `module`, `mdle`, or `code`"
+                    "default": "module",
+                    "values": ["module", "mdle", "code"],
+                    "description": "How `source` is interpreted: `module` (a fully-qualified MDL material name, or a `.mdle` path), `mdle` (a path to a `.mdle` file), or `code` (inline MDL module source)"
                 },
                 {
                     "name": "source",
                     "types": ["ANARI_STRING"],
                     "tags": [],
-                    "description": "The source of the MDL content. Depends on how the `sourceType` field is set"
+                    "default": "::visrtx::default::diffuseWhite",
+                    "description": "The MDL content, interpreted per `sourceType`: a module/material name, a `.mdle` path, or inline MDL module source"
+                },
+                {
+                    "name": "materialName",
+                    "types": ["ANARI_STRING"],
+                    "tags": [],
+                    "description": "Optional. Selects the material within `source`. For `module`, when set, `source` is treated as a pure module name (no `::material` split); for `mdle` it must be `main`; for `code` it defaults to `main`"
                 }
             ]
         }

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -232,37 +232,64 @@ mi::neuraylib::ITransaction *Core::createTransaction(
   return scope->create_transaction();
 }
 
-void Core::addBuiltinModule(
-    std::string_view moduleName, std::string_view moduleSource)
+mi::Sint32 Core::loadModuleSource(std::string_view moduleName,
+    std::string_view moduleSource,
+    mi::neuraylib::ITransaction *transaction)
 {
   auto impexpApi = make_handle(
       m_neuray->get_api_component<mi::neuraylib::IMdl_impexp_api>());
-
   auto executionContext =
       make_handle(m_mdlFactory->clone(m_executionContext.get()));
 
-  auto transaction = make_handle(createTransaction());
-  nonstd::scope_exit finalizeTransaction(
-      [transaction]() { transaction->commit(); });
-
-  auto result = impexpApi->load_module_from_string(transaction.get(),
+  auto result = impexpApi->load_module_from_string(transaction,
       std::string(moduleName).c_str(),
       std::string(moduleSource).c_str(),
       executionContext.get());
 
+  if (result < 0)
+    logExecutionContextMessages(executionContext.get());
+
+  return result;
+}
+
+const mi::neuraylib::IModule *Core::loadModuleFromString(
+    std::string_view moduleName,
+    std::string_view moduleSource,
+    mi::neuraylib::ITransaction *transaction)
+{
+  if (loadModuleSource(moduleName, moduleSource, transaction) < 0)
+    return nullptr;
+  return accessModule(moduleName, transaction);
+}
+
+const mi::neuraylib::IModule *Core::accessModule(
+    std::string_view moduleName, mi::neuraylib::ITransaction *transaction)
+{
+  auto dbName = make_handle(
+      m_mdlFactory->get_db_module_name(std::string(moduleName).c_str()));
+  return transaction->access<mi::neuraylib::IModule>(dbName->get_c_str());
+}
+
+void Core::addBuiltinModule(
+    std::string_view moduleName, std::string_view moduleSource)
+{
+  auto transaction = make_handle(createTransaction());
+  nonstd::scope_exit finalizeTransaction(
+      [transaction]() { transaction->commit(); });
+
+  auto result = loadModuleSource(moduleName, moduleSource, transaction.get());
+
   switch (result) {
-  case 0: {
+  case 0:
     logMessage(mi::base::MESSAGE_SEVERITY_INFO,
         "Added builtin module {} from source",
         moduleName);
     break;
-  }
-  case 1: {
+  case 1:
     logMessage(mi::base::MESSAGE_SEVERITY_INFO,
         "Builtin module {} already exists",
         moduleName);
     break;
-  }
   case -1:
     logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Invalid name {} or module source for builtin",
@@ -277,7 +304,6 @@ void Core::addBuiltinModule(
     logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
         "Unknown error while adding builtin module {}",
         moduleName);
-    logExecutionContextMessages(executionContext.get());
     break;
   }
 }

--- a/devices/rtx/libmdl/Core.h
+++ b/devices/rtx/libmdl/Core.h
@@ -58,6 +58,16 @@ class Core
   void addBuiltinModule(
       std::string_view moduleName, std::string_view moduleSource);
 
+  // Load an MDL module from in-memory source into `transaction` and return it.
+  // Returns null on failure (diagnostics are logged). Mirrors loadModule.
+  const mi::neuraylib::IModule *loadModuleFromString(std::string_view moduleName,
+      std::string_view moduleSource,
+      mi::neuraylib::ITransaction *transaction);
+
+  // Access an already-loaded module by its MDL name within `transaction`.
+  const mi::neuraylib::IModule *accessModule(
+      std::string_view moduleName, mi::neuraylib::ITransaction *transaction);
+
   // The main neuray interface can only be acquired once. Make sure it can be
   // shared if taken from there. The original subsystem keeps the ownership of
   // the returned value.
@@ -133,6 +143,12 @@ class Core
 
  private:
   Core(mi::neuraylib::INeuray *neuray, mi::base::ILogger *logger);
+
+  // Raw load_module_from_string wrapper. Returns the MDL result code:
+  // 0 = loaded, 1 = already present (both success), < 0 = failure (logged).
+  mi::Sint32 loadModuleSource(std::string_view moduleName,
+      std::string_view moduleSource,
+      mi::neuraylib::ITransaction *transaction);
 
   using DllHandle = void *;
   DllHandle m_dllHandle;

--- a/devices/rtx/libmdl/helpers.cpp
+++ b/devices/rtx/libmdl/helpers.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "Core.h"
+#include "source_name_utils.h"
 
 #include <mi/base/enums.h>
 #include <mi/base/handle.h>
@@ -72,10 +73,9 @@ std::tuple<std::string, std::string> parseMaterialSourceName(
         "The provided name '{}' is not an absolute fully-qualified"
         " material name, a leading '::' has been added.",
         name);
-    outModuleName = "::";
   }
 
-  outModuleName.append(name.substr(0, p_last));
+  outModuleName = normalizeModuleName(name.substr(0, p_last));
   outMaterialName = name.substr(p_last + 2);
   return {outModuleName, outMaterialName};
 }

--- a/devices/rtx/libmdl/helpers.cpp
+++ b/devices/rtx/libmdl/helpers.cpp
@@ -47,7 +47,7 @@ std::tuple<std::string, std::string> parseMaterialSourceName(
     // input already has ::main attached (optional)
     if (p_last != std::string::npos) {
       potential_path = name.substr(0, p_last);
-      potential_material_name = name.substr(p_last + 2, name.size() - p_last);
+      potential_material_name = name.substr(p_last + 2);
     }
 
     // is it an mdle?
@@ -76,7 +76,7 @@ std::tuple<std::string, std::string> parseMaterialSourceName(
   }
 
   outModuleName.append(name.substr(0, p_last));
-  outMaterialName = name.substr(p_last + 2, name.size() - p_last);
+  outMaterialName = name.substr(p_last + 2);
   return {outModuleName, outMaterialName};
 }
 

--- a/devices/rtx/libmdl/source_name_utils.h
+++ b/devices/rtx/libmdl/source_name_utils.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace visrtx::libmdl {
+
+// 128-bit FNV-1a over the bytes of `data`, rendered as 32 lowercase hex chars.
+// Implemented with two 64-bit lanes rather than `__int128` so it compiles on
+// MSVC as well as GCC/Clang.
+inline std::string fnv1a128Hex(std::string_view data)
+{
+  struct U128
+  {
+    std::uint64_t hi, lo;
+  };
+
+  // 128-bit multiply modulo 2^128. The low lanes need a full 64x64 -> 128
+  // product (computed via 32-bit halves, no compiler intrinsics); the cross
+  // lanes only reach the high 64 bits and the 2^128 term vanishes.
+  auto mul128 = [](U128 a, U128 b) -> U128 {
+    std::uint64_t al = a.lo & 0xffffffffu, ah = a.lo >> 32;
+    std::uint64_t bl = b.lo & 0xffffffffu, bh = b.lo >> 32;
+    std::uint64_t ll = al * bl, lh = al * bh, hl = ah * bl, hh = ah * bh;
+    std::uint64_t mid = (ll >> 32) + (lh & 0xffffffffu) + (hl & 0xffffffffu);
+    std::uint64_t lo = (ll & 0xffffffffu) | (mid << 32);
+    std::uint64_t hi = hh + (lh >> 32) + (hl >> 32) + (mid >> 32);
+    hi += a.lo * b.hi + a.hi * b.lo;
+    return U128{hi, lo};
+  };
+
+  // FNV-1a 128-bit parameters.
+  const U128 prime{0x0000000001000000ull, 0x000000000000013bull};
+  U128 hash{0x6c62272e07bb0142ull, 0x62b821756295c58dull};
+  for (unsigned char c : data) {
+    hash.lo ^= c;
+    hash = mul128(hash, prime);
+  }
+
+  auto laneToHex = [](std::uint64_t v) {
+    static const char *digits = "0123456789abcdef";
+    std::string s(16, '0');
+    for (int i = 15; i >= 0; --i) {
+      s[i] = digits[v & 0xfu];
+      v >>= 4;
+    }
+    return s;
+  };
+
+  return laneToHex(hash.hi) + laneToHex(hash.lo);
+}
+
+inline bool endsWith(std::string_view s, std::string_view suffix)
+{
+  return s.size() >= suffix.size()
+      && s.substr(s.size() - suffix.size()) == suffix;
+}
+
+// True for things the MDL loader should resolve as a file rather than a
+// fully-qualified module name.
+inline bool looksLikeModulePath(std::string_view s)
+{
+  return s.find('/') != std::string_view::npos || endsWith(s, ".mdl")
+      || endsWith(s, ".mdle");
+}
+
+// Ensure a fully-qualified MDL module name: prepend "::" for a bare relative
+// name, but leave absolute names ("::foo") and file paths untouched.
+inline std::string normalizeModuleName(std::string_view name)
+{
+  if (name.size() >= 2 && name[0] == ':' && name[1] == ':')
+    return std::string(name);
+  if (looksLikeModulePath(name))
+    return std::string(name);
+  return "::" + std::string(name);
+}
+
+// Synthetic, content-addressed module name for an inline source string.
+inline std::string makeInlineModuleName(std::string_view source)
+{
+  return "::__visrtx_inline_" + fnv1a128Hex(source);
+}
+
+} // namespace visrtx::libmdl


### PR DESCRIPTION
Add support for mdl material `sourceType`:
- `code`
- `mdle`

besides the existing `module`. Note that `mdle` has only been lightly exercised.