### PR TITLE
rtx: accept VEC3 vertex.tangent on triangle geometry

### DIFF
--- a/devices/rtx/device/geometry/ComputeTangent.cu
+++ b/devices/rtx/device/geometry/ComputeTangent.cu
@@ -319,6 +319,33 @@ __global__ void __doFinalizeTangents(glm::vec4 *tangents,
   tangents[v] = glm::vec4(T_orth, sign);
 }
 
+__global__ void __padTangentsVec3ToVec4(
+    glm::vec4 *dst, const glm::vec3 *src, unsigned int count)
+{
+  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= count)
+    return;
+  // No authored handedness in a VEC3 tangent; default the sign to +1.
+  dst[i] = glm::vec4(src[i], 1.0f);
+}
+
+bool convertTangentsVec3ToVec4(
+    Triangle *triangle, const glm::vec3 *src, glm::vec4 *dst, size_t count)
+{
+  if (count == 0)
+    return true;
+
+  const auto n = static_cast<unsigned int>(count);
+  __padTangentsVec3ToVec4<<<(n + 63) / 64, 64>>>(dst, src, n);
+  if (reportCudaError(
+          triangle, cudaGetLastError(), "launching tangent vec3->vec4 padding"))
+    return false;
+  if (reportCudaError(
+          triangle, cudaDeviceSynchronize(), "padding vec3 tangents to vec4"))
+    return false;
+  return true;
+}
+
 void updateGeometryTangent(Triangle *triangle)
 {
   auto indices = triangle->getParamObject<Array1D>("primitive.index");

--- a/devices/rtx/device/geometry/ComputeTangent.h
+++ b/devices/rtx/device/geometry/ComputeTangent.h
@@ -59,4 +59,13 @@ void computeVertexTangents(
 
 void updateGeometryTangent(Triangle *triangle);
 
+// Pad a VEC3 tangent array into the internal vec4(T, sign) layout the shader
+// expects. The ANARI spec allows authoring tangents as plain VEC3 (no
+// handedness), so the missing w component is defaulted to +1 (right-handed).
+// Both pointers are device memory; count is the number of tangents. Returns
+// false (and reports the error) if the conversion fails, so the caller can
+// drop the tangents rather than read an uninitialized buffer.
+bool convertTangentsVec3ToVec4(
+    Triangle *triangle, const glm::vec3 *src, glm::vec4 *dst, size_t count);
+
 } // namespace visrtx

--- a/devices/rtx/device/geometry/Triangle.cpp
+++ b/devices/rtx/device/geometry/Triangle.cpp
@@ -35,11 +35,76 @@
 
 namespace visrtx {
 
+// Resolve the device pointer the GPU reads tangents from. A non-empty staging
+// buffer means a VEC3 array was padded to vec4; otherwise a non-empty VEC4
+// array is read zero-copy from its own storage. Anything else -- absent,
+// empty, or an unsupported/failed-to-convert type -- yields no tangents, so
+// the shader falls back to a geometric basis.
+static const vec4 *resolveTangentPtr(
+    const helium::IntrusivePtr<Array1D> &tangents,
+    const DeviceBuffer &converted)
+{
+  if (converted)
+    return converted.ptrAs<vec4>();
+  if (tangents && tangents->size() > 0
+      && tangents->elementType() == ANARI_FLOAT32_VEC4)
+    return tangents->beginAs<vec4>(AddressSpace::GPU);
+  return nullptr;
+}
+
 Triangle::Triangle(DeviceGlobalState *d)
     : Geometry(d), m_index(this), m_vertex(this)
 {}
 
 Triangle::~Triangle() = default;
+
+void Triangle::prepareTangentArray(
+    const helium::IntrusivePtr<Array1D> &tangents,
+    DeviceBuffer &converted,
+    const char *paramName)
+{
+  // Only the staging buffer is rebuilt here; the array member is left untouched
+  // so it keeps faithfully reflecting the committed parameter (mutating it
+  // would let a finalize-only re-run trip the auto-compute-tangents gate).
+  converted.reset();
+
+  if (!tangents)
+    return;
+
+  const auto type = tangents->elementType();
+
+  // Already in the internal layout: read zero-copy in gpuData().
+  if (type == ANARI_FLOAT32_VEC4)
+    return;
+
+  // Spec-allowed VEC3 tangents: pad to vec4 with a default +1 handedness.
+  if (type == ANARI_FLOAT32_VEC3) {
+    const auto count = tangents->size();
+    if (count == 0)
+      return;
+    converted.reserve(count * sizeof(vec4));
+    // On allocation (empty buffer) or conversion failure, leave 'converted'
+    // empty; gpuData() then emits no tangents (resolveTangentPtr zero-copies
+    // VEC4 only) rather than reading an uninitialized buffer.
+    if (!converted
+        || !convertTangentsVec3ToVec4(this,
+            tangents->beginAs<vec3>(AddressSpace::GPU),
+            converted.ptrAs<vec4>(),
+            count)) {
+      converted.reset();
+    }
+    return;
+  }
+
+  // Anything else (e.g. the FIXED16 variants) is advertised by the query
+  // metadata but not yet handled here. Report it; gpuData() emits no tangents
+  // rather than throwing on a VEC4 read of a non-VEC4 array.
+  reportMessage(ANARI_SEVERITY_WARNING,
+      "'%s' on triangle geometry has unsupported element type '%s'; "
+      "expected ANARI_FLOAT32_VEC3 or ANARI_FLOAT32_VEC4 -- ignoring tangents",
+      paramName,
+      anari::toString(type));
+}
 
 void Triangle::commitParameters()
 {
@@ -108,6 +173,11 @@ void Triangle::finalize()
     updateGeometryTangent(this);
   }
 
+  prepareTangentArray(
+      m_vertexTangent, m_vertexTangentConverted, "vertex.tangent");
+  prepareTangentArray(
+      m_vertexTangentFV, m_vertexTangentFVConverted, "faceVarying.tangent");
+
   reportMessage(ANARI_SEVERITY_DEBUG,
       "finalizing %s triangle geometry",
       m_index ? "indexed" : "soup");
@@ -166,17 +236,15 @@ GeometryGPUData Triangle::gpuData() const
   tri.vertexNormals = m_vertexNormal
       ? m_vertexNormal->beginAs<vec3>(AddressSpace::GPU)
       : nullptr;
-  tri.vertexTangents = m_vertexTangent
-      ? m_vertexTangent->beginAs<vec4>(AddressSpace::GPU)
-      : nullptr;
+  tri.vertexTangents =
+      resolveTangentPtr(m_vertexTangent, m_vertexTangentConverted);
   populateAttributeDataSet(m_vertexAttributes, tri.vertexAttr);
   populateAttributeDataSet(m_vertexAttributesFV, tri.vertexAttrFV);
   tri.vertexNormalsFV = m_vertexNormalFV
       ? m_vertexNormalFV->beginAs<vec3>(AddressSpace::GPU)
       : nullptr;
-  tri.vertexTangentsFV = m_vertexTangentFV
-      ? m_vertexTangentFV->beginAs<vec4>(AddressSpace::GPU)
-      : nullptr;
+  tri.vertexTangentsFV =
+      resolveTangentPtr(m_vertexTangentFV, m_vertexTangentFVConverted);
   tri.cullBackfaces = m_cullBackfaces;
 
   return retval;

--- a/devices/rtx/device/geometry/Triangle.h
+++ b/devices/rtx/device/geometry/Triangle.h
@@ -34,6 +34,7 @@
 #include <helium/utility/IntrusivePtr.h>
 #include "Geometry.h"
 #include "array/Array1D.h"
+#include "utility/DeviceBuffer.h"
 
 namespace visrtx {
 
@@ -54,6 +55,15 @@ struct Triangle : public Geometry
   GeometryGPUData gpuData() const override;
   void cleanup();
 
+  // Build the GPU-side staging for one authored tangent array into 'converted':
+  // VEC4 input is read zero-copy (buffer left empty); VEC3 input is padded to
+  // vec4 (sign defaulted to +1); unsupported element types are reported and
+  // leave the buffer empty so resolveTangentPtr() emits no tangents. Called per
+  // array during finalize().
+  void prepareTangentArray(const helium::IntrusivePtr<Array1D> &tangents,
+      DeviceBuffer &converted,
+      const char *paramName);
+
   helium::ChangeObserverPtr<Array1D> m_index;
   helium::ChangeObserverPtr<Array1D> m_vertex;
   helium::IntrusivePtr<Array1D> m_vertexNormal;
@@ -62,6 +72,11 @@ struct Triangle : public Geometry
   helium::IntrusivePtr<Array1D> m_vertexNormalFV;
   helium::IntrusivePtr<Array1D> m_vertexTangent;
   helium::IntrusivePtr<Array1D> m_vertexTangentFV;
+
+  // VEC4 staging for VEC3-authored tangents; empty when the input is already
+  // VEC4 (zero-copy) or absent.
+  DeviceBuffer m_vertexTangentConverted;
+  DeviceBuffer m_vertexTangentFVConverted;
 
   CUdeviceptr m_vertexBufferPtr{};
 


### PR DESCRIPTION
Triangle geometry advertised ANARI_FLOAT32_VEC3 tangents in its query metadata, but gpuData() read every tangent array as vec4. A spec-valid VEC3 vertex.tangent / faceVarying.tangent therefore threw "incorrect element type queried for array" and terminated the device.

Normalize each tangent array to the internal vec4(T, sign) layout during finalize(): VEC4 input stays zero-copy, VEC3 input is padded into a device staging buffer with the handedness sign defaulted to +1, and any other element type (e.g. the advertised FIXED16 variants, not yet handled) is reported and produces no tangents instead of crashing. gpuData() selects the staging buffer or the array's own VEC4 storage via resolveTangentPtr(); the drop decision lives there, so the array members keep faithfully reflecting their parameters and a finalize-only re-run never trips the auto-compute-tangents gate. On a CUDA allocation or conversion failure the staging buffer is left empty so the GPU never reads uninitialized memory.

Verified with the ANARI CTS geometry/triangle_normal_tangent cases (previously: terminate on the vec3 variant; now 4/4 render) and a full geometry-category sweep (80/80, no regressions).