### PR TITLE
rtx: make ANARI library name configurable via VISRTX_LIBRARY_NAME

### DIFF
--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -50,6 +50,15 @@ include(EmbedPTX)
 
 #### RTX device options ####
 
+# Override for a dev build that must coexist with an official install, e.g.
+# -DVISRTX_LIBRARY_NAME=visrtx_dev.
+set(VISRTX_LIBRARY_NAME visrtx CACHE STRING
+  "ANARI library name: filename libanari_library_<name>.so and entrypoint anari_library_<name>_new_library")
+if(NOT VISRTX_LIBRARY_NAME MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+  message(FATAL_ERROR
+    "VISRTX_LIBRARY_NAME must be a valid C identifier (it is pasted into a symbol name): '${VISRTX_LIBRARY_NAME}'")
+endif()
+
 option(
   VISRTX_ENABLE_MDL_SUPPORT
   "Whether to enable NVIDIA MDL support for VisRTX materials"

--- a/devices/rtx/device/CMakeLists.txt
+++ b/devices/rtx/device/CMakeLists.txt
@@ -248,6 +248,9 @@ generate_export_header(${PROJECT_NAME}
   EXPORT_MACRO_NAME "VISRTX_DEVICE_INTERFACE"
 )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  OUTPUT_NAME anari_library_${VISRTX_LIBRARY_NAME})
+
 project_include_directories(
 PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
@@ -303,6 +306,9 @@ if(NOT WIN32)
 endif()
 
 project_compile_definitions(PRIVATE anari_library_visrtx_EXPORTS)
+
+set_source_files_properties(VisRTXLibrary.cpp PROPERTIES
+  COMPILE_DEFINITIONS VISRTX_LIBRARY_NAME=${VISRTX_LIBRARY_NAME})
 
 if (VISRTX_ENABLE_NVML)
   project_link_libraries(PRIVATE CUDA::nvml)

--- a/devices/rtx/device/VisRTXLibrary.cpp
+++ b/devices/rtx/device/VisRTXLibrary.cpp
@@ -69,8 +69,18 @@ const char **VisRTXLibrary::getDeviceExtensions(const char * /*deviceType*/)
 
 // Define library entrypoint //////////////////////////////////////////////////
 
-extern "C" VISRTX_DEVICE_INTERFACE ANARI_DEFINE_LIBRARY_ENTRYPOINT(
-    visrtx, handle, scb, scbPtr)
+#ifndef VISRTX_LIBRARY_NAME
+#define VISRTX_LIBRARY_NAME visrtx
+#endif
+
+// Extra indirection forces VISRTX_LIBRARY_NAME to expand before the entrypoint
+// macro pastes it into the symbol name (## suppresses expansion of its operands).
+#define VISRTX_ENTRYPOINT_EXPAND(name, h, s, sp)                               \
+  ANARI_DEFINE_LIBRARY_ENTRYPOINT(name, h, s, sp)
+#define VISRTX_LIBRARY_ENTRYPOINT(h, s, sp)                                    \
+  VISRTX_ENTRYPOINT_EXPAND(VISRTX_LIBRARY_NAME, h, s, sp)
+
+extern "C" VISRTX_DEVICE_INTERFACE VISRTX_LIBRARY_ENTRYPOINT(handle, scb, scbPtr)
 {
   return (ANARILibrary) new visrtx::VisRTXLibrary(handle, scb, scbPtr);
 }


### PR DESCRIPTION
Lets a dev build coexist with an official install in one process by parametrizing the output filename (`libanari_library_<name>.so`) and the entrypoint symbol (`anari_library_<name>_new_library`) from a single cache variable.
The default is 'visrtx'
