### PR TITLE
rtx: Add isosurface geometry

### DIFF
--- a/devices/rtx/device/CMakeLists.txt
+++ b/devices/rtx/device/CMakeLists.txt
@@ -146,6 +146,8 @@ set(SOURCES
   geometry/Geometry.cpp
   geometry/SDF.cpp
   $<$<BOOL:${VISRTX_ENABLE_NEURAL}>:geometry/Neural.cpp>
+  geometry/Isosurface.cpp
+  geometry/IsosurfaceBricks.cu
   geometry/Quad.cpp
   geometry/Sphere.cu
   geometry/Triangle.cpp

--- a/devices/rtx/device/geometry/Geometry.cpp
+++ b/devices/rtx/device/geometry/Geometry.cpp
@@ -34,6 +34,7 @@
 #include "Cone.h"
 #include "Curve.h"
 #include "Cylinder.h"
+#include "Isosurface.h"
 #include "Quad.h"
 #include "Sphere.h"
 #include "Triangle.h"
@@ -100,6 +101,8 @@ Geometry *Geometry::createInstance(
     return new Curve(d);
   else if (subtype == "sdf")
     return new SDF(d);
+  else if (subtype == "isosurface")
+    return new Isosurface(d);
 #ifdef VISRTX_USE_NEURAL
   else if (subtype == "neural")
     return new Neural(d);

--- a/devices/rtx/device/geometry/Intersectors_ptx.cu
+++ b/devices/rtx/device/geometry/Intersectors_ptx.cu
@@ -29,7 +29,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "geometry/IsosurfaceSample.h"
+#include "spatial_field/CustomFieldSamplerInline.h"
 #include "gpu/gpu_math.h"
+#include "gpu/gridTraversal.h"
 #include "gpu/shading_api.h"
 
 // glm
@@ -68,6 +71,17 @@ VISRTX_DEVICE void reportIntersectionVolume(const box1 &t)
       bit_cast<uint32_t>(rd.x),
       bit_cast<uint32_t>(rd.y),
       bit_cast<uint32_t>(rd.z));
+}
+
+VISRTX_DEVICE void reportIntersectionIsosurface(
+    float t, const vec3 &normal, uint32_t isovalueIndex)
+{
+  optixReportIntersection(t,
+      isovalueIndex, // hitKind: read in CH via optixGetHitKind()
+      bit_cast<uint32_t>(0.f), // u (unused for isosurface)
+      bit_cast<uint32_t>(normal.x),
+      bit_cast<uint32_t>(normal.y),
+      bit_cast<uint32_t>(normal.z));
 }
 
 // Primitive intersectors /////////////////////////////////////////////////////
@@ -249,13 +263,24 @@ VISRTX_DEVICE void intersectCone(const GeometryGPUData &geometryData)
 VISRTX_DEVICE bool rayBoxIntersection(
     const vec3 &ro, const vec3 &rd, const box3 &bounds, float &t0, float &t1)
 {
-  const vec3 mins = (bounds.lower - ro) * (1.f / rd);
-  const vec3 maxs = (bounds.upper - ro) * (1.f / rd);
-  const vec3 nears = min(mins, maxs);
-  const vec3 fars = max(mins, maxs);
-  t0 = max(nears.x, max(nears.y, nears.z));
-  t1 = min(fars.x, min(fars.y, fars.z));
-
+  // Per-axis slab test that handles axis-aligned rays (rd[a] == 0) explicitly,
+  // instead of (lower - ro) * (1/0). The latter yields 0*inf = NaN when the ray
+  // origin sits exactly on a finite box face, which min/max propagate so the
+  // test wrongly fails — the source of the axis-aligned tile seams.
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  t0 = -inf;
+  t1 = inf;
+  for (int a = 0; a < 3; ++a) {
+    if (rd[a] != 0.f) {
+      const float inv = 1.f / rd[a];
+      const float ta = (bounds.lower[a] - ro[a]) * inv;
+      const float tb = (bounds.upper[a] - ro[a]) * inv;
+      t0 = max(t0, min(ta, tb));
+      t1 = min(t1, max(ta, tb));
+    } else if (ro[a] < bounds.lower[a] || ro[a] > bounds.upper[a]) {
+      return false;
+    }
+  }
   return t0 < t1;
 }
 
@@ -402,6 +427,642 @@ VISRTX_DEVICE void intersectNeural(const GeometryGPUData &geometryData)
 
 #include "gpu/gpu_sdf.h"
 
+// Marches the [t0, t1] segment of one active macrocell on the global sample
+// lattice (defined by `phase`) and reports the nearest isovalue crossing in it,
+// returning true on a hit. Value-only march + 6-step bisection; the gradient
+// (6 extra texture fetches for built-in fields) is taken once, at the refined
+// hit. Specialized on the concrete sampler state — sampleValue/sampleNormal
+// resolve by ADL — so the hot path stays monomorphic.
+template <typename SamplerState>
+VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const SamplerState &st,
+    const vec3 &ro,
+    const vec3 &rd,
+    float t0,
+    float t1,
+    float phase,
+    ScreenSample &ss)
+{
+  const float step = iso.stepSize;
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+
+  // Snap onto the global lattice at/just below the segment entry so adjacent
+  // cells share samples (seam-free) and the entry face is covered.
+  float tStart = floorf((t0 - phase) / step) * step + phase;
+  tStart = fmaxf(tStart, ray::tmin());
+
+  const auto valueAt = [&](float t) {
+    const vec3 p = ro + t * rd;
+    return sampleValue(st, field, p);
+  };
+
+  float tPrev = tStart;
+  float vPrev = valueAt(tStart);
+
+  for (float t = tStart + step; t <= t1; t += step) {
+    const float v = valueAt(t);
+
+    // Find the nearest isovalue crossing within (tPrev, t]. The field is
+    // monotone across one sub-voxel step, so the crossings order by their
+    // linear-interpolated t -- pick the nearest from those estimates (no extra
+    // samples) and refine only that one by bisection below, instead of bisecting
+    // every bracketing isovalue (N root-finds -> 1).
+    float bestEst = t1 + 1.f;
+    float bestIv = 0.f;
+    uint32_t bestIdx = 0;
+    bool found = false;
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      const float fa = vPrev - iv;
+      const float fb = v - iv;
+      float est;
+      if (fa == 0.f)
+        est = tPrev; // exact crossing at the previous sample
+      else if ((fa < 0.f) != (fb < 0.f))
+        est = tPrev + (t - tPrev) * (fa / (fa - fb)); // sign change: fa != fb
+      else
+        continue;
+      if (est < bestEst) {
+        bestEst = est;
+        bestIv = iv;
+        bestIdx = i;
+        found = true;
+      }
+    }
+
+    if (found) {
+      // Refine the nearest crossing's root in [tPrev, t] by value-only bisection
+      // (skipped when it sits exactly on the previous sample).
+      float bestT = bestEst;
+      if (bestT > tPrev) {
+        float la = tPrev, lb = t, va = vPrev - bestIv, tm = bestT;
+        for (int k = 0; k < kIsosurfaceBisectionIters; ++k) {
+          tm = 0.5f * (la + lb);
+          const float fm = valueAt(tm) - bestIv;
+          if ((va < 0.f) != (fm < 0.f)) {
+            lb = tm;
+          } else {
+            la = tm;
+            va = fm;
+          }
+        }
+        bestT = tm;
+      }
+
+      // The field gradient points toward increasing value, which for most data
+      // (e.g. denser tissue) points into the surface. A level set has no
+      // inherent front/back, so orient the shading normal toward the incoming
+      // ray; otherwise the camera-facing side shades dark. (Object-space flip;
+      // correct for non-mirrored instance transforms.)
+      const vec3 pHit = ro + bestT * rd;
+      vec3 grad = sampleNormal(st, field, pHit);
+      if (dot(grad, rd) > 0.f)
+        grad = -grad;
+      reportIntersectionIsosurface(bestT, normalize(grad), bestIdx);
+      return true; // front-to-back: first bracketing step holds the nearest hit
+    }
+
+    tPrev = t;
+    vPrev = v;
+  }
+  return false;
+}
+
+// Walks the field's macrocell grid front-to-back (3D-DDA), marching only cells
+// whose value range brackets an isovalue, and reports the nearest crossing.
+// Empty-space skipping happens here — inactive cells are stepped over with no
+// sampling — so the geometry is a single field-bounds AABB rather than one
+// primitive per active macrocell.
+template <typename SamplerState>
+VISRTX_DEVICE void marchIsosurface(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const SamplerState &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  const float step = iso.stepSize;
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+
+  // One sampling phase per (pixel, frame), shared by every cell the ray
+  // crosses: a single continuous lattice (no per-cell restart -> no seams)
+  // whose phase varies per frame so accumulation averages residual aliasing
+  // into noise (the moiré fix).
+  const auto &fb = ss.frameData->fb;
+  const uint64_t pixelLinear =
+      uint64_t(ss.pixel.y) * fb.size.x + uint64_t(ss.pixel.x);
+  const uint64_t phaseHash = detail::pcg_mix64(
+      (uint64_t(fb.frameID) << 32u) ^ pixelLinear ^ 0x9E3779B97F4A7C15ULL);
+  const float phase = float(phaseHash >> 40) * (1.0f / 16777216.0f) * step;
+
+  GridTraversal trav(objRay, field.grid.dims, field.grid.objectBounds);
+  while (trav.valid()) {
+    const box1 vr = field.grid.valueRanges[trav.cellIndex];
+    bool active = vr.lower <= vr.upper;
+    if (active) {
+      active = false;
+      for (uint32_t i = 0; i < numIsovalues; ++i) {
+        if (isovals[i] >= vr.lower && isovals[i] <= vr.upper) {
+          active = true;
+          break;
+        }
+      }
+    }
+    if (active) {
+      // Extend one step past the cell exit so a crossing near the high face is
+      // caught even when the next cell is skipped (value ranges carry a one-
+      // voxel margin). Cap at the true ray tmax, NOT objRay.t.upper: the latter
+      // is clipped to this brick's AABB, so capping there zeroes the overrun at
+      // every brick-exit face and drops a crossing in the last partial step —
+      // a depth seam on the brick-boundary plane. Adjacent active cells/bricks
+      // re-check the overlap harmlessly; front-to-back keeps the nearest hit.
+      const float t1 = fminf(trav.tExit + step, ray::tmax());
+      if (marchIsosurfaceSegment(iso,
+              field,
+              st,
+              objRay.org,
+              objRay.dir,
+              trav.tEntry,
+              t1,
+              phase,
+              ss))
+        return;
+    }
+    trav.next();
+  }
+}
+
+// Per-grid voxel-DDA over a [t0,t1] sub-segment, returning true on the nearest
+// crossing within it. Each seeds the predecessor value just before t0 so a
+// crossing on the segment's entry face is caught (callers pass a one-voxel
+// margin past the segment so the shared face with the next macrocell is covered
+// too). These are the narrow phase of the two-level traversal below.
+
+// Structured-regular: piecewise-constant under nearest filtering, so the
+// isosurface is axis-aligned voxel faces. Walk the voxel grid in sample-
+// coordinate space (value boundaries are the integer planes); the DDA t is
+// shared with the object ray, so a sign change across a face gives the crossing
+// t AND the face axis directly.
+VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const StructuredRegularSamplerState &st,
+    const vec3 &ro,
+    const vec3 &rd,
+    float t0,
+    float t1,
+    ScreenSample &ss)
+{
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+
+  Ray cRay; // object ray in sample-coordinate space (shared t parameterization)
+  cRay.org = (ro - st.origin) * st.invSpacing + st.offset;
+  cRay.dir = rd * st.invSpacing;
+  cRay.t.lower = t0;
+  cRay.t.upper = t1;
+
+  GridTraversal trav(cRay, st.dims, box3(vec3(0.f), vec3(st.dims)));
+  if (!trav.valid())
+    return false;
+
+  const float firstSpan = trav.tExit - trav.tEntry;
+  float vPrev =
+      sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd);
+
+  while (trav.valid()) {
+    const float tMid = 0.5f * (trav.tEntry + trav.tExit);
+    const float vCur = sampleValue(st, field, ro + tMid * rd);
+    // Scan all isovalues (no divergent in-loop early-out; the uniform trip count
+    // lets ptxas unroll). Every bracket shares this face's t, so report the
+    // first one found.
+    int hitIdx = -1;
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
+        hitIdx = int(i);
+    }
+    if (hitIdx >= 0) {
+      vec3 n(0.f); // face the ray entered this voxel through
+      n[trav.crossedAxis] = 1.f;
+      if (dot(n, rd) > 0.f)
+        n = -n;
+      reportIntersectionIsosurface(trav.tEntry, n, uint32_t(hitIdx));
+      return true; // front-to-back: first crossing is the nearest hit
+    }
+    vPrev = vCur;
+    trav.next();
+  }
+  return false;
+}
+
+// NanoVDB regular: affine world->index map, so the index-space ray is straight
+// and shares the object t. Nearest fetch rounds the index (value boundaries at
+// half-integer index planes), so shift the DDA grid bounds by -0.5. (Object
+// normal uses the index axis directly — exact for axis-aligned grids; a rotated
+// map would need the map's inverse-transpose, a follow-up.)
+template <typename ValueType>
+VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const NvdbRegularSamplerState<ValueType> &st,
+    const vec3 &ro,
+    const vec3 &rd,
+    float t0,
+    float t1,
+    ScreenSample &ss)
+{
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+
+  const auto i0 = nvdbIndexPos(st, ro);
+  const auto i1 = nvdbIndexPos(st, ro + rd);
+  Ray idxRay;
+  idxRay.org = vec3(i0[0], i0[1], i0[2]);
+  idxRay.dir = vec3(i1[0] - i0[0], i1[1] - i0[1], i1[2] - i0[2]);
+  idxRay.t.lower = t0;
+  idxRay.t.upper = t1;
+
+  const vec3 lo(
+      st.indexMin[0] - 0.5f, st.indexMin[1] - 0.5f, st.indexMin[2] - 0.5f);
+  const vec3 hi(
+      st.indexMax[0] + 0.5f, st.indexMax[1] + 0.5f, st.indexMax[2] + 0.5f);
+  const ivec3 dims(int(st.indexMax[0] - st.indexMin[0]) + 1,
+      int(st.indexMax[1] - st.indexMin[1]) + 1,
+      int(st.indexMax[2] - st.indexMin[2]) + 1);
+
+  GridTraversal trav(idxRay, dims, box3(lo, hi));
+  if (!trav.valid())
+    return false;
+
+  const float firstSpan = trav.tExit - trav.tEntry;
+  float vPrev =
+      sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd);
+
+  while (trav.valid()) {
+    const float tMid = 0.5f * (trav.tEntry + trav.tExit);
+    const float vCur = sampleValue(st, field, ro + tMid * rd);
+    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
+        hitIdx = int(i);
+    }
+    if (hitIdx >= 0) {
+      vec3 n(0.f);
+      n[trav.crossedAxis] = 1.f;
+      if (dot(n, rd) > 0.f)
+        n = -n;
+      reportIntersectionIsosurface(trav.tEntry, n, uint32_t(hitIdx));
+      return true;
+    }
+    vPrev = vCur;
+    trav.next();
+  }
+  return false;
+}
+
+// Structured rectilinear: uniform voxel grid in sample (texcoord) space, warped
+// per-axis into object space. Non-uniform DDA whose integer-texcoord boundary
+// positions come straight from the inverse LUT (index->object). Value
+// boundaries are at integer texcoord (texel-floor nearest); the per-axis warp
+// keeps face normals axis-aligned in object space.
+VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const StructuredRectilinearSamplerState &st,
+    const vec3 &ro,
+    const vec3 &rd,
+    float t0,
+    float t1,
+    ScreenSample &ss)
+{
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+  const vec3 ext = st.axisBoundsMax - st.axisBoundsMin;
+
+  const auto boundaryPos = [&](int a, int m) {
+    const float ni = (float(m) - st.offset[a]) / st.dims[a];
+    return st.axisBoundsMin[a] + tex1D<float>(st.invAxisLUT[a], ni) * ext[a];
+  };
+
+  float t = fmaxf(t0, 0.f);
+  const vec3 c = structuredRectilinearCoord(st, ro + t * rd);
+  ivec3 vi(int(floorf(c.x)), int(floorf(c.y)), int(floorf(c.z)));
+  const ivec3 stepv(
+      rd.x > 0.f ? 1 : -1, rd.y > 0.f ? 1 : -1, rd.z > 0.f ? 1 : -1);
+
+  float vPrev; // predecessor sample, seeded voxel-relative on the first step
+  bool seeded = false;
+  int crossedAxis = 0;
+
+  constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
+  for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
+    float tExit = t1;
+    int exitAxis = crossedAxis;
+    // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
+    // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
+    // risking a re-picked boundary / stalled segment in larger scenes.
+    const float tEps = 1e-6f * fmaxf(1.f, fabsf(t));
+    for (int a = 0; a < 3; ++a) {
+      if (rd[a] == 0.f)
+        continue;
+      const int nb = rd[a] > 0.f ? vi[a] + 1 : vi[a];
+      const float te = (boundaryPos(a, nb) - ro[a]) / rd[a];
+      if (te > t + tEps && te < tExit) {
+        tExit = te;
+        exitAxis = a;
+      }
+    }
+    const float tExitSeg = fminf(tExit, t1);
+    if (!seeded) {
+      // Seed the predecessor a quarter of the entry voxel back (voxel-relative,
+      // as the uniform grids do) so an entry-face crossing is caught. A
+      // segment-relative backstep collapses to t under fp rounding on long
+      // segments, missing it.
+      vPrev = sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd);
+      seeded = true;
+    }
+    const float tMid = 0.5f * (t + tExitSeg);
+    const float vCur = sampleValue(st, field, ro + tMid * rd);
+    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
+        hitIdx = int(i);
+    }
+    if (hitIdx >= 0) {
+      vec3 n(0.f);
+      n[crossedAxis] = 1.f; // face the ray entered this voxel through
+      if (dot(n, rd) > 0.f)
+        n = -n;
+      reportIntersectionIsosurface(t, n, uint32_t(hitIdx));
+      return true;
+    }
+    vPrev = vCur;
+    crossedAxis = exitAxis;
+    t = tExit;
+    vi[exitAxis] += stepv[exitAxis];
+  }
+  return false;
+}
+
+// NanoVDB rectilinear: as structured rectilinear, but boundary world positions
+// are inverse-LUT (rect index -> uniform index) composed with the precomputed
+// uniform-index -> world map. Value boundaries at rect-index half-integers.
+template <typename ValueType>
+VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const NvdbRectilinearSamplerState<ValueType> &st,
+    const vec3 &ro,
+    const vec3 &rd,
+    float t0,
+    float t1,
+    ScreenSample &ss)
+{
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+
+  const auto boundaryPos = [&](int a, float rb) {
+    const float nr = (rb - st.offsetUp[a]) / st.scaleUp[a];
+    const float nu = tex1D<float>(st.invAxisLUT[a], nr);
+    const float ip = nu / st.scaleDown[a] + st.offsetDown[a]; // uniform index
+    return st.worldOrigin[a] + ip * st.worldVoxelStep[a];
+  };
+
+  float t = fmaxf(t0, 0.f);
+  const vec3 pEntry = ro + t * rd;
+  const auto idxEntry = worldToIndexRectilinear(st, &pEntry);
+  ivec3 vi(int(roundf(idxEntry[0])),
+      int(roundf(idxEntry[1])),
+      int(roundf(idxEntry[2])));
+  const ivec3 stepv(
+      rd.x > 0.f ? 1 : -1, rd.y > 0.f ? 1 : -1, rd.z > 0.f ? 1 : -1);
+
+  float vPrev; // predecessor sample, seeded voxel-relative on the first step
+  bool seeded = false;
+  int crossedAxis = 0;
+
+  constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
+  for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
+    float tExit = t1;
+    int exitAxis = crossedAxis;
+    // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
+    // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
+    // risking a re-picked boundary / stalled segment in larger scenes.
+    const float tEps = 1e-6f * fmaxf(1.f, fabsf(t));
+    for (int a = 0; a < 3; ++a) {
+      if (rd[a] == 0.f)
+        continue;
+      const float rb = rd[a] > 0.f ? float(vi[a]) + 0.5f : float(vi[a]) - 0.5f;
+      const float te = (boundaryPos(a, rb) - ro[a]) / rd[a];
+      if (te > t + tEps && te < tExit) {
+        tExit = te;
+        exitAxis = a;
+      }
+    }
+    const float tExitSeg = fminf(tExit, t1);
+    if (!seeded) {
+      // Seed the predecessor a quarter of the entry voxel back (voxel-relative,
+      // as the uniform grids do) so an entry-face crossing is caught. A
+      // segment-relative backstep collapses to t under fp rounding on long
+      // segments, missing it.
+      vPrev = sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd);
+      seeded = true;
+    }
+    const float tMid = 0.5f * (t + tExitSeg);
+    const float vCur = sampleValue(st, field, ro + tMid * rd);
+    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
+        hitIdx = int(i);
+    }
+    if (hitIdx >= 0) {
+      vec3 n(0.f);
+      n[crossedAxis] = 1.f; // face the ray entered this voxel through
+      if (dot(n, rd) > 0.f)
+        n = -n;
+      reportIntersectionIsosurface(t, n, uint32_t(hitIdx));
+      return true;
+    }
+    vPrev = vCur;
+    crossedAxis = exitAxis;
+    t = tExit;
+    vi[exitAxis] += stepv[exitAxis];
+  }
+  return false;
+}
+
+// Two-level traversal: walk the coarse macrocell grid (empty-space skipping via
+// its value ranges) and only run the per-voxel DDA inside macrocells whose range
+// brackets an isovalue. Each active segment is extended one voxel past the cell
+// exit so a crossing on the shared face with a skipped neighbour is still found;
+// front-to-back keeps the nearest hit. (`voxelDDASegment` resolves per grid.)
+template <typename SamplerState>
+VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const SamplerState &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  const float *const isovals = iso.isovalues;
+  const uint32_t numIsovalues = iso.numIsovalues;
+  const float margin = 2.f * iso.stepSize; // ~one voxel, to cover the exit face
+
+  GridTraversal mc(objRay, field.grid.dims, field.grid.objectBounds);
+  while (mc.valid()) {
+    const box1 vr = field.grid.valueRanges[mc.cellIndex];
+    bool active = vr.lower <= vr.upper;
+    if (active) {
+      active = false;
+      for (uint32_t i = 0; i < numIsovalues; ++i) {
+        if (isovals[i] >= vr.lower && isovals[i] <= vr.upper) {
+          active = true;
+          break;
+        }
+      }
+    }
+    if (active) {
+      // Cap at the true ray tmax, NOT objRay.t.upper (which is clipped to this
+      // brick's AABB): capping at the brick edge zeroes the margin at every
+      // brick-exit face and drops a crossing on the face shared with the next
+      // brick -- a depth seam on the brick-boundary plane. The per-grid DDA
+      // stays in bounds via its own grid clamp; adjacent bricks re-check the
+      // overlap harmlessly and front-to-back keeps the nearest hit. (Mirrors
+      // the linear ray-march path above.)
+      const float t1 = fminf(mc.tExit + margin, ray::tmax());
+      if (voxelDDASegment(
+              iso, field, st, objRay.org, objRay.dir, mc.tEntry, t1, ss))
+        return;
+    }
+    mc.next();
+  }
+}
+
+// Voxel-DDA isosurface intersection for built-in grids. Concrete grid samplers
+// run the two-level macrocell-skip + voxel-DDA for nearest filtering, and the
+// fixed-step ray march for linear (smooth) surfaces. The generic form is the
+// ray-march hook for fields without analytic voxel boundaries (e.g. custom
+// fields); built-in fields are currently gated to require a space-skipping grid
+// in Isosurface::finalize, so it is unused here today.
+template <typename SamplerState>
+VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const SamplerState &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  marchIsosurface(iso, field, st, objRay, ss);
+}
+
+VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const StructuredRegularSamplerState &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  if (st.filter != SpatialFieldFilter::Nearest)
+    marchIsosurface(iso, field, st, objRay, ss);
+  else
+    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+}
+
+template <typename ValueType>
+VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const NvdbRegularSamplerState<ValueType> &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  if (st.filter != SpatialFieldFilter::Nearest)
+    marchIsosurface(iso, field, st, objRay, ss);
+  else
+    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+}
+
+VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const StructuredRectilinearSamplerState &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  if (st.filter != SpatialFieldFilter::Nearest)
+    marchIsosurface(iso, field, st, objRay, ss);
+  else
+    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+}
+
+template <typename ValueType>
+VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
+    const SpatialFieldGPUData &field,
+    const NvdbRectilinearSamplerState<ValueType> &st,
+    const Ray &objRay,
+    ScreenSample &ss)
+{
+  if (st.filter != SpatialFieldFilter::Nearest)
+    marchIsosurface(iso, field, st, objRay, ss);
+  else
+    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+}
+
+VISRTX_DEVICE void intersectIsosurface(const GeometryGPUData &geometryData)
+{
+  const auto &iso = geometryData.isosurface;
+  auto &ss = ray::screenSample();
+  const auto &field = ss.frameData->registry.fields[iso.field];
+
+  Ray objRay;
+  objRay.org = ray::localOrigin();
+  objRay.dir = ray::localDirection();
+  objRay.t.lower = ray::tmin();
+  objRay.t.upper = ray::tmax();
+
+  // Limit the march to this brick (one BVH primitive == one active-region
+  // brick) so its DDA walks only its own macrocells; the BVH has already culled
+  // bricks the ray misses.
+  box1 tBrick;
+  if (!rayBoxIntersection(objRay.org,
+          objRay.dir,
+          iso.brickBounds[ray::primID()],
+          tBrick.lower,
+          tBrick.upper))
+    return;
+  objRay.t.lower = fmaxf(objRay.t.lower, tBrick.lower);
+  objRay.t.upper = fminf(objRay.t.upper, tBrick.upper);
+
+  // Clip to the field's region of interest, matching the volume path.
+  box1 tRoi;
+  if (!rayBoxIntersection(
+          objRay.org, objRay.dir, field.roi, tRoi.lower, tRoi.upper))
+    return;
+  objRay.t.lower = fmaxf(objRay.t.lower, tRoi.lower);
+  objRay.t.upper = fminf(objRay.t.upper, tRoi.upper);
+  if (!(objRay.t.lower < objRay.t.upper))
+    return;
+
+  // Dispatch once on the concrete field sampler; the marcher calls the shared
+  // sampleValue/sampleNormal, resolved by ADL on the state type.
+  VolumeSamplingState st;
+  switch (field.samplerCallableIndex) {
+#define X(ENTRY, MEMBER, INIT_FN)                                              \
+  case SbtCallableEntryPoints::ENTRY:                                          \
+    INIT_FN(st.MEMBER, &field);                                                \
+    marchIsosurfaceVoxels(iso, field, st.MEMBER, objRay, ss);                  \
+    return;
+    VISRTX_ISOSURFACE_FIELD_VARIANTS
+#undef X
+  case SbtCallableEntryPoints::SpatialFieldSamplerCustom:
+    // Custom fields have no inline sampler; sample via the SBT callables
+    // (initSamplerState/sampleValue/sampleNormal route through optixDirectCall).
+    // The generic marchIsosurfaceVoxels falls back to the fixed-step ray march.
+    initSamplerState(st, field);
+    marchIsosurfaceVoxels(iso, field, st, objRay, ss);
+    return;
+  default:
+    return; // unsupported field type
+  }
+}
+
 // Generic geometry dispatch //////////////////////////////////////////////////
 
 VISRTX_DEVICE void intersectGeometry()
@@ -423,6 +1084,9 @@ VISRTX_DEVICE void intersectGeometry()
     break;
   case GeometryType::SDF:
     intersectSDF(geometryData);
+    break;
+  case GeometryType::ISOSURFACE:
+    intersectIsosurface(geometryData);
     break;
 #ifdef VISRTX_USE_NEURAL
   case GeometryType::NEURAL:

--- a/devices/rtx/device/geometry/Intersectors_ptx.cu
+++ b/devices/rtx/device/geometry/Intersectors_ptx.cu
@@ -29,6 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "geometry/IsosurfaceLinear.h"
 #include "geometry/IsosurfaceSample.h"
 #include "spatial_field/CustomFieldSamplerInline.h"
 #include "gpu/gpu_math.h"
@@ -444,7 +445,9 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
     float phase,
     ScreenSample &ss)
 {
-  const float step = iso.stepSize;
+  // iso.stepSize is an object-space distance; rd (the object ray direction) is
+  // non-unit under instance scaling, so divide to get the step in ray-t units.
+  const float step = iso.stepSize / length(rd);
   const float *const isovals = iso.isovalues;
   const uint32_t numIsovalues = iso.numIsovalues;
 
@@ -461,7 +464,11 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
   float tPrev = tStart;
   float vPrev = valueAt(tStart);
 
-  for (float t = tStart + step; t <= t1; t += step) {
+  // Integer step index (not t += step) so float error can't drop or double the
+  // final step near t1 over a long segment.
+  const int nSteps = step > 0.f ? int(floorf((t1 - tStart) / step)) : 0;
+  for (int i = 1; i <= nSteps; ++i) {
+    const float t = tStart + float(i) * step;
     const float v = valueAt(t);
 
     // Find the nearest isovalue crossing within (tPrev, t]. The field is
@@ -518,9 +525,17 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
       // correct for non-mirrored instance transforms.)
       const vec3 pHit = ro + bestT * rd;
       vec3 grad = sampleNormal(st, field, pHit);
-      if (dot(grad, rd) > 0.f)
-        grad = -grad;
-      reportIntersectionIsosurface(bestT, normalize(grad), bestIdx);
+      // Guard a (near-)zero gradient (field extremum/saddle): normalize(0) is
+      // NaN. Fall back to facing the incoming ray.
+      vec3 nrm;
+      if (dot(grad, grad) < 1e-12f) {
+        nrm = normalize(-rd);
+      } else {
+        if (dot(grad, rd) > 0.f)
+          grad = -grad;
+        nrm = normalize(grad);
+      }
+      reportIntersectionIsosurface(bestT, nrm, bestIdx);
       return true; // front-to-back: first bracketing step holds the nearest hit
     }
 
@@ -534,7 +549,9 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
 // whose value range brackets an isovalue, and reports the nearest crossing.
 // Empty-space skipping happens here — inactive cells are stepped over with no
 // sampling — so the geometry is a single field-bounds AABB rather than one
-// primitive per active macrocell.
+// primitive per active macrocell. This fixed-step march is now the fallback for
+// fields without analytic voxel boundaries (custom fields); built-in grids use
+// the per-voxel DDA (marchVoxelsMacrocellSkip) for both filters.
 template <typename SamplerState>
 VISRTX_DEVICE void marchIsosurface(const IsosurfaceGeometryData &iso,
     const SpatialFieldGPUData &field,
@@ -542,7 +559,9 @@ VISRTX_DEVICE void marchIsosurface(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  const float step = iso.stepSize;
+  // Object-space distance -> ray-t units (objRay.dir is non-unit under instance
+  // scaling); phase and the exit overrun below both inherit these t units.
+  const float step = iso.stepSize / length(objRay.dir);
   const float *const isovals = iso.isovalues;
   const uint32_t numIsovalues = iso.numIsovalues;
 
@@ -594,6 +613,67 @@ VISRTX_DEVICE void marchIsosurface(const IsosurfaceGeometryData &iso,
   }
 }
 
+// Per-voxel crossing test shared by all four grid voxelDDASegment variants
+// below — the only per-filter logic, factored out so the four overloads differ
+// only in their traversal mechanics. st.filter is a per-field constant, so the
+// branch is warp-uniform. Nearest = piecewise-constant face test (one midpoint
+// sample; report the entry-face normal at tEntry). Linear = the trilinear-along-
+// ray cubic (linearCrossing). Returns true and reports the hit on a crossing;
+// otherwise carries the predecessor sample `vPrev` (voxel midpoint for nearest,
+// exit-face value for linear) and returns false. crossedAxis is the face the ray
+// entered this voxel through. Callers seed vPrev per-filter before the first
+// voxel (nearest a quarter-voxel back; linear the exact entry-face value, since
+// linearCrossing consumes it as the cubic's node-0).
+template <typename SamplerState>
+VISRTX_DEVICE bool crossingTest(const SamplerState &st,
+    const SpatialFieldGPUData &field,
+    const vec3 &ro,
+    const vec3 &rd,
+    float tEntry,
+    float tExit,
+    int crossedAxis,
+    const float *isovals,
+    uint32_t numIsovalues,
+    float &vPrev,
+    ScreenSample &ss)
+{
+  if (st.filter == SpatialFieldFilter::Nearest) {
+    const float tMid = 0.5f * (tEntry + tExit);
+    const float vCur = sampleValue(st, field, ro + tMid * rd);
+    // Scan all isovalues (no divergent in-loop early-out; the uniform trip count
+    // lets ptxas unroll). Every bracket shares this face's t, so report the first.
+    int hitIdx = -1;
+    for (uint32_t i = 0; i < numIsovalues; ++i) {
+      const float iv = isovals[i];
+      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
+        hitIdx = int(i);
+    }
+    if (hitIdx >= 0) {
+      vec3 n(0.f); // face the ray entered this voxel through
+      n[crossedAxis] = 1.f;
+      if (dot(n, rd) > 0.f)
+        n = -n;
+      reportIntersectionIsosurface(tEntry, n, uint32_t(hitIdx));
+      return true; // front-to-back: first crossing is the nearest hit
+    }
+    vPrev = vCur;
+  } else {
+    // Exit-face value sampled only on the linear path (nearest keeps its single
+    // midpoint sample). Carried as the next voxel's entry value -> one fetch/voxel.
+    const float vExit = sampleValue(st, field, ro + tExit * rd);
+    float hitT;
+    vec3 hitN;
+    uint32_t hitIdx;
+    if (linearCrossing(st, field, ro, rd, tEntry, tExit, vPrev, vExit, isovals,
+            numIsovalues, hitT, hitN, hitIdx)) {
+      reportIntersectionIsosurface(hitT, hitN, hitIdx);
+      return true;
+    }
+    vPrev = vExit;
+  }
+  return false;
+}
+
 // Per-grid voxel-DDA over a [t0,t1] sub-segment, returning true on the nearest
 // crossing within it. Each seeds the predecessor value just before t0 so a
 // crossing on the segment's entry face is caught (callers pass a one-voxel
@@ -628,30 +708,18 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
     return false;
 
   const float firstSpan = trav.tExit - trav.tEntry;
-  float vPrev =
-      sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd);
+  // Nearest seeds a quarter-voxel before entry (an entry-side value for the face
+  // sign-test); linear needs the EXACT entry-face value — linearCrossing consumes
+  // vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample would
+  // corrupt the first voxel's root in every active segment.
+  float vPrev = st.filter == SpatialFieldFilter::Nearest
+      ? sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd)
+      : sampleValue(st, field, ro + trav.tEntry * rd);
 
   while (trav.valid()) {
-    const float tMid = 0.5f * (trav.tEntry + trav.tExit);
-    const float vCur = sampleValue(st, field, ro + tMid * rd);
-    // Scan all isovalues (no divergent in-loop early-out; the uniform trip count
-    // lets ptxas unroll). Every bracket shares this face's t, so report the
-    // first one found.
-    int hitIdx = -1;
-    for (uint32_t i = 0; i < numIsovalues; ++i) {
-      const float iv = isovals[i];
-      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
-        hitIdx = int(i);
-    }
-    if (hitIdx >= 0) {
-      vec3 n(0.f); // face the ray entered this voxel through
-      n[trav.crossedAxis] = 1.f;
-      if (dot(n, rd) > 0.f)
-        n = -n;
-      reportIntersectionIsosurface(trav.tEntry, n, uint32_t(hitIdx));
-      return true; // front-to-back: first crossing is the nearest hit
-    }
-    vPrev = vCur;
+    if (crossingTest(st, field, ro, rd, trav.tEntry, trav.tExit,
+            trav.crossedAxis, isovals, numIsovalues, vPrev, ss))
+      return true;
     trav.next();
   }
   return false;
@@ -696,27 +764,18 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
     return false;
 
   const float firstSpan = trav.tExit - trav.tEntry;
-  float vPrev =
-      sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd);
+  // Nearest seeds a quarter-voxel before entry (an entry-side value for the face
+  // sign-test); linear needs the EXACT entry-face value — linearCrossing consumes
+  // vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample would
+  // corrupt the first voxel's root in every active segment.
+  float vPrev = st.filter == SpatialFieldFilter::Nearest
+      ? sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd)
+      : sampleValue(st, field, ro + trav.tEntry * rd);
 
   while (trav.valid()) {
-    const float tMid = 0.5f * (trav.tEntry + trav.tExit);
-    const float vCur = sampleValue(st, field, ro + tMid * rd);
-    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
-    for (uint32_t i = 0; i < numIsovalues; ++i) {
-      const float iv = isovals[i];
-      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
-        hitIdx = int(i);
-    }
-    if (hitIdx >= 0) {
-      vec3 n(0.f);
-      n[trav.crossedAxis] = 1.f;
-      if (dot(n, rd) > 0.f)
-        n = -n;
-      reportIntersectionIsosurface(trav.tEntry, n, uint32_t(hitIdx));
+    if (crossingTest(st, field, ro, rd, trav.tEntry, trav.tExit,
+            trav.crossedAxis, isovals, numIsovalues, vPrev, ss))
       return true;
-    }
-    vPrev = vCur;
     trav.next();
   }
   return false;
@@ -753,12 +812,30 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
 
   float vPrev; // predecessor sample, seeded voxel-relative on the first step
   bool seeded = false;
+  // First-voxel entry face: the axis whose entry boundary the ray crossed most
+  // recently (largest entry-t <= t). GridTraversal derives this from its slab
+  // test for the uniform grids; the hand-rolled DDA must compute it, else the
+  // first voxel always reports an x-face normal.
   int crossedAxis = 0;
+  {
+    float tEnter = -1e30f;
+    const float epsE = 1e-6f * fmaxf(1.f, fabsf(t));
+    for (int a = 0; a < 3; ++a) {
+      if (rd[a] == 0.f)
+        continue;
+      const int eb = rd[a] > 0.f ? vi[a] : vi[a] + 1; // boundary behind the ray
+      const float te = (boundaryPos(a, eb) - ro[a]) / rd[a];
+      if (te <= t + epsE && te > tEnter) {
+        tEnter = te;
+        crossedAxis = a;
+      }
+    }
+  }
 
   constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
   for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
     float tExit = t1;
-    int exitAxis = crossedAxis;
+    int exitAxis = -1; // set below to the exit-boundary axis; -1 => none before t1
     // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
     // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
     // risking a re-picked boundary / stalled segment in larger scenes.
@@ -779,26 +856,18 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
       // as the uniform grids do) so an entry-face crossing is caught. A
       // segment-relative backstep collapses to t under fp rounding on long
       // segments, missing it.
-      vPrev = sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd);
+      // See the uniform-grid seed note: linear needs the exact entry-face value
+      // (cubic node-0), nearest the quarter-voxel-back entry-side value.
+      vPrev = st.filter == SpatialFieldFilter::Nearest
+          ? sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd)
+          : sampleValue(st, field, ro + t * rd);
       seeded = true;
     }
-    const float tMid = 0.5f * (t + tExitSeg);
-    const float vCur = sampleValue(st, field, ro + tMid * rd);
-    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
-    for (uint32_t i = 0; i < numIsovalues; ++i) {
-      const float iv = isovals[i];
-      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
-        hitIdx = int(i);
-    }
-    if (hitIdx >= 0) {
-      vec3 n(0.f);
-      n[crossedAxis] = 1.f; // face the ray entered this voxel through
-      if (dot(n, rd) > 0.f)
-        n = -n;
-      reportIntersectionIsosurface(t, n, uint32_t(hitIdx));
+    if (crossingTest(st, field, ro, rd, t, tExitSeg, crossedAxis, isovals,
+            numIsovalues, vPrev, ss))
       return true;
-    }
-    vPrev = vCur;
+    if (exitAxis < 0) // no forward boundary before t1: the segment ends here
+      break;
     crossedAxis = exitAxis;
     t = tExit;
     vi[exitAxis] += stepv[exitAxis];
@@ -840,12 +909,29 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
 
   float vPrev; // predecessor sample, seeded voxel-relative on the first step
   bool seeded = false;
+  // First-voxel entry face: axis whose entry boundary the ray crossed most
+  // recently (largest entry-t <= t), as the uniform GridTraversal would derive
+  // it — otherwise the first voxel always reports an x-face normal.
   int crossedAxis = 0;
+  {
+    float tEnter = -1e30f;
+    const float epsE = 1e-6f * fmaxf(1.f, fabsf(t));
+    for (int a = 0; a < 3; ++a) {
+      if (rd[a] == 0.f)
+        continue;
+      const float rb = rd[a] > 0.f ? float(vi[a]) - 0.5f : float(vi[a]) + 0.5f;
+      const float te = (boundaryPos(a, rb) - ro[a]) / rd[a];
+      if (te <= t + epsE && te > tEnter) {
+        tEnter = te;
+        crossedAxis = a;
+      }
+    }
+  }
 
   constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
   for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
     float tExit = t1;
-    int exitAxis = crossedAxis;
+    int exitAxis = -1; // set below to the exit-boundary axis; -1 => none before t1
     // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
     // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
     // risking a re-picked boundary / stalled segment in larger scenes.
@@ -866,26 +952,18 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
       // as the uniform grids do) so an entry-face crossing is caught. A
       // segment-relative backstep collapses to t under fp rounding on long
       // segments, missing it.
-      vPrev = sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd);
+      // See the uniform-grid seed note: linear needs the exact entry-face value
+      // (cubic node-0), nearest the quarter-voxel-back entry-side value.
+      vPrev = st.filter == SpatialFieldFilter::Nearest
+          ? sampleValue(st, field, ro + (t - 0.25f * (tExitSeg - t)) * rd)
+          : sampleValue(st, field, ro + t * rd);
       seeded = true;
     }
-    const float tMid = 0.5f * (t + tExitSeg);
-    const float vCur = sampleValue(st, field, ro + tMid * rd);
-    int hitIdx = -1; // first bracket; scan all (no divergent in-loop early-out)
-    for (uint32_t i = 0; i < numIsovalues; ++i) {
-      const float iv = isovals[i];
-      if (hitIdx < 0 && ((vPrev < iv) != (vCur < iv)))
-        hitIdx = int(i);
-    }
-    if (hitIdx >= 0) {
-      vec3 n(0.f);
-      n[crossedAxis] = 1.f; // face the ray entered this voxel through
-      if (dot(n, rd) > 0.f)
-        n = -n;
-      reportIntersectionIsosurface(t, n, uint32_t(hitIdx));
+    if (crossingTest(st, field, ro, rd, t, tExitSeg, crossedAxis, isovals,
+            numIsovalues, vPrev, ss))
       return true;
-    }
-    vPrev = vCur;
+    if (exitAxis < 0) // no forward boundary before t1: the segment ends here
+      break;
     crossedAxis = exitAxis;
     t = tExit;
     vi[exitAxis] += stepv[exitAxis];
@@ -907,7 +985,9 @@ VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
 {
   const float *const isovals = iso.isovalues;
   const uint32_t numIsovalues = iso.numIsovalues;
-  const float margin = 2.f * iso.stepSize; // ~one voxel, to cover the exit face
+  // ~one voxel, to cover the exit face. iso.stepSize is object-space; objRay.dir
+  // is non-unit under instance scaling, so convert to ray-t units.
+  const float margin = 2.f * iso.stepSize / length(objRay.dir);
 
   GridTraversal mc(objRay, field.grid.dims, field.grid.objectBounds);
   while (mc.valid()) {
@@ -940,11 +1020,12 @@ VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
 }
 
 // Voxel-DDA isosurface intersection for built-in grids. Concrete grid samplers
-// run the two-level macrocell-skip + voxel-DDA for nearest filtering, and the
-// fixed-step ray march for linear (smooth) surfaces. The generic form is the
-// ray-march hook for fields without analytic voxel boundaries (e.g. custom
-// fields); built-in fields are currently gated to require a space-skipping grid
-// in Isosurface::finalize, so it is unused here today.
+// run the two-level macrocell-skip + per-voxel DDA for BOTH filters: nearest
+// does the piecewise-constant face test, linear solves the per-voxel trilinear
+// cubic (linearCrossing). The fixed-step ray march below is no longer reached by
+// built-in fields. This generic form is the ray-march fallback for fields
+// without analytic voxel boundaries (e.g. custom fields); built-in fields are
+// gated to require a space-skipping grid in Isosurface::finalize.
 template <typename SamplerState>
 VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const SpatialFieldGPUData &field,
@@ -961,10 +1042,9 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  if (st.filter != SpatialFieldFilter::Nearest)
-    marchIsosurface(iso, field, st, objRay, ss);
-  else
-    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+  // Both filters traverse the voxel-DDA now: nearest does the face test, linear
+  // solves the per-voxel cubic (the fixed-step march is no longer reached).
+  marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
 template <typename ValueType>
@@ -974,10 +1054,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  if (st.filter != SpatialFieldFilter::Nearest)
-    marchIsosurface(iso, field, st, objRay, ss);
-  else
-    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
 VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
@@ -986,10 +1064,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  if (st.filter != SpatialFieldFilter::Nearest)
-    marchIsosurface(iso, field, st, objRay, ss);
-  else
-    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
 template <typename ValueType>
@@ -999,10 +1075,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  if (st.filter != SpatialFieldFilter::Nearest)
-    marchIsosurface(iso, field, st, objRay, ss);
-  else
-    marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
 VISRTX_DEVICE void intersectIsosurface(const GeometryGPUData &geometryData)

--- a/devices/rtx/device/geometry/Isosurface.cpp
+++ b/devices/rtx/device/geometry/Isosurface.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Isosurface.h"
+#include "IsosurfaceBricks.h"
+
+namespace visrtx {
+
+// hitKind is a 7-bit OptiX field; the matched isovalue index must fit.
+static constexpr uint32_t MAX_ISOVALUES = 128;
+static_assert(MAX_ISOVALUES <= 128,
+    "isovalue index is packed into OptiX's 7-bit hitKind; must fit in [0,127]");
+
+Isosurface::Isosurface(DeviceGlobalState *d)
+    : Geometry(d), m_field(this), m_isovalueArray(this)
+{}
+
+Isosurface::~Isosurface() = default;
+
+void Isosurface::commitParameters()
+{
+  Geometry::commitParameters();
+  m_field = getParamObject<SpatialField>("field");
+  m_isovalueArray = getParamObject<Array1D>("isovalue");
+  m_hasScalarIsovalue =
+      getParam("isovalue", ANARI_FLOAT32, &m_isovalueScalar);
+}
+
+void Isosurface::finalize()
+{
+  m_numBricks = 0;
+  m_isovaluesDev = nullptr;
+  m_numIsovalues = 0;
+
+  if (!m_field) {
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "missing required parameter 'field' on isosurface geometry");
+    return;
+  }
+  if (m_field->m_uniformGrid.m_valueRanges == nullptr) {
+    // The field's space-skipping grid isn't built yet; a field committed before
+    // this geometry re-triggers finalize via the field ChangeObserverPtr once
+    // its grid is ready. (Custom fields build the grid in their finalize too.)
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "isosurface 'field' space-skipping grid not ready; nothing will render "
+        "yet");
+    return;
+  }
+  if (!m_isovalueArray && !m_hasScalarIsovalue) {
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "missing required parameter 'isovalue' on isosurface geometry");
+    return;
+  }
+  if (m_isovalueArray && m_isovalueArray->size() == 0) {
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "empty 'isovalue' array on isosurface geometry; one or more values are "
+        "required, nothing will render");
+    return;
+  }
+  if (m_isovalueArray && m_isovalueArray->elementType() != ANARI_FLOAT32) {
+    // beginAs<float>() only asserts the element type, so under NDEBUG a non-
+    // FLOAT32 array would be silently reinterpreted as float garbage. Reject it.
+    reportMessage(ANARI_SEVERITY_WARNING,
+        "isosurface 'isovalue' array must be ANARI_FLOAT32; nothing will render");
+    return;
+  }
+
+  // Resolve the device isovalue array (array form preferred).
+  if (m_isovalueArray) {
+    m_numIsovalues = uint32_t(m_isovalueArray->size());
+    if (m_numIsovalues > MAX_ISOVALUES) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+          "isosurface 'isovalue' array has %u entries; clamping to %u",
+          m_numIsovalues,
+          MAX_ISOVALUES);
+      m_numIsovalues = MAX_ISOVALUES;
+    }
+    m_isovaluesDev = m_isovalueArray->beginAs<float>(AddressSpace::GPU);
+  } else {
+    m_numIsovalues = 1;
+    m_scalarIsovalueBuffer.reserve(sizeof(float));
+    m_scalarIsovalueBuffer.upload(&m_isovalueScalar, 1);
+    m_isovaluesDev = (const float *)m_scalarIsovalueBuffer.ptr();
+  }
+
+  dropUndersizedPrimitiveArrays();
+
+  // Coarse active-region BLAS: a small set of bricks tightly bounding the
+  // active macrocells, so the BVH culls rays missing the surface while the
+  // in-program DDA still does fine per-cell skipping inside each brick.
+  auto &state = *deviceState();
+  m_numBricks = buildIsosurfaceBricks(state.stream,
+      m_field->m_uniformGrid.gpuData(),
+      m_isovaluesDev,
+      m_numIsovalues,
+      m_aabbs);
+  m_aabbsBufferPtr = (CUdeviceptr)m_aabbs.ptr();
+
+  reportMessage(ANARI_SEVERITY_DEBUG,
+      "finalizing isosurface geometry: %u isovalue(s), %zu active bricks",
+      m_numIsovalues,
+      m_numBricks);
+
+  upload();
+}
+
+void Isosurface::dropUndersizedPrimitiveArrays()
+{
+  auto dropIfShort = [&](helium::IntrusivePtr<Array1D> &array,
+                         const char *name) {
+    if (array && array->size() < m_numIsovalues) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+          "isosurface '%s' array has %zu element(s) but the geometry has %u "
+          "isovalue(s); ignoring it",
+          name,
+          array->size(),
+          m_numIsovalues);
+      array = {};
+    }
+  };
+
+  dropIfShort(m_primitiveAttributes.attribute0, "primitive.attribute0");
+  dropIfShort(m_primitiveAttributes.attribute1, "primitive.attribute1");
+  dropIfShort(m_primitiveAttributes.attribute2, "primitive.attribute2");
+  dropIfShort(m_primitiveAttributes.attribute3, "primitive.attribute3");
+  dropIfShort(m_primitiveAttributes.color, "primitive.color");
+  dropIfShort(m_primitiveId, "primitive.id");
+}
+
+bool Isosurface::isValid() const
+{
+  return m_field && m_field->isValid()
+      && m_field->m_uniformGrid.m_valueRanges != nullptr
+      && ((m_isovalueArray && m_isovalueArray->size() > 0) || m_hasScalarIsovalue);
+}
+
+void Isosurface::populateBuildInput(OptixBuildInput &buildInput) const
+{
+  buildInput.type = OPTIX_BUILD_INPUT_TYPE_CUSTOM_PRIMITIVES;
+  buildInput.customPrimitiveArray.numPrimitives = uint32_t(m_numBricks);
+  // OptiX requires a null aabb buffer when there are no primitives. An empty
+  // isosurface (isovalue outside the field's value range) has zero active
+  // bricks; passing the (non-null) buffer with numPrimitives == 0 is a fatal
+  // ACCEL build error.
+  buildInput.customPrimitiveArray.aabbBuffers =
+      m_numBricks ? &m_aabbsBufferPtr : nullptr;
+
+  static uint32_t buildInputFlags[1] = {OPTIX_GEOMETRY_FLAG_NONE};
+  buildInput.customPrimitiveArray.flags = buildInputFlags;
+  buildInput.customPrimitiveArray.numSbtRecords = 1;
+}
+
+GeometryGPUData Isosurface::gpuData() const
+{
+  auto retval = Geometry::gpuData();
+  retval.type = GeometryType::ISOSURFACE;
+
+  auto &iso = retval.isosurface;
+  iso.field = m_field->index();
+  iso.isovalues = m_isovaluesDev;
+  iso.numIsovalues = m_numIsovalues;
+  iso.brickBounds = (const box3 *)m_aabbs.ptr();
+  iso.stepSize = m_field->stepSize();
+
+  return retval;
+}
+
+int Isosurface::optixGeometryType() const
+{
+  return OPTIX_BUILD_INPUT_TYPE_CUSTOM_PRIMITIVES;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/geometry/Isosurface.h
+++ b/devices/rtx/device/geometry/Isosurface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,48 +31,44 @@
 
 #pragma once
 
+#include "Geometry.h"
 #include "array/Array1D.h"
-#include "array/Array3D.h"
 #include "spatial_field/SpatialField.h"
+#include "utility/DeviceBuffer.h"
 
 namespace visrtx {
 
-struct StructuredRectilinearField : public SpatialField
+struct Isosurface : public Geometry
 {
-  StructuredRectilinearField(DeviceGlobalState *d);
-  ~StructuredRectilinearField();
+  Isosurface(DeviceGlobalState *d);
+  ~Isosurface() override;
 
   void commitParameters() override;
   void finalize() override;
   bool isValid() const override;
 
-  box3 bounds() const override;
-  float stepSize() const override;
+  void populateBuildInput(OptixBuildInput &) const override;
+  int optixGeometryType() const override;
 
  private:
-  SpatialFieldGPUData gpuData() const override;
-  void cleanup();
+  GeometryGPUData gpuData() const override;
 
-  void buildGrid();
+  // Drops any per-primitive array shorter than m_numIsovalues (warns), so the
+  // GPU never indexes a primitive attribute out of bounds.
+  void dropUndersizedPrimitiveArrays();
 
-  std::string m_filter;
-  bool m_cellCentered{false};
-  box3 m_roi{box3(vec3(std::numeric_limits<float>::lowest()),
-      vec3(std::numeric_limits<float>::max()))};
-  helium::ChangeObserverPtr<Array3D> m_data;
+  helium::ChangeObserverPtr<SpatialField> m_field;
+  helium::ChangeObserverPtr<Array1D> m_isovalueArray;
+  float m_isovalueScalar{0.f};
+  bool m_hasScalarIsovalue{false};
 
-  // Required rectilinear axis arrays (all 3 required)
-  box3 m_bounds;
-  helium::ChangeObserverPtr<Array1D> m_axisArrayX;
-  helium::ChangeObserverPtr<Array1D> m_axisArrayY;
-  helium::ChangeObserverPtr<Array1D> m_axisArrayZ;
-  cudaArray_t m_axisLutArrays[3]{};
-  cudaTextureObject_t m_axisLutTextures[3]{};
-  cudaArray_t m_invAxisLutArrays[3]{};
-  cudaTextureObject_t m_invAxisLutTextures[3]{};
+  DeviceBuffer m_scalarIsovalueBuffer; // holds the single scalar on device
+  DeviceBuffer m_aabbs; // coarse active-region brick boxes (object space)
+  CUdeviceptr m_aabbsBufferPtr{};
+  size_t m_numBricks{0};
 
-  cudaArray_t m_cudaArray{};
-  cudaTextureObject_t m_textureObject{};
+  const float *m_isovaluesDev{nullptr};
+  uint32_t m_numIsovalues{0};
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/geometry/IsosurfaceBricks.cu
+++ b/devices/rtx/device/geometry/IsosurfaceBricks.cu
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "IsosurfaceBricks.h"
+#include "gpu/gpu_math.h"
+// thrust
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+
+namespace visrtx {
+
+// Macrocells per brick edge. Larger -> fewer, looser bricks (cheaper/smaller
+// BVH, weaker culling); 1 -> one primitive per macrocell. A field with fewer
+// than BRICK_SIZE macrocells per axis collapses to a single brick (= the whole
+// field bounds), matching the single-primitive path.
+static constexpr int BRICK_SIZE = 4;
+
+__global__ void buildBricksGPU(box3 *bricks,
+    uint8_t *flags,
+    UniformGridData grid,
+    const float *isovalues,
+    uint32_t numIsovalues,
+    ivec3 brickDims)
+{
+  const size_t b = blockIdx.x * size_t(blockDim.x) + threadIdx.x;
+  const size_t n = size_t(brickDims.x) * brickDims.y * brickDims.z;
+  if (b >= n)
+    return;
+
+  const ivec3 brick(b % brickDims.x,
+      (b / brickDims.x) % brickDims.y,
+      b / (size_t(brickDims.x) * brickDims.y));
+
+  const vec3 gridSize = grid.objectBounds.upper - grid.objectBounds.lower;
+  const ivec3 mcBegin = brick * BRICK_SIZE;
+  const ivec3 mcEnd = min(mcBegin + ivec3(BRICK_SIZE), grid.dims);
+
+  bool active = false;
+  vec3 lo(3.0e38f);
+  vec3 hi(-3.0e38f);
+  for (int z = mcBegin.z; z < mcEnd.z; ++z) {
+    for (int y = mcBegin.y; y < mcEnd.y; ++y) {
+      for (int x = mcBegin.x; x < mcEnd.x; ++x) {
+        const size_t i =
+            x + size_t(grid.dims.x) * (y + size_t(grid.dims.y) * z);
+        const box1 vr = grid.valueRanges[i];
+        if (!(vr.lower <= vr.upper))
+          continue;
+        bool cellActive = false;
+        for (uint32_t k = 0; k < numIsovalues; ++k) {
+          const float iv = isovalues[k];
+          if (iv >= vr.lower && iv <= vr.upper) {
+            cellActive = true;
+            break;
+          }
+        }
+        if (!cellActive)
+          continue;
+        active = true;
+        const ivec3 mc(x, y, z);
+        lo = min(lo,
+            grid.objectBounds.lower + (vec3(mc) / vec3(grid.dims)) * gridSize);
+        hi = max(hi,
+            grid.objectBounds.lower
+                + (vec3(mc + ivec3(1)) / vec3(grid.dims)) * gridSize);
+      }
+    }
+  }
+
+  flags[b] = active ? uint8_t(1) : uint8_t(0);
+  bricks[b] = active ? box3(lo, hi) : box3(vec3(0.f), vec3(0.f));
+}
+
+size_t buildIsosurfaceBricks(cudaStream_t stream,
+    const UniformGridData &grid,
+    const float *isovaluesDev,
+    uint32_t numIsovalues,
+    DeviceBuffer &outAabbs)
+{
+  if (grid.valueRanges == nullptr || isovaluesDev == nullptr
+      || numIsovalues == 0 || grid.dims.x <= 0 || grid.dims.y <= 0
+      || grid.dims.z <= 0)
+    return 0;
+
+  const ivec3 brickDims(iDivUp(grid.dims.x, BRICK_SIZE),
+      iDivUp(grid.dims.y, BRICK_SIZE),
+      iDivUp(grid.dims.z, BRICK_SIZE));
+  const size_t n = size_t(brickDims.x) * brickDims.y * brickDims.z;
+
+  thrust::device_vector<box3> dense(n);
+  thrust::device_vector<uint8_t> flags(n);
+
+  const size_t threads = 256;
+  buildBricksGPU<<<iDivUp(n, threads), threads, 0, stream>>>(
+      thrust::raw_pointer_cast(dense.data()),
+      thrust::raw_pointer_cast(flags.data()),
+      grid,
+      isovaluesDev,
+      numIsovalues,
+      brickDims);
+
+  outAabbs.reserve(n * sizeof(box3));
+  auto outBegin = thrust::device_pointer_cast<box3>((box3 *)outAabbs.ptr());
+  auto outEnd = thrust::copy_if(thrust::cuda::par.on(stream),
+      dense.begin(),
+      dense.end(),
+      flags.begin(),
+      outBegin,
+      [] __device__(uint8_t f) { return f != uint8_t(0); });
+
+  return size_t(outEnd - outBegin);
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/geometry/IsosurfaceBricks.h
+++ b/devices/rtx/device/geometry/IsosurfaceBricks.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include "gpu/gpu_objects.h"
+#include "utility/DeviceBuffer.h"
+// cuda
+#include <cuda_runtime.h>
+
+namespace visrtx {
+
+// Builds a coarse "active-region" BLAS for an isosurface: the field's macrocell
+// grid is tiled into bricks (BRICK_SIZE macrocells per edge); each brick that
+// contains a macrocell whose value range brackets an isovalue is emitted as one
+// AABB tightly bounding its active macrocells. This lets the BVH cull rays that
+// miss the active region while keeping the primitive count far below one box
+// per macrocell; the intersection program's DDA does the fine per-cell skipping
+// inside each brick. Returns the number of active bricks (compacted into
+// outAabbs as box3). Returns 0 (and writes nothing) for an empty active set.
+size_t buildIsosurfaceBricks(cudaStream_t stream,
+    const UniformGridData &grid,
+    const float *isovaluesDev,
+    uint32_t numIsovalues,
+    DeviceBuffer &outAabbs);
+
+} // namespace visrtx

--- a/devices/rtx/device/geometry/IsosurfaceLinear.h
+++ b/devices/rtx/device/geometry/IsosurfaceLinear.h
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include "gpu/gpu_decl.h"  // VISRTX_DEVICE (== inline on host)
+#include <glm/glm.hpp>
+#include <cstdint>
+
+namespace visrtx {
+
+using glm::vec3;
+
+// Incomplete is sufficient: linearCrossing only forwards `field` by reference to
+// the per-sampler sampleValue()/sampleNormal() hooks (resolved at instantiation
+// in device code). Forward-declaring keeps this header host-parseable without
+// the device-only gpu_objects.h (which pulls in OptiX/CUDA).
+struct SpatialFieldGPUData;
+
+// Trilinear interpolant of the 8 cell corners at local coord u in [0,1]^3.
+// Corner index: c[i + 2*j + 4*k] is the value at local corner (i,j,k).
+VISRTX_DEVICE float trilinearValue(const float c[8], const vec3 &u)
+{
+  const float x = u.x, y = u.y, z = u.z, X = 1.f - x, Y = 1.f - y, Z = 1.f - z;
+  return c[0] * X * Y * Z + c[1] * x * Y * Z + c[2] * X * y * Z + c[3] * x * y * Z
+      + c[4] * X * Y * z + c[5] * x * Y * z + c[6] * X * y * z + c[7] * x * y * z;
+}
+
+namespace detail {
+constexpr float kCoeffDegenerateEps = 1e-12f; // |leading coeff| below this drops a degree
+constexpr float kExtremumMargin = 1e-5f;       // ignore g' roots within this of an endpoint
+constexpr float kRootTolerance = 1e-6f;        // |g| below this counts as a root
+constexpr int kRootRefineIters = 8;            // false-position refinement steps
+} // namespace detail
+
+// Monomial form of the cubic through the fixed nodes {0,1/3,2/3,1} plus the
+// monotone-span boundaries (roots of g' partitioning [0,1]). Splitting prepare
+// from solve lets a voxel with N isovalues fit the cubic + extrema ONCE: across
+// isovalues the cubic only shifts by the constant -iso, so k1,k2,k3 — and hence
+// g' and its roots — are isovalue-independent; only k0 moves.
+struct CubicPrep
+{
+  float k0, k1, k2, k3; // g(s) = ((k3 s + k2) s + k1) s + k0
+  float bound[4]; // monotone-span boundaries; `nb` of them used, in [0,1]
+  int nb;
+};
+
+// Fit the cubic through the four node VALUES (constant inverse Vandermonde) and
+// partition [0,1] at g's extrema. Isovalue-independent — call once per voxel.
+VISRTX_DEVICE CubicPrep prepareCubic(float n0, float n1, float n2, float n3)
+{
+  CubicPrep p;
+  p.k0 = n0;
+  p.k1 = -5.5f * n0 + 9.f * n1 - 4.5f * n2 + n3;
+  p.k2 = 9.f * n0 - 22.5f * n1 + 18.f * n2 - 4.5f * n3;
+  p.k3 = -4.5f * n0 + 13.5f * n1 - 13.5f * n2 + 4.5f * n3;
+
+  // Build up to 4 monotone-span boundaries [0, e0, e1, 1] from g' roots.
+  p.bound[0] = 0.f; p.bound[1] = 1.f; p.bound[2] = 1.f; p.bound[3] = 1.f;
+  p.nb = 2;
+  const float a = 3.f * p.k3, b = 2.f * p.k2, cc = p.k1; // g'(s)=a s^2+b s+c
+  if (fabsf(a) > detail::kCoeffDegenerateEps) {
+    const float disc = b * b - 4.f * a * cc;
+    if (disc > 0.f) {
+      const float sq = sqrtf(disc);
+      float r0 = (-b - sq) / (2.f * a), r1 = (-b + sq) / (2.f * a);
+      if (r0 > r1) { const float t = r0; r0 = r1; r1 = t; }
+      float tmp[4]; int n = 0;
+      tmp[n++] = 0.f;
+      if (r0 > detail::kExtremumMargin && r0 < 1.f - detail::kExtremumMargin) tmp[n++] = r0;
+      if (r1 > detail::kExtremumMargin && r1 < 1.f - detail::kExtremumMargin) tmp[n++] = r1;
+      tmp[n++] = 1.f;
+      for (int i = 0; i < n; ++i) p.bound[i] = tmp[i];
+      p.nb = n;
+    }
+  } else if (fabsf(b) > detail::kCoeffDegenerateEps) {
+    const float r = -cc / b;
+    if (r > detail::kExtremumMargin && r < 1.f - detail::kExtremumMargin) { p.bound[1] = r; p.bound[2] = 1.f; p.nb = 3; }
+  }
+  return p;
+}
+
+// Smallest root in [0,1] of (prepared cubic) - iso. Reuses the prepared spans;
+// only the constant term shifts by -iso. Returns false on no crossing.
+VISRTX_DEVICE bool solveCubic(const CubicPrep &p, float iso, float &outS)
+{
+  const float k0 = p.k0 - iso;
+  auto gc = [&](float s) { return ((p.k3 * s + p.k2) * s + p.k1) * s + k0; };
+
+  // First monotone span with a sign change -> regula-falsi to the root.
+  for (int i = 0; i + 1 < p.nb; ++i) {
+    float lo = p.bound[i], hi = p.bound[i + 1];
+    float glo = gc(lo), ghi = gc(hi);
+    if (glo == 0.f) { outS = lo; return true; }
+    if ((glo < 0.f) == (ghi < 0.f)) continue;
+    // Illinois-modified false position: halving the retained endpoint's value
+    // breaks one-sided stagnation so the bracket shrinks from both ends and m
+    // converges superlinearly. glo,ghi have opposite signs here, so
+    // ghi-glo = |glo|+|ghi| > 0 and m is strictly inside [lo,hi].
+    float m; // assigned by the false-position step below before any use
+    for (int it = 0; it < detail::kRootRefineIters; ++it) {
+      m = (lo * ghi - hi * glo) / (ghi - glo);
+      const float gm = gc(m);
+      if (fabsf(gm) < detail::kRootTolerance) { outS = m; return true; }
+      if ((gm < 0.f) == (glo < 0.f)) { // gm on lo's side: advance lo, retain hi
+        lo = m; glo = gm; ghi *= 0.5f;
+      } else { // gm on hi's side: advance hi, retain lo
+        hi = m; ghi = gm; glo *= 0.5f;
+      }
+    }
+    // The bracket already proved a sign change, so a root exists; after the
+    // bounded Illinois iterations the latest iterate is the best estimate (no
+    // residual gate needed -- the return is intentional).
+    outS = m; // converged estimate (two-sided shrink), not the bracket midpoint
+    return true;
+  }
+  return false;
+}
+
+// Smallest root in [0,1] of the cubic sampled at {0,1/3,2/3,1} as g0..g3 (already
+// iso-subtracted). Thin prepare+solve wrapper, kept for the host unit test.
+VISRTX_DEVICE bool firstCubicRoot(
+    float g0, float g1, float g2, float g3, float &outS)
+{
+  return solveCubic(prepareCubic(g0, g1, g2, g3), 0.f, outS);
+}
+
+// Convenience wrapper: smallest root in [0,1] of trilinear(lerp(aEntry,aExit,s))
+// - iso, sampling the cubic at the four fixed nodes. (Exercised by the host
+// unit test; the device path samples the field directly via linearCrossing.)
+VISRTX_DEVICE bool firstTrilinearRoot(
+    const float c[8], const vec3 &aEntry, const vec3 &aExit, float iso, float &outS)
+{
+  const vec3 d = aExit - aEntry;
+  return firstCubicRoot(trilinearValue(c, aEntry) - iso,
+      trilinearValue(c, aEntry + (1.f / 3.f) * d) - iso,
+      trilinearValue(c, aEntry + (2.f / 3.f) * d) - iso,
+      trilinearValue(c, aExit) - iso,
+      outS);
+}
+
+// Shared narrow-phase for one voxel under linear filtering. tEntry/tExit bound
+// the voxel along the ray; vEntry/vExit are the field values there (hybrid
+// bracket, carried by the caller). For each isovalue that straddles the bracket
+// it fits the field's cubic from hardware samples and solves; the nearest
+// crossing across isovalues wins. Writes the hit t, oriented+normalized object
+// normal, and isovalue index; returns true on a hit. sampleValue/sampleNormal
+// are resolved per-sampler by ADL at instantiation.
+template <typename S>
+VISRTX_DEVICE bool linearCrossing(const S &state,
+    const SpatialFieldGPUData &field,
+    const vec3 &ro,
+    const vec3 &rd,
+    float tEntry,
+    float tExit,
+    float vEntry,
+    float vExit,
+    const float *isovals,
+    uint32_t numIsovalues,
+    float &outT,
+    vec3 &outNormal,
+    uint32_t &outIdx)
+{
+  const float lo = fminf(vEntry, vExit), hi = fmaxf(vEntry, vExit);
+
+  // Hybrid bracket: only sample/solve when an isovalue straddles the segment
+  // ends. The carried endpoint values (vEntry/vExit) avoid re-fetching them.
+  bool bracketed = false;
+  for (uint32_t i = 0; i < numIsovalues; ++i)
+    if (isovals[i] >= lo && isovals[i] <= hi) {
+      bracketed = true;
+      break;
+    }
+  if (!bracketed)
+    return false;
+
+  // Fit the field along the ray from 4 hardware samples: trilinear-along-a-ray
+  // is cubic, and sampling the field directly (like the old march) avoids the
+  // per-cell corner reconstruction whose half-texel cell mismatch faceted the
+  // surface (AO crease lattice). Endpoints reuse vEntry/vExit; sample the two
+  // interior nodes.
+  const float dt = tExit - tEntry;
+  const float f0 = vEntry;
+  const float f1 = sampleValue(state, field, ro + (tEntry + dt * (1.f / 3.f)) * rd);
+  const float f2 = sampleValue(state, field, ro + (tEntry + dt * (2.f / 3.f)) * rd);
+  const float f3 = vExit;
+
+  // Fit the cubic + extrema once; only k0 shifts per isovalue (solveCubic).
+  const CubicPrep prep = prepareCubic(f0, f1, f2, f3);
+
+  float bestS = 2.f;
+  uint32_t bestIdx = 0;
+  for (uint32_t i = 0; i < numIsovalues; ++i) {
+    const float iv = isovals[i];
+    if (iv < lo || iv > hi)
+      continue;
+    float s;
+    if (solveCubic(prep, iv, s) && s < bestS) {
+      bestS = s;
+      bestIdx = i;
+    }
+  }
+
+  if (bestS > 1.f)
+    return false;
+
+  outT = tEntry + bestS * dt;
+  // Central-difference gradient (sampleNormal): smooth across cells, the same
+  // normal the volume integrator uses.
+  const vec3 pHit = ro + outT * rd;
+  vec3 n = sampleNormal(state, field, pHit);
+  // A (near-)zero gradient at a field extremum/saddle makes normalize(n) NaN,
+  // which poisons shading. Fall back to facing the incoming ray.
+  if (dot(n, n) < 1e-12f) {
+    outNormal = normalize(-rd);
+  } else {
+    if (dot(n, rd) > 0.f)
+      n = -n;
+    outNormal = normalize(n);
+  }
+  outIdx = bestIdx;
+  return true;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/geometry/IsosurfaceLinear.h
+++ b/devices/rtx/device/geometry/IsosurfaceLinear.h
@@ -137,6 +137,20 @@ VISRTX_DEVICE bool firstTrilinearRoot(
       outS);
 }
 
+// Object-space field gradient at a linear-isosurface hit. The hit value is
+// already known (≈ the matched isovalue, vHit), so NanoVDB grids override this
+// with a forward difference reusing vHit -- 3 taps vs central difference's 6,
+// still spanning into the neighbour cell so it stays smooth (unlike the faceted
+// per-cell analytic gradient). The generic fallback is the shared central-
+// difference sampleNormal (structured/raw is hardware tex3D, already cheap; the
+// volume integrator keeps its own sampleNormal). Resolved by ADL at instantiation.
+template <typename S>
+VISRTX_DEVICE vec3 isosurfaceHitGradient(
+    const S &state, const SpatialFieldGPUData &field, const vec3 &p, float /*vHit*/)
+{
+  return sampleNormal(state, field, p);
+}
+
 // Shared narrow-phase for one voxel under linear filtering. tEntry/tExit bound
 // the voxel along the ray; vEntry/vExit are the field values there (hybrid
 // bracket, carried by the caller). For each isovalue that straddles the bracket
@@ -203,10 +217,10 @@ VISRTX_DEVICE bool linearCrossing(const S &state,
     return false;
 
   outT = tEntry + bestS * dt;
-  // Central-difference gradient (sampleNormal): smooth across cells, the same
-  // normal the volume integrator uses.
+  // Forward-difference gradient reusing the hit value (isovals[bestIdx]); see
+  // isosurfaceHitGradient. NanoVDB: 3 taps; others fall back to central diff.
   const vec3 pHit = ro + outT * rd;
-  vec3 n = sampleNormal(state, field, pHit);
+  vec3 n = isosurfaceHitGradient(state, field, pHit, isovals[bestIdx]);
   // A (near-)zero gradient at a field extremum/saddle makes normalize(n) NaN,
   // which poisons shading. Fall back to facing the incoming ray.
   if (dot(n, n) < 1e-12f) {

--- a/devices/rtx/device/geometry/IsosurfaceSample.h
+++ b/devices/rtx/device/geometry/IsosurfaceSample.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+// Inline field sampling for the isosurface intersector. Built-in fields are
+// sampled through their concrete inline samplers (no OptiX callable). The
+// Init/Sample direct callables exist only for external custom fields, which
+// are out of scope here.
+//
+// VISRTX_ISOSURFACE_FIELD_VARIANTS is the single source of truth for the
+// supported built-in fields; the intersector expands it once to dispatch on
+// the concrete sampler (no per-sample switch).
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/sbt.h"
+#include "gpu/shadingState.h"
+#include "spatial_field/NvdbRectilinearSamplerInline.h"
+#include "spatial_field/NvdbRegularSamplerInline.h"
+#include "spatial_field/StructuredRectilinearSamplerInline.h"
+#include "spatial_field/StructuredRegularSamplerInline.h"
+
+namespace visrtx {
+
+// (sbt entry point, VolumeSamplingState union member, init fn). Sampling goes
+// through the shared sampleValue/sampleNormal overloads, resolved by ADL on the
+// concrete state type, so no per-variant sample fn is needed here.
+#define VISRTX_ISOSURFACE_FIELD_VARIANTS                                       \
+  X(SpatialFieldSamplerRegular, structuredRegular, initStructuredRegularSampler)\
+  X(SpatialFieldSamplerRectilinear, structuredRectilinear,                     \
+      initStructuredRectilinearSampler)                                        \
+  X(SpatialFieldSamplerNvdbFp4, nvdbFp4, initNvdbSampler)                      \
+  X(SpatialFieldSamplerNvdbFp8, nvdbFp8, initNvdbSampler)                      \
+  X(SpatialFieldSamplerNvdbFp16, nvdbFp16, initNvdbSampler)                    \
+  X(SpatialFieldSamplerNvdbFpN, nvdbFpN, initNvdbSampler)                      \
+  X(SpatialFieldSamplerNvdbFloat, nvdbFloat, initNvdbSampler)                  \
+  X(SpatialFieldSamplerNvdbRectilinearFp4, nvdbRectilinearFp4,                 \
+      initNvdbRectilinearSampler)                                             \
+  X(SpatialFieldSamplerNvdbRectilinearFp8, nvdbRectilinearFp8,                 \
+      initNvdbRectilinearSampler)                                             \
+  X(SpatialFieldSamplerNvdbRectilinearFp16, nvdbRectilinearFp16,               \
+      initNvdbRectilinearSampler)                                             \
+  X(SpatialFieldSamplerNvdbRectilinearFpN, nvdbRectilinearFpN,                 \
+      initNvdbRectilinearSampler)                                             \
+  X(SpatialFieldSamplerNvdbRectilinearFloat, nvdbRectilinearFloat,             \
+      initNvdbRectilinearSampler)
+
+} // namespace visrtx

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -131,6 +131,7 @@ enum class GeometryType
   SPHERE,
   SDF,
   NEURAL,
+  ISOSURFACE,
   UNKNOWN
 };
 
@@ -245,6 +246,21 @@ struct SphereGeometryData
   float radius;
 };
 
+// Value-only bisection steps used to refine an isosurface crossing within one
+// march step. The hit is localized to the final bracket, stepSize/2^iters; the
+// secondary-ray offset (populateSurfaceHit) is derived from this so AO/shadow
+// rays clear the marched surface instead of self-occluding (acne).
+constexpr int kIsosurfaceBisectionIters = 6;
+
+struct IsosurfaceGeometryData
+{
+  DeviceObjectIndex field; // index into frameData.registry.fields
+  const float *isovalues; // device array, length numIsovalues
+  uint32_t numIsovalues; // <= 128 (hitKind carrier limit)
+  const box3 *brickBounds; // per-GAS-primitive coarse brick box, object space
+  float stepSize; // march step, captured from field->stepSize()
+};
+
 #ifdef VISRTX_USE_NEURAL
 
 constexpr uint32_t NEURAL_NB_MAX_LAYERS = 5;
@@ -275,6 +291,7 @@ struct GeometryGPUData
     ConeGeometryData cone;
     SphereGeometryData sphere;
     SDFGeometryData sdf;
+    IsosurfaceGeometryData isosurface;
 #ifdef VISRTX_USE_NEURAL
     NeuralGeometryData neural;
 #endif
@@ -476,21 +493,22 @@ struct UniformGridData
                          // lookup.
 };
 
-struct StructuredRegularData
-{
-  cudaTextureObject_t texObj;
-  vec3 origin;
-  vec3 invDims;
-  vec3 invSpacing;
-  bool cellCentered;
-
-  StructuredRegularData() = default;
-};
-
 enum class SpatialFieldFilter : uint8_t
 {
   Nearest = 0,
   Linear = 1
+};
+
+struct StructuredRegularData
+{
+  cudaTextureObject_t texObj;
+  vec3 origin;
+  vec3 invSpacing;
+  ivec3 dims; // voxel (texel) counts — drives the isosurface voxel-DDA
+  bool cellCentered;
+  SpatialFieldFilter filter;
+
+  StructuredRegularData() = default;
 };
 
 struct NVdbRegularData
@@ -510,9 +528,11 @@ struct StructuredRectilinearData
   cudaTextureObject_t texObj;
   vec3 dims;
   bool cellCentered;
-  cudaTextureObject_t axisLUT[3];
+  cudaTextureObject_t axisLUT[3]; // object -> index (sampling)
+  cudaTextureObject_t invAxisLUT[3]; // index -> object (isosurface voxel-DDA)
   vec3 axisBoundsMin;
   vec3 axisBoundsMax;
+  SpatialFieldFilter filter;
 
   StructuredRectilinearData() = default;
 };
@@ -523,7 +543,8 @@ struct NVdbRectilinearData
   const void *gridData;
   bool cellCentered;
   SpatialFieldFilter filter;
-  cudaTextureObject_t axisLUT[3];
+  cudaTextureObject_t axisLUT[3]; // normalized uniform index -> rectilinear index
+  cudaTextureObject_t invAxisLUT[3]; // inverse (isosurface voxel-DDA)
   vec3 invAvgVoxelSize;
 
   NVdbRectilinearData() = default;

--- a/devices/rtx/device/gpu/gridTraversal.h
+++ b/devices/rtx/device/gpu/gridTraversal.h
@@ -41,9 +41,10 @@ namespace visrtx {
 // reading cellIndex / tEntry / tExit each iteration and calling next().
 struct GridTraversal
 {
-  int cellIndex;
+  size_t cellIndex; // size_t: the linear index overflows int32 above ~2^31 cells
   float tEntry;
   float tExit;
+  int crossedAxis; // axis of the face the ray entered the current cell through
 
   VISRTX_DEVICE GridTraversal(const Ray &ray, ivec3 gridDims, box3 bounds)
       : m_gridDims(gridDims), m_tEnd(ray.t.upper), m_valid(false)
@@ -60,13 +61,18 @@ struct GridTraversal
     constexpr float inf = std::numeric_limits<float>::infinity();
     float tIn = -inf;
     float tOut = inf;
+    crossedAxis = 0;
     vec3 rcpDir;
     for (int axis = 0; axis < 3; ++axis) {
       if (ray.dir[axis] != 0.f) {
         rcpDir[axis] = 1.f / ray.dir[axis];
         const float t1 = (bounds.lower[axis] - ray.org[axis]) * rcpDir[axis];
         const float t2 = (bounds.upper[axis] - ray.org[axis]) * rcpDir[axis];
-        tIn = max(tIn, min(t1, t2));
+        const float tNear = min(t1, t2);
+        if (tNear > tIn) {
+          tIn = tNear;
+          crossedAxis = axis; // grid is entered through this axis' face
+        }
         tOut = min(tOut, max(t1, t2));
       } else {
         rcpDir[axis] = 0.f;
@@ -128,6 +134,15 @@ struct GridTraversal
  private:
   VISRTX_DEVICE void step(float tNext)
   {
+    // The axis with the smallest tMax is the boundary plane being crossed —
+    // i.e. the face through which the ray enters the next cell.
+    if (m_tMax.x <= m_tMax.y && m_tMax.x <= m_tMax.z)
+      crossedAxis = 0;
+    else if (m_tMax.y <= m_tMax.z)
+      crossedAxis = 1;
+    else
+      crossedAxis = 2;
+
     if (m_tMax.x <= tNext) {
       m_cell.x += m_step.x;
       m_tMax.x += m_tDelta.x;
@@ -154,8 +169,9 @@ struct GridTraversal
 
       const float t1 = min(tNext, m_tEnd);
       if (t1 > m_t) {
-        cellIndex = m_cell.x + m_cell.y * m_gridDims.x
-            + m_cell.z * m_gridDims.x * m_gridDims.y;
+        cellIndex = size_t(m_cell.x)
+            + size_t(m_gridDims.x)
+                * (size_t(m_cell.y) + size_t(m_gridDims.y) * size_t(m_cell.z));
         tEntry = m_t;
         tExit = t1;
         m_valid = true;

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -308,6 +308,7 @@ VISRTX_DEVICE void computeTangentSpace(
     break;
   }
   case GeometryType::SPHERE:
+  case GeometryType::ISOSURFACE:
   case GeometryType::CONE:
   case GeometryType::NEURAL:
   case GeometryType::CYLINDER:
@@ -400,9 +401,27 @@ VISRTX_DEVICE void populateSurfaceHit(SurfaceHit &hit)
   hit.hitpoint = ray::hitpoint();
   hit.uvw = ray::uvw(gd.type);
   hit.primID = ray::primID();
+  if (gd.type == GeometryType::ISOSURFACE)
+    hit.primID = optixGetHitKind();
   hit.objID = sd.id;
   hit.instID = isd.id;
   hit.epsilon = epsilonFrom(ray::hitpoint(), ray::direction(), ray::t());
+  if (gd.type == GeometryType::ISOSURFACE) {
+    // Isosurface hits lie on a voxel-resolution surface — exact voxel faces for
+    // the nearest voxel-DDA, bisection-localized for the marched linear/custom
+    // path. Either way the surface has voxel-scale relief, so a secondary ray
+    // offset by less than a voxel grazes into adjacent voxels and self-occludes
+    // (AO/shadow acne; on blocky nearest surfaces, a per-voxel waffle). stepSize
+    // is half the smallest voxel, so 2*stepSize lifts the ray clear by one.
+    // stepSize is object-space but hit.epsilon is world-space, so under a scaled
+    // instance scale the lift by the object->world distance ratio along the ray:
+    // |worldDir|/|objDir|. optixGetObjectRayDirection is illegal in closest-hit,
+    // so derive objDir from the stored worldToObject linear map instead.
+    const vec3 wdir = ray::direction();
+    const vec3 odir = mat3(hit.instance->worldToObject) * wdir;
+    hit.epsilon = fmaxf(hit.epsilon,
+        2.f * gd.isosurface.stepSize * length(wdir) / length(odir));
+  }
   ray::computeTangentSpace(gd, ray::primID(), hit);
 }
 

--- a/devices/rtx/device/gpu/shadingState.h
+++ b/devices/rtx/device/gpu/shadingState.h
@@ -170,9 +170,10 @@ struct StructuredRegularSamplerState
 {
   cudaTextureObject_t texObj;
   vec3 origin;
-  vec3 invDims;
   vec3 invSpacing;
   vec3 offset;
+  ivec3 dims; // voxel (texel) counts — drives the isosurface voxel-DDA
+  SpatialFieldFilter filter;
 };
 
 // Structured Rectilinear Sampler State
@@ -181,10 +182,12 @@ struct StructuredRectilinearSamplerState
   cudaTextureObject_t texObj;
   vec3 dims;
   vec3 offset;
-  cudaTextureObject_t axisLUT[3];
+  cudaTextureObject_t axisLUT[3]; // object -> index (sampling)
+  cudaTextureObject_t invAxisLUT[3]; // index -> object (isosurface voxel-DDA)
   vec3 axisBoundsMin;
   vec3 axisBoundsMax;
   vec3 invAvgVoxelSpacing;
+  SpatialFieldFilter filter;
 };
 
 // NanoVDB Sampler States
@@ -239,7 +242,12 @@ struct NvdbRectilinearSamplerState
   nanovdb::Vec3f indexMin;
   nanovdb::Vec3f indexMax;
   cudaTextureObject_t axisLUT[3];
+  cudaTextureObject_t invAxisLUT[3]; // rect index -> uniform index (voxel-DDA)
   nanovdb::Vec3f invAvgVoxelSize;
+  // Per-axis affine uniform-index -> world map (axis-aligned grids), so the
+  // isosurface DDA can place voxel-boundary planes in object space.
+  vec3 worldOrigin;
+  vec3 worldVoxelStep;
   SpatialFieldFilter filter;
 };
 

--- a/devices/rtx/device/renderer/Quality_ptx.cu
+++ b/devices/rtx/device/renderer/Quality_ptx.cu
@@ -404,15 +404,14 @@ VISRTX_GLOBAL void __raygen__()
         }
 
         accumulateValue(sample.opacity, 1.0f, sample.opacity);
-        sampleContribution *= volumeSample.albedo;
-        if (shouldTerminatePath(ss,
-                bounceDepth,
-                sampleContribution,
-                true,
-                RUSSIAN_ROULETTE_START_DEPTH_VOLUME,
-                /*maxSurvivalProb=*/0.5f))
-          break;
 
+        // Record first-hit AOVs (object/instance id, depth, albedo, normal)
+        // BEFORE the contribution-based path termination below. A fully opaque
+        // but zero-albedo (black) volume scatters here, then drives
+        // sampleContribution to 0 via the albedo multiply — shouldTerminatePath
+        // would break out before these AOVs were written, leaving the object-id
+        // / depth / normal buffers unset for opaque-black regions. The AOVs are
+        // first-hit metadata, independent of the path's radiance contribution.
         if (isFirstBounce) {
           setPixelIds(frameData.fb,
               ss.pixel,
@@ -427,6 +426,15 @@ VISRTX_GLOBAL void __raygen__()
               : -ray.dir;
           sample.normal = volumeNormal;
         }
+
+        sampleContribution *= volumeSample.albedo;
+        if (shouldTerminatePath(ss,
+                bounceDepth,
+                sampleContribution,
+                true,
+                RUSSIAN_ROULETTE_START_DEPTH_VOLUME,
+                /*maxSurvivalProb=*/0.5f))
+          break;
 
         const vec3 scatterDir = randomDir(ss.rs);
         ray = Ray{scatterPos + scatterDir * VOLUME_SCATTER_EPSILON, scatterDir};

--- a/devices/rtx/device/spatial_field/CustomFieldSamplerInline.h
+++ b/devices/rtx/device/spatial_field/CustomFieldSamplerInline.h
@@ -1,0 +1,54 @@
+// Copyright 2025-2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Custom spatial-field per-sample API. Unlike the built-in inline samplers,
+// the user sample() implementation is compiled into the value/normal
+// direct-callables (CustomFieldSampler_ptx.cu), so sampling routes back through
+// the SBT via optixDirectCall (callable-in-callable). Living in a header lets
+// both the volume integrator (CustomFieldSampler_ptx.cu) and the isosurface
+// intersector (Intersectors_ptx.cu) resolve sampleValue/sampleNormal on
+// VolumeSamplingState by ADL.
+
+#include "gpu/gpu_decl.h"
+#include "gpu/gpu_objects.h"
+#include "gpu/sbt.h"
+#include "gpu/shadingState.h"
+
+#include <optix_device.h>
+
+namespace visrtx {
+
+VISRTX_DEVICE void initSamplerState(
+    VolumeSamplingState &s, const SpatialFieldGPUData &field)
+{
+  optixDirectCall<void>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::Init),
+      &s,
+      &field);
+}
+
+VISRTX_DEVICE float sampleValue(const VolumeSamplingState &s,
+    const SpatialFieldGPUData &field,
+    const vec3 &p)
+{
+  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::SampleValue),
+      &s,
+      &field,
+      &p);
+}
+
+VISRTX_DEVICE vec3 sampleNormal(const VolumeSamplingState &s,
+    const SpatialFieldGPUData &field,
+    const vec3 &p)
+{
+  return optixDirectCall<vec3>(uint32_t(field.samplerCallableIndex)
+          + uint32_t(SpatialFieldSamplerEntryPoints::SampleNormal),
+      &s,
+      &field,
+      &p);
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/spatial_field/CustomFieldSampler_ptx.cu
+++ b/devices/rtx/device/spatial_field/CustomFieldSampler_ptx.cu
@@ -104,43 +104,9 @@ VISRTX_CALLABLE vec3 __direct_callable__sampleNormalCustom(
 //=============================================================================
 
 // Shared per-sample API (see gpu/volumeIntegrationDetail.h) for custom fields.
-// Unlike the built-in inline samplers, custom sampling routes back through the
-// user's init/value/normal direct-callables, so it needs `field` for the
-// callable index.
-namespace visrtx {
-
-VISRTX_DEVICE void initSamplerState(
-    VolumeSamplingState &s, const SpatialFieldGPUData &field)
-{
-  optixDirectCall<void>(uint32_t(field.samplerCallableIndex)
-          + uint32_t(SpatialFieldSamplerEntryPoints::Init),
-      &s,
-      &field);
-}
-
-VISRTX_DEVICE float sampleValue(const VolumeSamplingState &s,
-    const SpatialFieldGPUData &field,
-    const vec3 &p)
-{
-  return optixDirectCall<float>(uint32_t(field.samplerCallableIndex)
-          + uint32_t(SpatialFieldSamplerEntryPoints::SampleValue),
-      &s,
-      &field,
-      &p);
-}
-
-VISRTX_DEVICE vec3 sampleNormal(const VolumeSamplingState &s,
-    const SpatialFieldGPUData &field,
-    const vec3 &p)
-{
-  return optixDirectCall<vec3>(uint32_t(field.samplerCallableIndex)
-          + uint32_t(SpatialFieldSamplerEntryPoints::SampleNormal),
-      &s,
-      &field,
-      &p);
-}
-
-} // namespace visrtx
+// Routes init/value/normal back through the SBT (callable-in-callable); shared
+// with the isosurface intersector via CustomFieldSamplerInline.h.
+#include "CustomFieldSamplerInline.h"
 
 VISRTX_CALLABLE float __direct_callable__sampleDistanceCustom(ScreenSample *ss,
     const VolumeHit *hit,

--- a/devices/rtx/device/spatial_field/NvdbRectilinearField.cpp
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearField.cpp
@@ -155,7 +155,11 @@ void NvdbRectilinearField::finalize()
     if (!RectilinearLUT::buildAxisLUT(axisData,
             numCoords,
             m_axisLutTextures[axis],
-            m_axisLutArrays[axis])) {
+            m_axisLutArrays[axis])
+        || !RectilinearLUT::buildInverseAxisLUT(axisData,
+            numCoords,
+            m_invAxisLutTextures[axis],
+            m_invAxisLutArrays[axis])) {
       reportMessage(ANARI_SEVERITY_WARNING,
           "failed to build rectilinear LUT for axis %d (insufficient coordinates or non-monotonic ordering).",
           axis);
@@ -269,6 +273,9 @@ SpatialFieldGPUData NvdbRectilinearField::gpuData() const
   sf.data.nvdbRectilinear.axisLUT[0] = m_axisLutTextures[0];
   sf.data.nvdbRectilinear.axisLUT[1] = m_axisLutTextures[1];
   sf.data.nvdbRectilinear.axisLUT[2] = m_axisLutTextures[2];
+  sf.data.nvdbRectilinear.invAxisLUT[0] = m_invAxisLutTextures[0];
+  sf.data.nvdbRectilinear.invAxisLUT[1] = m_invAxisLutTextures[1];
+  sf.data.nvdbRectilinear.invAxisLUT[2] = m_invAxisLutTextures[2];
   sf.data.nvdbRectilinear.invAvgVoxelSize = m_invAvgVoxelSize;
 
   sf.grid = m_uniformGrid.gpuData();
@@ -288,6 +295,12 @@ void NvdbRectilinearField::cleanup()
       cudaFreeArray(m_axisLutArrays[i]);
     m_axisLutTextures[i] = {};
     m_axisLutArrays[i] = {};
+    if (m_invAxisLutTextures[i])
+      cudaDestroyTextureObject(m_invAxisLutTextures[i]);
+    if (m_invAxisLutArrays[i])
+      cudaFreeArray(m_invAxisLutArrays[i]);
+    m_invAxisLutTextures[i] = {};
+    m_invAxisLutArrays[i] = {};
   }
   m_bounds = box3(vec3(std::numeric_limits<float>::max()),
       vec3(std::numeric_limits<float>::lowest()));

--- a/devices/rtx/device/spatial_field/NvdbRectilinearField.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearField.h
@@ -77,6 +77,8 @@ struct NvdbRectilinearField : public SpatialField
   vec3 m_axisBoundsMax;
   cudaArray_t m_axisLutArrays[3]{};
   cudaTextureObject_t m_axisLutTextures[3]{};
+  cudaArray_t m_invAxisLutArrays[3]{};
+  cudaTextureObject_t m_invAxisLutTextures[3]{};
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
@@ -190,4 +190,28 @@ VISRTX_DEVICE vec3 sampleNormal(
       * 0.5f;
 }
 
+// Forward-difference gradient at a linear isosurface hit (see the regular
+// sampler): reuse vHit (≈ the matched isovalue) for 3 +1-voxel taps vs 6. Per-
+// axis invAvgVoxelSize weighting matches the central difference (its *0.5 and
+// the 1- vs 2-voxel span both wash out under the caller's normalize).
+template <typename ValueType>
+VISRTX_DEVICE vec3 isosurfaceHitGradient(
+    const NvdbRectilinearSamplerState<ValueType> &state,
+    const SpatialFieldGPUData &,
+    const vec3 &p,
+    float vHit)
+{
+  const auto indexPos = worldToIndexRectilinear(state, &p);
+  const float sx =
+      sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(1, 0, 0));
+  const float sy =
+      sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(0, 1, 0));
+  const float sz =
+      sampleAtIndexRectilinear(state, indexPos + nanovdb::Vec3f(0, 0, 1));
+  return vec3(sx - vHit, sy - vHit, sz - vHit)
+      * vec3(state.invAvgVoxelSize[0],
+          state.invAvgVoxelSize[1],
+          state.invAvgVoxelSize[2]);
+}
+
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
@@ -73,12 +73,31 @@ VISRTX_DEVICE void initNvdbRectilinearSampler(
   const nanovdb::CoordBBox indexBBox = grid->indexBBox();
   const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
 
-  state.scaleDown = 1.0f / dims;
-  state.scaleUp = dims - nanovdb::Vec3f(1.0f);
-  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
+  // NanoVDB's index space spans [0, N] over the world bbox (N voxels as cells),
+  // mapped to the axis LUT's [0,1] domain by scaleDown then back by scaleUp.
+  // offsetDown is +min (min-relative): a grid whose index bbox does not start at
+  // 0 (any real index-centered NanoVDB grid) otherwise drives the normalized
+  // coord negative, the LUT clamps it, and every sample collapses to a constant.
+  // span = N-1, clamped to >=1 so a degenerate 1-node axis can't make scaleUp 0
+  // (the DDA's boundaryPos divides by scaleUp). A 1-node rectilinear axis is
+  // already rejected upstream — the axis LUT needs >= 2 coords — so this is just
+  // defensive against NaN.
+  const nanovdb::Vec3f span(dims[0] > 1.f ? dims[0] - 1.f : 1.f,
+      dims[1] > 1.f ? dims[1] - 1.f : 1.f,
+      dims[2] > 1.f ? dims[2] - 1.f : 1.f);
+  state.scaleUp = span;
+  state.offsetDown = nanovdb::Vec3f(indexBBox.min());
   if (field->data.nvdbRectilinear.cellCentered) {
+    // Cell-centered: cells fill [0,N], no stretch. scaleDown 1/(N-1) cancels
+    // scaleUp (N-1) to an identity LUT map; the -0.5 offset samples cell centers.
+    state.scaleDown = nanovdb::Vec3f(1.0f) / span;
     state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
   } else {
+    // Node-centered: N nodes fill only [0, N-1] of the [0,N] domain. scaleDown
+    // 1/N then scaleUp (N-1) stretches the full domain onto the node range
+    // (symmetric half voxels); 1/(N-1) would leave a full constant voxel at the
+    // high boundary.
+    state.scaleDown = nanovdb::Vec3f(1.0f) / dims;
     state.offsetUp = state.offsetDown;
   }
   state.indexMin = nanovdb::Vec3f(indexBBox.min());

--- a/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRectilinearSamplerInline.h
@@ -106,9 +106,21 @@ VISRTX_DEVICE void initNvdbRectilinearSampler(
   state.axisLUT[0] = field->data.nvdbRectilinear.axisLUT[0];
   state.axisLUT[1] = field->data.nvdbRectilinear.axisLUT[1];
   state.axisLUT[2] = field->data.nvdbRectilinear.axisLUT[2];
+  state.invAxisLUT[0] = field->data.nvdbRectilinear.invAxisLUT[0];
+  state.invAxisLUT[1] = field->data.nvdbRectilinear.invAxisLUT[1];
+  state.invAxisLUT[2] = field->data.nvdbRectilinear.invAxisLUT[2];
 
   const auto &iavs = field->data.nvdbRectilinear.invAvgVoxelSize;
   state.invAvgVoxelSize = nanovdb::Vec3f(iavs.x, iavs.y, iavs.z);
+
+  // Per-axis affine uniform-index -> world map for the isosurface DDA (assumes
+  // an axis-aligned grid map; a rotated/sheared map would need the full 3x3).
+  const auto w0 = grid->indexToWorldF(nanovdb::Vec3f(0.f, 0.f, 0.f));
+  const auto wx = grid->indexToWorldF(nanovdb::Vec3f(1.f, 0.f, 0.f));
+  const auto wy = grid->indexToWorldF(nanovdb::Vec3f(0.f, 1.f, 0.f));
+  const auto wz = grid->indexToWorldF(nanovdb::Vec3f(0.f, 0.f, 1.f));
+  state.worldOrigin = vec3(w0[0], w0[1], w0[2]);
+  state.worldVoxelStep = vec3(wx[0] - w0[0], wy[1] - w0[1], wz[2] - w0[2]);
 }
 
 template <typename ValueType>

--- a/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
@@ -161,4 +161,26 @@ VISRTX_DEVICE vec3 sampleNormal(
       (szp - szn) * state.scale[2] * state.invTwoVoxelSize[2]);
 }
 
+// Forward-difference gradient at a linear isosurface hit: reuse the hit value
+// (vHit ≈ the matched isovalue) so only +1-voxel samples are taken — 3 fetches
+// vs sampleNormal's 6. The +1-voxel span still reaches into the neighbour cell,
+// so it stays smooth (no per-cell faceting). Per-axis object-space weighting is
+// the central difference's (the uniform 1- vs 2-voxel span factor washes out
+// under the caller's normalize).
+template <typename ValueType>
+VISRTX_DEVICE vec3 isosurfaceHitGradient(
+    const NvdbRegularSamplerState<ValueType> &state,
+    const SpatialFieldGPUData &,
+    const vec3 &p,
+    float vHit)
+{
+  const auto indexPos = nvdbIndexPos(state, p);
+  const float sx = nvdbSampleAtIndex(state, indexPos + nanovdb::Vec3f(1, 0, 0));
+  const float sy = nvdbSampleAtIndex(state, indexPos + nanovdb::Vec3f(0, 1, 0));
+  const float sz = nvdbSampleAtIndex(state, indexPos + nanovdb::Vec3f(0, 0, 1));
+  return vec3((sx - vHit) * state.scale[0] * state.invTwoVoxelSize[0],
+      (sy - vHit) * state.scale[1] * state.invTwoVoxelSize[1],
+      (sz - vHit) * state.scale[2] * state.invTwoVoxelSize[2]);
+}
+
 } // namespace visrtx

--- a/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/NvdbRegularSamplerInline.h
@@ -83,17 +83,21 @@ VISRTX_DEVICE void initNvdbSampler(
 
   const nanovdb::CoordBBox indexBBox = grid->indexBBox();
   const nanovdb::Vec3f dims = nanovdb::Vec3f(indexBBox.dim());
-  // NanoVDB samplers get exact values at 0, 1, ... N, which works for
-  // node centered data. For cell centered data, we need to offset by -0.5
-  // and clamp to artificially create the full voxel, extrapolating the
-  // outermost voxel values.
-  // Scale moves from index space to index space - 1
-  state.offsetDown = -nanovdb::Vec3f(indexBBox.min());
+  // NanoVDB's index space spans [0, N] over the world bbox (it treats the N
+  // voxels as cells [i, i+1]), but node-centered data of N nodes only fills the
+  // index range [0, N-1]. So node-centered scales the (min-relative) index by
+  // (N-1)/N to map the full [0,N] domain onto the node range, giving symmetric
+  // half voxels at both boundaries; the identity (scale 1) instead leaves the
+  // phantom cell [N-1, N] as a full constant voxel at the high boundary. Cell-
+  // centered data stores values at the cell centers, so shift by -0.5 and clamp
+  // (extrapolating the outermost voxel) — no stretch. offsetDown is +min, so a
+  // grid whose index bbox does not start at 0 still maps correctly.
+  state.offsetDown = nanovdb::Vec3f(indexBBox.min());
   if (field->data.nvdbRegular.cellCentered) {
-    state.offsetUp = nanovdb::Vec3f(-0.5f) + state.offsetDown;
+    state.offsetUp = nanovdb::Vec3f(indexBBox.min()) - nanovdb::Vec3f(0.5f);
     state.scale = nanovdb::Vec3f(1.0f);
   } else {
-    state.offsetUp = state.offsetDown;
+    state.offsetUp = nanovdb::Vec3f(indexBBox.min());
     state.scale = (dims - nanovdb::Vec3f(1.0f)) / dims;
   }
 

--- a/devices/rtx/device/spatial_field/RectilinearLUT.h
+++ b/devices/rtx/device/spatial_field/RectilinearLUT.h
@@ -45,7 +45,7 @@ namespace visrtx {
  * Utility to build a backmapping LUT for rectilinear coordinates.
  *
  * Given a forward axis array (monotonically increasing object-space
- * coordinates), this builds a 1024-texel 1D CUDA texture that maps normalized
+ * coordinates), this builds an 8192-texel 1D CUDA texture that maps normalized
  * object-space coordinates [0,1] to normalized index-space coordinates [0,1].
  *
  * Uses linear interpolation to invert the piecewise-linear forward mapping.
@@ -53,6 +53,18 @@ namespace visrtx {
 class RectilinearLUT
 {
  public:
+  // Both builders divide by per-segment and total coordinate gaps; a duplicate
+  // or decreasing coordinate would produce NaN/inf LUT texels. Enforce the
+  // strictly-increasing contract up front so callers fail fast (their finalize
+  // paths warn on a false return) instead of silently building a poisoned LUT.
+  static bool isStrictlyIncreasing(const float *axisCoords, size_t numCoords)
+  {
+    for (size_t i = 1; i < numCoords; ++i)
+      if (!(axisCoords[i] > axisCoords[i - 1]))
+        return false;
+    return true;
+  }
+
   /**
    * Build a rectilinear LUT for a single axis.
    *
@@ -74,11 +86,11 @@ class RectilinearLUT
     outLutTexture = {};
     outCudaArray = {};
 
-    if (!axisCoords || numCoords < 2) {
+    if (!axisCoords || numCoords < 2 || !isStrictlyIncreasing(axisCoords, numCoords)) {
       return false;
     }
 
-    constexpr size_t lutSize = 1024;
+    constexpr size_t lutSize = 8192;
     std::vector<float> lut;
     lut.reserve(lutSize);
     // Make sure bounds interpolate exactly
@@ -86,7 +98,7 @@ class RectilinearLUT
 
     float step = (axisCoords[numCoords - 1] - axisCoords[0]) / (lutSize - 1);
     float currentValue = axisCoords[0] + step;
-    float invDim = 1.0 / (numCoords - 1);
+    float invDim = 1.0f / (numCoords - 1);
 
     size_t baseIndex = 0;
 
@@ -119,6 +131,59 @@ class RectilinearLUT
       return false;
     }
 
+    return true;
+  }
+
+  /**
+   * Build the inverse rectilinear LUT for a single axis: maps normalized
+   * index-space coordinates [0,1] back to normalized object-space coordinates
+   * [0,1]. This is the companion of buildAxisLUT (which maps object->index) and
+   * lets the isosurface voxel-DDA recover the object-space position of an
+   * integer voxel boundary directly (no per-hit root-find): for boundary index
+   * k, objectPos = boundsMin + tex(invLUT, k/(numCoords-1)) * (boundsMax-boundsMin).
+   *
+   * Same contract as buildAxisLUT (strictly monotonic input, >= 2 coords).
+   */
+  static bool buildInverseAxisLUT(const float *axisCoords,
+      size_t numCoords,
+      cudaTextureObject_t &outLutTexture,
+      cudaArray_t &outCudaArray)
+  {
+    outLutTexture = {};
+    outCudaArray = {};
+
+    if (!axisCoords || numCoords < 2 || !isStrictlyIncreasing(axisCoords, numCoords))
+      return false;
+
+    constexpr size_t lutSize = 8192;
+    const float c0 = axisCoords[0];
+    const float cN = axisCoords[numCoords - 1];
+    const float invExtent = (cN != c0) ? 1.0f / (cN - c0) : 0.0f;
+
+    std::vector<float> lut;
+    lut.reserve(lutSize);
+    for (size_t i = 0; i < lutSize; ++i) {
+      const float ni = float(i) / float(lutSize - 1); // normalized index [0,1]
+      const float fidx = ni * float(numCoords - 1); // fractional grid index
+      size_t k = size_t(fidx);
+      if (k > numCoords - 2)
+        k = numCoords - 2;
+      const float frac = fidx - float(k);
+      const float obj =
+          axisCoords[k] + frac * (axisCoords[k + 1] - axisCoords[k]);
+      lut.push_back((obj - c0) * invExtent); // normalized object [0,1]
+    }
+
+    makeCudaArrayFloat(outCudaArray, 1, lut.data(), uvec3(lutSize, 1, 1));
+    if (!outCudaArray)
+      return false;
+
+    outLutTexture =
+        makeCudaTextureObject1D(outCudaArray, false, "linear", "clampToEdge");
+    if (!outLutTexture) {
+      cudaFreeArray(outCudaArray);
+      return false;
+    }
     return true;
   }
 };

--- a/devices/rtx/device/spatial_field/StructuredRectilinearField.cpp
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearField.cpp
@@ -202,7 +202,11 @@ void StructuredRectilinearField::finalize()
     if (!RectilinearLUT::buildAxisLUT(axisData,
             numCoords,
             m_axisLutTextures[axis],
-            m_axisLutArrays[axis])) {
+            m_axisLutArrays[axis])
+        || !RectilinearLUT::buildInverseAxisLUT(axisData,
+            numCoords,
+            m_invAxisLutTextures[axis],
+            m_invAxisLutArrays[axis])) {
       reportMessage(ANARI_SEVERITY_WARNING,
           "failed to build rectilinear LUT for axis %d (insufficient coordinates or non-monotonic ordering).",
           axis);
@@ -274,8 +278,14 @@ SpatialFieldGPUData StructuredRectilinearField::gpuData() const
   sf.data.structuredRectilinear.axisLUT[0] = m_axisLutTextures[0];
   sf.data.structuredRectilinear.axisLUT[1] = m_axisLutTextures[1];
   sf.data.structuredRectilinear.axisLUT[2] = m_axisLutTextures[2];
+  sf.data.structuredRectilinear.invAxisLUT[0] = m_invAxisLutTextures[0];
+  sf.data.structuredRectilinear.invAxisLUT[1] = m_invAxisLutTextures[1];
+  sf.data.structuredRectilinear.invAxisLUT[2] = m_invAxisLutTextures[2];
   sf.data.structuredRectilinear.axisBoundsMin = m_bounds.lower;
   sf.data.structuredRectilinear.axisBoundsMax = m_bounds.upper;
+  sf.data.structuredRectilinear.filter = m_filter == "nearest"
+      ? SpatialFieldFilter::Nearest
+      : SpatialFieldFilter::Linear;
 
   sf.grid = m_uniformGrid.gpuData();
 
@@ -299,6 +309,12 @@ void StructuredRectilinearField::cleanup()
       cudaFreeArray(m_axisLutArrays[i]);
     m_axisLutTextures[i] = {};
     m_axisLutArrays[i] = {};
+    if (m_invAxisLutTextures[i])
+      cudaDestroyTextureObject(m_invAxisLutTextures[i]);
+    if (m_invAxisLutArrays[i])
+      cudaFreeArray(m_invAxisLutArrays[i]);
+    m_invAxisLutTextures[i] = {};
+    m_invAxisLutArrays[i] = {};
   }
 
   m_textureObject = {};
@@ -312,8 +328,6 @@ void StructuredRectilinearField::buildGrid()
 {
   auto dims = m_data->size();
   m_uniformGrid.init(ivec3(dims.x, dims.y, dims.z), bounds());
-
-  size_t numVoxels = (dims.x - 1) * size_t(dims.y - 1) * (dims.z - 1);
   m_uniformGrid.computeValueRanges(gpuData());
 }
 

--- a/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
@@ -58,8 +58,12 @@ VISRTX_DEVICE void initStructuredRectilinearSampler(
   state.axisLUT[0] = data.axisLUT[0];
   state.axisLUT[1] = data.axisLUT[1];
   state.axisLUT[2] = data.axisLUT[2];
+  state.invAxisLUT[0] = data.invAxisLUT[0];
+  state.invAxisLUT[1] = data.invAxisLUT[1];
+  state.invAxisLUT[2] = data.invAxisLUT[2];
   state.axisBoundsMin = data.axisBoundsMin;
   state.axisBoundsMax = data.axisBoundsMax;
+  state.filter = data.filter;
 
   // Voxels per unit extent: cell count (cell-centered) or node-segment count
   // (node-centered) over the axis span — both equal state.dims.

--- a/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
+++ b/devices/rtx/device/spatial_field/StructuredRectilinearSamplerInline.h
@@ -46,7 +46,14 @@ VISRTX_DEVICE void initStructuredRectilinearSampler(
   const auto &data = field->data.structuredRectilinear;
 
   state.texObj = data.texObj;
-  state.dims = data.dims - vec3(1);
+  // Texture-coordinate scale = number of axis segments (numCoords - 1), so the
+  // warped node-index maps directly onto the texture coordinate.
+  //   node-centered: numCoords == data.dims nodes  -> scale data.dims - 1,
+  //                  sampled at texel centers (offset 0.5).
+  //   cell-centered: numCoords == data.dims + 1 nodes over data.dims cells
+  //                  -> scale data.dims, cell center i+0.5 lands on texel
+  //                  center i+0.5 (offset 0).
+  state.dims = data.cellCentered ? data.dims : data.dims - vec3(1);
   state.offset = vec3(data.cellCentered ? 0.0f : 0.5f);
   state.axisLUT[0] = data.axisLUT[0];
   state.axisLUT[1] = data.axisLUT[1];
@@ -54,9 +61,10 @@ VISRTX_DEVICE void initStructuredRectilinearSampler(
   state.axisBoundsMin = data.axisBoundsMin;
   state.axisBoundsMax = data.axisBoundsMax;
 
+  // Voxels per unit extent: cell count (cell-centered) or node-segment count
+  // (node-centered) over the axis span — both equal state.dims.
   const vec3 extent = data.axisBoundsMax - data.axisBoundsMin;
-  state.invAvgVoxelSpacing =
-      data.cellCentered ? (state.dims + vec3(1)) / extent : state.dims / extent;
+  state.invAvgVoxelSpacing = state.dims / extent;
 }
 
 // Maps an object-space position to texture sample coordinates through the

--- a/devices/rtx/device/spatial_field/StructuredRegularField.cpp
+++ b/devices/rtx/device/spatial_field/StructuredRegularField.cpp
@@ -204,10 +204,12 @@ SpatialFieldGPUData StructuredRegularField::gpuData() const
   sf.samplerCallableIndex = SbtCallableEntryPoints::SpatialFieldSamplerRegular;
   sf.data.structuredRegular.texObj = m_textureObject;
   sf.data.structuredRegular.origin = m_origin;
-  sf.data.structuredRegular.invDims =
-      1.0f / vec3(dims.x - 1, dims.y - 1, dims.z - 1);
   sf.data.structuredRegular.invSpacing = 1.0f / m_spacing;
+  sf.data.structuredRegular.dims = ivec3(dims.x, dims.y, dims.z);
   sf.data.structuredRegular.cellCentered = m_cellCentered;
+  sf.data.structuredRegular.filter = m_filter == "nearest"
+      ? SpatialFieldFilter::Nearest
+      : SpatialFieldFilter::Linear;
   sf.grid = m_uniformGrid.gpuData();
 
   sf.roi.lower = m_roi.lower;
@@ -231,8 +233,6 @@ void StructuredRegularField::buildGrid()
 {
   auto dims = m_data->size();
   m_uniformGrid.init(ivec3(dims.x, dims.y, dims.z), bounds());
-
-  size_t numVoxels = (dims.x - 1) * size_t(dims.y - 1) * (dims.z - 1);
   m_uniformGrid.computeValueRanges(gpuData());
 }
 

--- a/devices/rtx/device/spatial_field/StructuredRegularSamplerInline.h
+++ b/devices/rtx/device/spatial_field/StructuredRegularSamplerInline.h
@@ -44,10 +44,11 @@ VISRTX_DEVICE void initStructuredRegularSampler(
 {
   state.texObj = field->data.structuredRegular.texObj;
   state.origin = field->data.structuredRegular.origin;
-  state.invDims = field->data.structuredRegular.invDims;
   state.invSpacing = field->data.structuredRegular.invSpacing;
   state.offset =
       vec3(field->data.structuredRegular.cellCentered ? 0.0f : 0.5f);
+  state.dims = field->data.structuredRegular.dims;
+  state.filter = field->data.structuredRegular.filter;
 }
 
 // Shared per-sample API (see gpu/volumeIntegrationDetail.h). sampleValue

--- a/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
+++ b/devices/rtx/device/spatial_field/space_skipping/UniformGrid.cu
@@ -110,7 +110,7 @@ __global__ void computeValueRangesGPU(box1 *valueRanges,
 
   ivec3 mcID(threadID % mcDims.x,
       threadID / mcDims.x % mcDims.y,
-      threadID / (mcDims.x * mcDims.y));
+      threadID / (size_t(mcDims.x) * mcDims.y));
 
   // Field voxel range covered by this macrocell, with 1-voxel margin
   // to account for trilinear interpolation across macrocell boundaries

--- a/devices/rtx/device/visrtx_device.json
+++ b/devices/rtx/device/visrtx_device.json
@@ -21,6 +21,7 @@
       "khr_geometry_cone",
       "khr_geometry_curve",
       "khr_geometry_cylinder",
+      "khr_geometry_isosurface",
       "khr_geometry_quad",
       "khr_geometry_sphere",
       "khr_geometry_triangle",


### PR DESCRIPTION
Implements the ANARI **KHR_GEOMETRY_ISOSURFACE** geometry: a surface rendered wherever a spatial field equals one or more isovalues. Because it's a geometry, it flows through the existing surface/material/AOV/shadow pipeline with no renderer changes.

- Isosurface geometry — a new primitive geometry (like Sphere/Cone) that references a SpatialField and an isovalue array, intersecting the ray with the crossing surface rather than extracting a mesh.
- Macrogrid space-skipping — traversal walks a coarse grid of macrocells (shared with volume rendering), each holding the field's value range, and skips any cell that can't bracket the isovalue. NanoVDB fields skip at the brick level too. This is what makes large fields tractable.
- Per-voxel DDA for built-in fields — once inside an active region, the four built-in samplers (structured regular/rectilinear, NanoVDB regular/rectilinear) step voxel-by-voxel via a DDA and solve the crossing analytically per cell, instead of a fixed-step march. Custom fields keep the ray-march fallback.
- Fixes uncovered while wiring this up: NanoVDB index-offset sign, sampler centering, and an integer overflow in macrocell index decomposition.

<img width="933" height="736" alt="image" src="https://github.com/user-attachments/assets/ecb4f33b-9fe7-45b2-8816-d0db6f20e1b3" />
