### PR TITLE
feat(tsd): add BoxOutlineRenderPass and viewport Show Bounds toggle

### DIFF
--- a/tsd/CONTEXT-MAP.md
+++ b/tsd/CONTEXT-MAP.md
@@ -6,6 +6,8 @@
   representations and persists native TSD state
 - [TSD App](./src/tsd/app/CONTEXT.md) — composes reusable application state
   around TSD scenes, animations, rendering, and interaction
+- [TSD Rendering](./src/tsd/rendering/CONTEXT.md) — turns TSD scenes into
+  images via render indexes and an image pipeline of composable passes
 - [SciVis Studio](./apps/interactive/scivisStudio/CONTEXT.md) — organizes
   scientific-visualization assets into projects and shots
 

--- a/tsd/src/tsd/algorithms/CMakeLists.txt
+++ b/tsd/src/tsd/algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ project_sources(PRIVATE
   cpu/autoExposure.cpp
   cpu/outputTransform.cpp
   cpu/visualizeAOV.cpp
+  cpu/boxOutline.cpp
   cpu/outline.cpp
   cpu/clearBuffers.cpp
   cpu/convertColorBuffer.cpp
@@ -42,6 +43,7 @@ if (TSD_USE_CUDA)
     cuda/autoExposure.cu
     cuda/outputTransform.cu
     cuda/visualizeAOV.cu
+    cuda/boxOutline.cu
     cuda/outline.cu
     cuda/clearBuffers.cu
     cuda/convertColorBuffer.cu

--- a/tsd/src/tsd/algorithms/cpu/boxOutline.cpp
+++ b/tsd/src/tsd/algorithms/cpu/boxOutline.cpp
@@ -1,0 +1,148 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/algorithms/cpu/boxOutline.hpp"
+#include "detail/parallel_for.h"
+// std
+#include <algorithm>
+#include <cmath>
+
+namespace tsd::algorithms::cpu {
+
+namespace {
+
+// Fraction of the fragment's eye distance subtracted before the depth
+// compare; the box typically touches the geometry it bounds, so it would
+// z-fight without a relative bias toward the camera.
+constexpr float DEPTH_BIAS = 1e-3f;
+
+struct ProjectedEdge
+{
+  tsd::math::float2 s0, s1; // pixel-space endpoints
+  float invW0, invW1; // 1/clip.w for perspective-correct interpolation
+  tsd::math::float3 world0, world1; // world-space endpoints
+};
+
+struct ProjectedEdges
+{
+  int count{0};
+  ProjectedEdge e[12];
+};
+
+// Project the 12 box edges to pixel space, clipping the portion of each edge
+// behind the eye (clip.w <= 0, perspective only; w == 1 for orthographic).
+ProjectedEdges projectBoxEdges(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    uint32_t width,
+    uint32_t height)
+{
+  using namespace tsd::math;
+
+  float3 corners[8];
+  float4 clip[8];
+  for (int i = 0; i < 8; i++) {
+    corners[i] = float3(i & 1 ? box.upper.x : box.lower.x,
+        i & 2 ? box.upper.y : box.lower.y,
+        i & 4 ? box.upper.z : box.lower.z);
+    clip[i] = mul(projView, float4(corners[i], 1.f));
+  }
+
+  constexpr float W_EPS = 1e-6f;
+
+  ProjectedEdges result;
+  for (int i = 0; i < 8; i++) {
+    for (int bit = 1; bit <= 4; bit <<= 1) {
+      if (i & bit)
+        continue;
+      const int j = i | bit;
+
+      // Clip t-range of the segment to clip.w >= W_EPS //
+
+      const float w0 = clip[i].w;
+      const float w1 = clip[j].w;
+      if (w0 < W_EPS && w1 < W_EPS)
+        continue;
+
+      float t0 = 0.f;
+      float t1 = 1.f;
+      if (w0 < W_EPS)
+        t0 = (W_EPS - w0) / (w1 - w0);
+      else if (w1 < W_EPS)
+        t1 = (W_EPS - w0) / (w1 - w0);
+
+      const float4 c0 = lerp(clip[i], clip[j], t0);
+      const float4 c1 = lerp(clip[i], clip[j], t1);
+
+      auto toScreen = [&](const float4 &c) {
+        const float2 ndc(c.x / c.w, c.y / c.w);
+        return float2((ndc.x * 0.5f + 0.5f) * width,
+            (ndc.y * 0.5f + 0.5f) * height);
+      };
+
+      auto &edge = result.e[result.count++];
+      edge.s0 = toScreen(c0);
+      edge.s1 = toScreen(c1);
+      edge.invW0 = 1.f / c0.w;
+      edge.invW1 = 1.f / c1.w;
+      edge.world0 = lerp(corners[i], corners[j], t0);
+      edge.world1 = lerp(corners[i], corners[j], t1);
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+void boxOutline(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height)
+{
+  using namespace tsd::math;
+
+  const ProjectedEdges edges = projectBoxEdges(box, projView, width, height);
+  const float halfWidth = std::max(1u, lineWidth) * 0.5f;
+
+  detail::parallel_for(0u, width * height, [=](uint32_t i) {
+    const float2 p(i % width + 0.5f, i / width + 0.5f);
+
+    for (int e = 0; e < edges.count; e++) {
+      const auto &edge = edges.e[e];
+      const float2 d = edge.s1 - edge.s0;
+      const float len2 = dot(d, d);
+      const float t =
+          len2 > 0.f ? std::clamp(dot(p - edge.s0, d) / len2, 0.f, 1.f) : 0.f;
+      const float2 closest = edge.s0 + t * d;
+      if (length(p - closest) > halfWidth)
+        continue;
+
+      if (depth || orthographicDepth) {
+        // Perspective-correct world position at t //
+        const float iw0 = (1.f - t) * edge.invW0;
+        const float iw1 = t * edge.invW1;
+        const float3 world =
+            (edge.world0 * iw0 + edge.world1 * iw1) / (iw0 + iw1);
+
+        const float z = orthographicDepth ? dot(world - eye, dir)
+                                          : length(world - eye);
+        if (orthographicDepth && z < 0.f)
+          continue; // behind the orthographic camera plane
+        if (depth && z * (1.f - DEPTH_BIAS) > depth[i])
+          continue;
+      }
+
+      color[i] = outlineColor;
+      break;
+    }
+  });
+}
+
+} // namespace tsd::algorithms::cpu

--- a/tsd/src/tsd/algorithms/cpu/boxOutline.hpp
+++ b/tsd/src/tsd/algorithms/cpu/boxOutline.hpp
@@ -1,0 +1,32 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// tsd_core
+#include "tsd/core/TSDMath.hpp"
+// std
+#include <cstdint>
+
+namespace tsd::algorithms::cpu {
+
+// Rasterize the Box Outline (12 edges) of a world-space AABB into the color
+// buffer. Corners are projected through projView; edge segments behind the
+// eye are clipped (perspective). Fragments are depth-tested against 'depth'
+// (eye-to-hit distance, with a small relative bias toward the camera) when
+// non-null, otherwise drawn as an overlay. When orthographicDepth is true the
+// fragment depth is the signed distance along 'dir' from the camera plane at
+// 'eye' instead of the Euclidean distance from 'eye'.
+void boxOutline(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height);
+
+} // namespace tsd::algorithms::cpu

--- a/tsd/src/tsd/algorithms/cuda/boxOutline.cu
+++ b/tsd/src/tsd/algorithms/cuda/boxOutline.cu
@@ -1,0 +1,191 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tsd/algorithms/cuda/boxOutline.hpp"
+// thrust
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+// std
+#include <algorithm>
+#include <cmath>
+
+namespace tsd::algorithms::cuda {
+
+namespace {
+
+// Fraction of the fragment's eye distance subtracted before the depth
+// compare; the box typically touches the geometry it bounds, so it would
+// z-fight without a relative bias toward the camera.
+constexpr float DEPTH_BIAS = 1e-3f;
+
+struct ProjectedEdge
+{
+  tsd::math::float2 s0, s1; // pixel-space endpoints
+  float invW0, invW1; // 1/clip.w for perspective-correct interpolation
+  tsd::math::float3 world0, world1; // world-space endpoints
+};
+
+struct ProjectedEdges
+{
+  int count{0};
+  ProjectedEdge e[12];
+};
+
+// Project the 12 box edges to pixel space, clipping the portion of each edge
+// behind the eye (clip.w <= 0, perspective only; w == 1 for orthographic).
+// Runs on the host; the result is captured by value into the device lambda.
+ProjectedEdges projectBoxEdges(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    uint32_t width,
+    uint32_t height)
+{
+  using math_float2 = tsd::math::float2;
+  using math_float3 = tsd::math::float3;
+  using math_float4 = tsd::math::float4;
+
+  math_float3 corners[8];
+  math_float4 clip[8];
+  for (int i = 0; i < 8; i++) {
+    corners[i] = math_float3(i & 1 ? box.upper.x : box.lower.x,
+        i & 2 ? box.upper.y : box.lower.y,
+        i & 4 ? box.upper.z : box.lower.z);
+    clip[i] = tsd::math::mul(projView, math_float4(corners[i], 1.f));
+  }
+
+  constexpr float W_EPS = 1e-6f;
+
+  ProjectedEdges result;
+  for (int i = 0; i < 8; i++) {
+    for (int bit = 1; bit <= 4; bit <<= 1) {
+      if (i & bit)
+        continue;
+      const int j = i | bit;
+
+      // Clip t-range of the segment to clip.w >= W_EPS //
+
+      const float w0 = clip[i].w;
+      const float w1 = clip[j].w;
+      if (w0 < W_EPS && w1 < W_EPS)
+        continue;
+
+      float t0 = 0.f;
+      float t1 = 1.f;
+      if (w0 < W_EPS)
+        t0 = (W_EPS - w0) / (w1 - w0);
+      else if (w1 < W_EPS)
+        t1 = (W_EPS - w0) / (w1 - w0);
+
+      const math_float4 c0 = tsd::math::lerp(clip[i], clip[j], t0);
+      const math_float4 c1 = tsd::math::lerp(clip[i], clip[j], t1);
+
+      auto toScreen = [&](const math_float4 &c) {
+        const math_float2 ndc(c.x / c.w, c.y / c.w);
+        return math_float2((ndc.x * 0.5f + 0.5f) * width,
+            (ndc.y * 0.5f + 0.5f) * height);
+      };
+
+      auto &edge = result.e[result.count++];
+      edge.s0 = toScreen(c0);
+      edge.s1 = toScreen(c1);
+      edge.invW0 = 1.f / c0.w;
+      edge.invW1 = 1.f / c1.w;
+      edge.world0 = tsd::math::lerp(corners[i], corners[j], t0);
+      edge.world1 = tsd::math::lerp(corners[i], corners[j], t1);
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+void boxOutline(cudaStream_t stream,
+    const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height)
+{
+  const ProjectedEdges edges = projectBoxEdges(box, projView, width, height);
+  const float halfWidth = std::max(1u, lineWidth) * 0.5f;
+
+  thrust::for_each(thrust::cuda::par.on(stream),
+      thrust::make_counting_iterator(0u),
+      thrust::make_counting_iterator(width * height),
+      [=] __device__(uint32_t i) {
+        using tsd::math::dot;
+        // linalg::length is host-only; use dot + sqrtf in device code
+        auto norm2 = [](const tsd::math::float2 &v) {
+          return ::sqrtf(dot(v, v));
+        };
+        auto norm3 = [](const tsd::math::float3 &v) {
+          return ::sqrtf(dot(v, v));
+        };
+        const tsd::math::float2 p(i % width + 0.5f, i / width + 0.5f);
+
+        for (int e = 0; e < edges.count; e++) {
+          const auto &edge = edges.e[e];
+          const tsd::math::float2 d = edge.s1 - edge.s0;
+          const float len2 = dot(d, d);
+          const float t = len2 > 0.f
+              ? ::fminf(::fmaxf(dot(p - edge.s0, d) / len2, 0.f), 1.f)
+              : 0.f;
+          const tsd::math::float2 closest = edge.s0 + t * d;
+          if (norm2(p - closest) > halfWidth)
+            continue;
+
+          if (depth || orthographicDepth) {
+            // Perspective-correct world position at t //
+            const float iw0 = (1.f - t) * edge.invW0;
+            const float iw1 = t * edge.invW1;
+            const tsd::math::float3 world =
+                (edge.world0 * iw0 + edge.world1 * iw1) / (iw0 + iw1);
+
+            const float z = orthographicDepth ? dot(world - eye, dir)
+                                              : norm3(world - eye);
+            if (orthographicDepth && z < 0.f)
+              continue; // behind the orthographic camera plane
+            if (depth && z * (1.f - DEPTH_BIAS) > depth[i])
+              continue;
+          }
+
+          color[i] = outlineColor;
+          break;
+        }
+      });
+}
+
+void boxOutline(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height)
+{
+  boxOutline(cudaStream_t{0},
+      box,
+      projView,
+      eye,
+      dir,
+      orthographicDepth,
+      depth,
+      color,
+      outlineColor,
+      lineWidth,
+      width,
+      height);
+}
+
+} // namespace tsd::algorithms::cuda

--- a/tsd/src/tsd/algorithms/cuda/boxOutline.hpp
+++ b/tsd/src/tsd/algorithms/cuda/boxOutline.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// tsd_core
+#include "tsd/core/TSDMath.hpp"
+// cuda
+#include <cuda_runtime_api.h>
+// std
+#include <cstdint>
+
+namespace tsd::algorithms::cuda {
+
+void boxOutline(cudaStream_t stream,
+    const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height);
+
+void boxOutline(const tsd::math::box3 &box,
+    const tsd::math::mat4 &projView,
+    const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    bool orthographicDepth,
+    const float *depth,
+    uint32_t *color,
+    uint32_t outlineColor,
+    uint32_t lineWidth,
+    uint32_t width,
+    uint32_t height);
+
+} // namespace tsd::algorithms::cuda

--- a/tsd/src/tsd/rendering/CMakeLists.txt
+++ b/tsd/src/tsd/rendering/CMakeLists.txt
@@ -13,6 +13,7 @@ PRIVATE
   pipeline/passes/AnariAxesRenderPass.cpp
   pipeline/passes/AnariSceneRenderPass.cpp
   pipeline/passes/AutoExposurePass.cpp
+  pipeline/passes/BoxOutlineRenderPass.cpp
   pipeline/passes/ClearBuffersPass.cpp
   pipeline/passes/CopyFromColorBufferPass.cpp
   pipeline/passes/CopyToColorBufferPass.cpp
@@ -46,6 +47,7 @@ if (TSD_USE_CUDA)
     pipeline/passes/AnariAxesRenderPass.cpp
     pipeline/passes/AnariSceneRenderPass.cpp
     pipeline/passes/AutoExposurePass.cpp
+    pipeline/passes/BoxOutlineRenderPass.cpp
     pipeline/passes/ClearBuffersPass.cpp
     pipeline/passes/ImagePass.cpp
     pipeline/passes/OutlineRenderPass.cpp

--- a/tsd/src/tsd/rendering/CONTEXT.md
+++ b/tsd/src/tsd/rendering/CONTEXT.md
@@ -1,0 +1,25 @@
+# TSD Rendering
+
+Turns TSD scenes into images: render indexes feed ANARI devices, and an image
+pipeline of composable passes produces the final per-pixel output.
+
+## Language
+
+**Image Pipeline**:
+An ordered sequence of Image Passes that all read and write a shared set of
+per-pixel buffers, executed in insertion order each frame.
+
+**Image Pass**:
+A single, independently enable-able stage of an Image Pipeline.
+
+**Outline**:
+An image-space silhouette border around an object or primitive, derived from
+the rendered ID buffers. An Outline traces what was rendered; it does not
+project geometry.
+_Avoid_: highlight, selection border
+
+**Box Outline**:
+The wireframe formed by the twelve edges of an axis-aligned box, projected
+through a camera view. A Box Outline is a generic box drawing; it is not
+inherently a bounding box — bounding is one client's interpretation.
+_Avoid_: bounding box pass, box wireframe

--- a/tsd/src/tsd/rendering/pipeline/ImagePipeline.h
+++ b/tsd/src/tsd/rendering/pipeline/ImagePipeline.h
@@ -5,6 +5,7 @@
 
 #include "passes/AnariAxesRenderPass.h"
 #include "passes/AnariSceneRenderPass.h"
+#include "passes/BoxOutlineRenderPass.h"
 #include "passes/ClearBuffersPass.h"
 #if ENABLE_SDL
 #include "passes/CopyToSDLTexturePass.h"

--- a/tsd/src/tsd/rendering/pipeline/passes/BoxOutlineRenderPass.cpp
+++ b/tsd/src/tsd/rendering/pipeline/passes/BoxOutlineRenderPass.cpp
@@ -1,0 +1,139 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "BoxOutlineRenderPass.h"
+// tsd_algorithms
+#include "tsd/algorithms/cpu/boxOutline.hpp"
+#ifdef TSD_ALGORITHMS_HAS_CUDA
+#include "tsd/algorithms/cuda/boxOutline.hpp"
+#endif
+// helium
+#include <helium/helium_math.h>
+// std
+#include <cmath>
+
+namespace tsd::rendering {
+
+BoxOutlineRenderPass::BoxOutlineRenderPass() = default;
+
+BoxOutlineRenderPass::~BoxOutlineRenderPass() = default;
+
+void BoxOutlineRenderPass::setBox(const tsd::math::box3 &box)
+{
+  m_box = box;
+}
+
+void BoxOutlineRenderPass::setPerspectiveView(const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    const tsd::math::float3 &up,
+    float fovy)
+{
+  m_viewKind = ViewKind::PERSPECTIVE;
+  m_eye = eye;
+  m_dir = dir;
+  m_up = up;
+  m_fovy = fovy;
+}
+
+void BoxOutlineRenderPass::setOrthographicView(const tsd::math::float3 &eye,
+    const tsd::math::float3 &dir,
+    const tsd::math::float3 &up,
+    float height)
+{
+  m_viewKind = ViewKind::ORTHOGRAPHIC;
+  m_eye = eye;
+  m_dir = dir;
+  m_up = up;
+  m_height = height;
+}
+
+void BoxOutlineRenderPass::setColor(const tsd::math::float4 &color)
+{
+  m_color = color;
+}
+
+void BoxOutlineRenderPass::setWidth(uint32_t width)
+{
+  m_width = width;
+}
+
+void BoxOutlineRenderPass::setDepthTestEnabled(bool enabled)
+{
+  m_depthTestEnabled = enabled;
+}
+
+void BoxOutlineRenderPass::render(ImageBuffers &b, int stageId)
+{
+  if (!b.color || stageId == 0 || m_viewKind == ViewKind::NONE)
+    return;
+
+  const auto size = getDimensions();
+  if (size.x == 0 || size.y == 0)
+    return;
+
+  const float aspect = size.x / float(size.y);
+
+  const auto view =
+      linalg::lookat_matrix(m_eye, m_eye + m_dir, m_up);
+
+  // Only the projected xy is consumed downstream (fragment depth comes from
+  // the interpolated world position), so near/far need no scene fitting.
+  constexpr float near = 0.1f;
+  constexpr float far = 1000.f;
+
+  tsd::math::mat4 proj;
+  if (m_viewKind == ViewKind::PERSPECTIVE) {
+    const float oneOverTanFov = 1.f / std::tan(m_fovy / 2.f);
+    proj = tsd::math::mat4{
+        {oneOverTanFov / aspect, 0.f, 0.f, 0.f},
+        {0.f, oneOverTanFov, 0.f, 0.f},
+        {0.f, 0.f, -(far + near) / (far - near), -1.f},
+        {0.f, 0.f, -2.f * far * near / (far - near), 0.f},
+    };
+  } else {
+    const float halfHeight = m_height * 0.5f;
+    const float halfWidth = halfHeight * aspect;
+    proj = tsd::math::mat4{
+        {1.f / halfWidth, 0.f, 0.f, 0.f},
+        {0.f, 1.f / halfHeight, 0.f, 0.f},
+        {0.f, 0.f, -2.f / (far - near), 0.f},
+        {0.f, 0.f, -(far + near) / (far - near), 1.f},
+    };
+  }
+
+  const auto projView = tsd::math::mul(proj, view);
+  const auto color = helium::cvt_color_to_uint32(m_color);
+  const float *depth = m_depthTestEnabled ? b.depth : nullptr;
+  const bool orthographicDepth = m_viewKind == ViewKind::ORTHOGRAPHIC;
+
+#ifdef TSD_ALGORITHMS_HAS_CUDA
+  if (b.stream) {
+    tsd::algorithms::cuda::boxOutline(b.stream,
+        m_box,
+        projView,
+        m_eye,
+        m_dir,
+        orthographicDepth,
+        depth,
+        b.color,
+        color,
+        m_width,
+        size.x,
+        size.y);
+    return;
+  }
+#endif
+  tsd::algorithms::cpu::boxOutline(m_box,
+      projView,
+      m_eye,
+      m_dir,
+      orthographicDepth,
+      depth,
+      b.color,
+      color,
+      m_width,
+      size.x,
+      size.y);
+}
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/rendering/pipeline/passes/BoxOutlineRenderPass.h
+++ b/tsd/src/tsd/rendering/pipeline/passes/BoxOutlineRenderPass.h
@@ -1,0 +1,63 @@
+// Copyright 2026 NVIDIA Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ImagePass.h"
+// tsd_core
+#include "tsd/core/TSDMath.hpp"
+
+namespace tsd::rendering {
+
+/*
+ * Draws the Box Outline (12 edges) of a single world-space AABB into the
+ * color buffer through the given camera view. One box per pass instance;
+ * hide it via setEnabled(false). Lines are depth-tested against the depth
+ * buffer by default and silently fall back to an overlay when no depth
+ * buffer is present.
+ */
+struct BoxOutlineRenderPass : public ImagePass
+{
+  BoxOutlineRenderPass();
+  ~BoxOutlineRenderPass() override;
+  const char *name() const override { return "Box Outline"; }
+
+  void setBox(const tsd::math::box3 &box);
+  void setPerspectiveView(const tsd::math::float3 &eye,
+      const tsd::math::float3 &dir,
+      const tsd::math::float3 &up,
+      float fovy);
+  // 'eye' must lie on the plane where the camera's rays originate (the same
+  // eye handed to the ANARI camera, e.g. Manipulator::eye_FixedDistance()) —
+  // fragment depth is measured from that plane along 'dir'.
+  void setOrthographicView(const tsd::math::float3 &eye,
+      const tsd::math::float3 &dir,
+      const tsd::math::float3 &up,
+      float height);
+  void setColor(const tsd::math::float4 &color);
+  void setWidth(uint32_t width);
+  void setDepthTestEnabled(bool enabled);
+
+ private:
+  void render(ImageBuffers &b, int stageId) override;
+
+  enum class ViewKind
+  {
+    NONE,
+    PERSPECTIVE,
+    ORTHOGRAPHIC
+  };
+
+  tsd::math::box3 m_box{{0.f, 0.f, 0.f}, {0.f, 0.f, 0.f}};
+  ViewKind m_viewKind{ViewKind::NONE};
+  tsd::math::float3 m_eye{0.f, 0.f, 0.f};
+  tsd::math::float3 m_dir{0.f, 0.f, -1.f};
+  tsd::math::float3 m_up{0.f, 1.f, 0.f};
+  float m_fovy{0.f}; // radians, perspective only
+  float m_height{0.f}; // world units, orthographic only
+  tsd::math::float4 m_color{0.8f, 0.8f, 0.8f, 1.f};
+  uint32_t m_width{1};
+  bool m_depthTestEnabled{true};
+};
+
+} // namespace tsd::rendering

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.cpp
@@ -339,6 +339,9 @@ void Viewport::saveSettings(tsd::core::DataNode &root)
   root["showOnlySelected"] = m_showOnlySelected;
   root["highlightSelection"] = m_highlightSelection;
   root["outlinePrimitives"] = m_outlinePrimitives;
+  root["showWorldBounds"] = m_showWorldBounds;
+  root["worldBoundsColor"] = m_worldBoundsColor;
+  root["worldBoundsWidth"] = m_worldBoundsWidth;
   root["visualizeAOV"] = static_cast<int>(m_visualizeAOV);
   root["depthVisualMinimum"] = m_depthVisualMinimum;
   root["depthVisualMaximum"] = m_depthVisualMaximum;
@@ -368,6 +371,9 @@ void Viewport::loadSettings(tsd::core::DataNode &root)
   root["showOnlySelected"].getValue(ANARI_BOOL, &m_showOnlySelected);
   root["highlightSelection"].getValue(ANARI_BOOL, &m_highlightSelection);
   root["outlinePrimitives"].getValue(ANARI_BOOL, &m_outlinePrimitives);
+  root["showWorldBounds"].getValue(ANARI_BOOL, &m_showWorldBounds);
+  root["worldBoundsColor"].getValue(ANARI_FLOAT32_VEC4, &m_worldBoundsColor);
+  root["worldBoundsWidth"].getValue(ANARI_INT32, &m_worldBoundsWidth);
   int aovType = static_cast<int>(m_visualizeAOV);
   root["visualizeAOV"].getValue(ANARI_INT32, &aovType);
   m_visualizeAOV = static_cast<tsd::rendering::AOVType>(aovType);
@@ -526,6 +532,9 @@ void Viewport::imagePipeline_populate(tsd::rendering::ImagePipeline &p)
 
   m_outlinePass = p.emplace_back<tsd::rendering::OutlineRenderPass>();
 
+  m_boundsOutlinePass = p.emplace_back<tsd::rendering::BoxOutlineRenderPass>();
+  m_boundsOutlinePass->setEnabled(false);
+
   m_outputPass = p.emplace_back<tsd::rendering::CopyToSDLTexturePass>(
       m_app->sdlRenderer());
 
@@ -642,6 +651,7 @@ void Viewport::teardownDevice()
   m_outputTransformPass = nullptr;
   m_primitiveOutlinePass = nullptr;
   m_outlinePass = nullptr;
+  m_boundsOutlinePass = nullptr;
   m_outputPass = nullptr;
   m_saveToFilePass = nullptr;
 
@@ -744,6 +754,8 @@ void Viewport::updateImage()
   }
   m_outlinePass->setOutlineId(id);
 
+  updateBoundsOutlinePass();
+
   auto start = std::chrono::steady_clock::now();
   BaseViewport::imagePipeline_render();
   if (m_autoExposurePass)
@@ -757,6 +769,52 @@ void Viewport::updateImage()
   m_latestAnariFL = duration * 1000;
   m_minFL = m_minFL ? std::min(*m_minFL, m_latestAnariFL) : m_latestAnariFL;
   m_maxFL = m_maxFL ? std::max(*m_maxFL, m_latestAnariFL) : m_latestAnariFL;
+}
+
+void Viewport::updateBoundsOutlinePass()
+{
+  if (!m_boundsOutlinePass)
+    return;
+
+  const auto subtype =
+      m_camera.current ? m_camera.current->subtype() : tsd::core::Token();
+  const bool supportedCamera = subtype == scene::tokens::camera::perspective
+      || subtype == scene::tokens::camera::orthographic;
+  const bool enabled = m_showWorldBounds && supportedCamera;
+  m_boundsOutlinePass->setEnabled(enabled);
+  if (!enabled)
+    return;
+
+  tsd::math::box3 bounds;
+  anariGetProperty(m_device,
+      m_rIdx->world(),
+      "bounds",
+      ANARI_FLOAT32_BOX3,
+      &bounds,
+      sizeof(bounds),
+      ANARI_WAIT);
+  m_boundsOutlinePass->setBox(bounds);
+
+  m_boundsOutlinePass->setColor(m_worldBoundsColor);
+  m_boundsOutlinePass->setWidth(uint32_t(std::max(1, m_worldBoundsWidth)));
+
+  if (subtype == scene::tokens::camera::perspective) {
+    const float fovy =
+        m_camera.current->parameterValueAs<float>("fovy").value_or(
+            math::radians(40.f));
+    m_boundsOutlinePass->setPerspectiveView(m_camera.arcball->eye(),
+        m_camera.arcball->dir(),
+        m_camera.arcball->up(),
+        fovy);
+  } else {
+    // Eye and height must match updateCameraParametersOrthographic so the
+    // outline lands on the same image as the rendered scene.
+    m_boundsOutlinePass->setOrthographicView(
+        m_camera.arcball->eye_FixedDistance(),
+        m_camera.arcball->dir(),
+        m_camera.arcball->up(),
+        m_camera.arcball->distance() * 0.75f);
+  }
 }
 
 void Viewport::syncImagePassState()
@@ -1102,6 +1160,19 @@ void Viewport::ui_menubar_Viewport()
 void Viewport::ui_menubar_World()
 {
   if (ImGui::BeginMenu("World")) {
+    ImGui::Checkbox("Show Bounds", &m_showWorldBounds);
+
+    ImGui::BeginDisabled(!m_showWorldBounds);
+    ImGui::Indent(INDENT_AMOUNT);
+    ImGui::ColorEdit4(
+        "Color##worldBounds", &m_worldBoundsColor.x, ImGuiColorEditFlags_NoInputs);
+    if (ImGui::DragInt("Width##worldBounds", &m_worldBoundsWidth, 0.25f, 1, 16))
+      m_worldBoundsWidth = std::max(1, m_worldBoundsWidth);
+    ImGui::Unindent(INDENT_AMOUNT);
+    ImGui::EndDisabled();
+
+    ImGui::Separator();
+
     if (ImGui::MenuItem("Print Bounds")) {
       tsd::math::float3 bounds[2];
 

--- a/tsd/src/tsd/ui/imgui/windows/Viewport.h
+++ b/tsd/src/tsd/ui/imgui/windows/Viewport.h
@@ -12,6 +12,7 @@
 #include "tsd/rendering/pipeline/ImagePipeline.h"
 #include "tsd/rendering/pipeline/passes/AnariSceneRenderPass.h"
 #include "tsd/rendering/pipeline/passes/AutoExposurePass.h"
+#include "tsd/rendering/pipeline/passes/BoxOutlineRenderPass.h"
 #include "tsd/rendering/pipeline/passes/CopyToSDLTexturePass.h"
 #include "tsd/rendering/pipeline/passes/OutlineRenderPass.h"
 #include "tsd/rendering/pipeline/passes/PrimitiveOutlineRenderPass.h"
@@ -74,6 +75,7 @@ struct Viewport : public BaseViewport
 
   void updateFrame();
   void updateImage();
+  void updateBoundsOutlinePass();
   void syncImagePassState();
   void updateDisplayPassState();
 
@@ -102,6 +104,9 @@ struct Viewport : public BaseViewport
   bool m_highlightSelection{true};
   bool m_outlinePrimitives{false};
   bool m_showOnlySelected{false};
+  bool m_showWorldBounds{false};
+  tsd::math::float4 m_worldBoundsColor{0.8f, 0.8f, 0.8f, 1.f};
+  int m_worldBoundsWidth{1};
   std::optional<float> m_frameProgress{0.f};
   bool m_deviceSupportsPrimitiveId{false};
 
@@ -141,6 +146,7 @@ struct Viewport : public BaseViewport
   tsd::rendering::OutputTransformPass *m_outputTransformPass{nullptr};
   tsd::rendering::PrimitiveOutlineRenderPass *m_primitiveOutlinePass{nullptr};
   tsd::rendering::OutlineRenderPass *m_outlinePass{nullptr};
+  tsd::rendering::BoxOutlineRenderPass *m_boundsOutlinePass{nullptr};
   tsd::rendering::CopyToSDLTexturePass *m_outputPass{nullptr};
   tsd::rendering::SaveToFilePass *m_saveToFilePass{nullptr};
 

--- a/tsd/tests/test_Algorithms.cpp
+++ b/tsd/tests/test_Algorithms.cpp
@@ -5,6 +5,7 @@
 #include "catch.hpp"
 // tsd_algorithms
 #include "tsd/algorithms/cpu/autoExposure.hpp"
+#include "tsd/algorithms/cpu/boxOutline.hpp"
 #include "tsd/algorithms/cpu/clearBuffers.hpp"
 #include "tsd/algorithms/cpu/convertColorBuffer.hpp"
 #include "tsd/algorithms/cpu/depthCompositeFrame.hpp"
@@ -279,6 +280,218 @@ SCENARIO("Host AOV visualization converts buffers into display colors",
         REQUIRE(idColor[1] == packColor({0.f, 0.f, 0.f, 1.f}));
         REQUIRE(idColor[0] == idColor[2]);
         REQUIRE(idColor[0] != idColor[3]);
+      }
+    }
+  }
+}
+
+SCENARIO("Host box outlining rasterizes only the projected box edges",
+    "[Algorithms]")
+{
+  GIVEN("An 8x8 frame and a box that projects onto known pixel centers")
+  {
+    // Identity projView acts as an orthographic camera at the origin looking
+    // down -z: NDC == world xy. Corners at +/-0.375 land on the pixel
+    // centers of columns/rows 2 and 5 in an 8x8 image.
+    const math::mat4 projView = math::IDENTITY_MAT4;
+    const math::box3 box{{-0.375f, -0.375f, -1.f}, {0.375f, 0.375f, -0.5f}};
+    const math::float3 eye(0.f, 0.f, 0.f);
+    const math::float3 dir(0.f, 0.f, -1.f);
+
+    const uint32_t baseColor = packColor({0.2f, 0.4f, 0.6f, 1.f});
+    const uint32_t boxColor = packColor({1.f, 0.f, 0.f, 1.f});
+    std::vector<uint32_t> color(64, baseColor);
+
+    WHEN("The box outline is drawn without a depth buffer")
+    {
+      cpu::boxOutline(
+          box, projView, eye, dir, true, nullptr, color.data(), boxColor, 1u,
+          8u, 8u);
+
+      THEN("Border pixels of the projected rectangle are shaded")
+      {
+        auto at = [&](uint32_t x, uint32_t y) { return color[y * 8 + x]; };
+        REQUIRE(at(2, 2) == boxColor); // corner
+        REQUIRE(at(4, 2) == boxColor); // bottom edge
+        REQUIRE(at(5, 5) == boxColor); // corner
+        REQUIRE(at(2, 3) == boxColor); // left edge
+        REQUIRE(at(5, 4) == boxColor); // right edge
+        REQUIRE(at(3, 5) == boxColor); // top edge
+      }
+
+      THEN("Interior and exterior pixels are untouched")
+      {
+        auto at = [&](uint32_t x, uint32_t y) { return color[y * 8 + x]; };
+        REQUIRE(at(3, 3) == baseColor);
+        REQUIRE(at(4, 4) == baseColor);
+        REQUIRE(at(0, 0) == baseColor);
+        REQUIRE(at(7, 7) == baseColor);
+        REQUIRE(at(4, 0) == baseColor);
+      }
+    }
+  }
+}
+
+SCENARIO("Host box outlining respects the depth buffer", "[Algorithms]")
+{
+  GIVEN("A box one unit in front of an orthographic camera plane")
+  {
+    const math::mat4 projView = math::IDENTITY_MAT4;
+    const math::box3 box{{-0.375f, -0.375f, -1.f}, {0.375f, 0.375f, -1.f}};
+    const math::float3 eye(0.f, 0.f, 0.f);
+    const math::float3 dir(0.f, 0.f, -1.f);
+
+    const uint32_t baseColor = packColor({0.2f, 0.4f, 0.6f, 1.f});
+    const uint32_t boxColor = packColor({1.f, 0.f, 0.f, 1.f});
+    std::vector<uint32_t> color(64, baseColor);
+
+    WHEN("Everything in the depth buffer is nearer than the box")
+    {
+      std::vector<float> depth(64, 0.5f);
+      cpu::boxOutline(box, projView, eye, dir, true, depth.data(),
+          color.data(), boxColor, 1u, 8u, 8u);
+
+      THEN("No pixels are shaded")
+      {
+        REQUIRE(std::all_of(color.begin(), color.end(), [&](uint32_t c) {
+          return c == baseColor;
+        }));
+      }
+    }
+
+    WHEN("Everything in the depth buffer is farther than the box")
+    {
+      std::vector<float> depth(64, 2.f);
+      cpu::boxOutline(box, projView, eye, dir, true, depth.data(),
+          color.data(), boxColor, 1u, 8u, 8u);
+
+      THEN("Edge pixels are shaded")
+      {
+        REQUIRE(color[2 * 8 + 2] == boxColor);
+      }
+    }
+
+    WHEN("Occluding depth exists but no depth buffer is passed")
+    {
+      cpu::boxOutline(box, projView, eye, dir, true, nullptr, color.data(),
+          boxColor, 1u, 8u, 8u);
+
+      THEN("The outline is drawn as an overlay anyway")
+      {
+        REQUIRE(color[2 * 8 + 2] == boxColor);
+      }
+    }
+
+    WHEN("The depth buffer exactly matches the box (touching geometry)")
+    {
+      std::vector<float> depth(64, 1.f);
+      cpu::boxOutline(box, projView, eye, dir, true, depth.data(),
+          color.data(), boxColor, 1u, 8u, 8u);
+
+      THEN("The relative bias keeps the outline visible")
+      {
+        REQUIRE(color[2 * 8 + 2] == boxColor);
+      }
+    }
+  }
+}
+
+SCENARIO(
+    "Host box outlining clips edges behind a perspective camera",
+    "[Algorithms]")
+{
+  GIVEN("A perspective camera at the origin looking down -z")
+  {
+    const math::float3 eye(0.f, 0.f, 0.f);
+    const math::float3 dir(0.f, 0.f, -1.f);
+    const math::float3 up(0.f, 1.f, 0.f);
+    const auto view = linalg::lookat_matrix(eye, eye + dir, up);
+
+    const float fovy = math::radians(60.f);
+    const float oneOverTanFov = 1.f / std::tan(fovy / 2.f);
+    const float near = 0.1f, far = 100.f;
+    const math::mat4 proj{{oneOverTanFov, 0.f, 0.f, 0.f},
+        {0.f, oneOverTanFov, 0.f, 0.f},
+        {0.f, 0.f, -(far + near) / (far - near), -1.f},
+        {0.f, 0.f, -2.f * far * near / (far - near), 0.f}};
+    const auto projView = math::mul(proj, view);
+
+    const uint32_t baseColor = packColor({0.2f, 0.4f, 0.6f, 1.f});
+    const uint32_t boxColor = packColor({1.f, 0.f, 0.f, 1.f});
+    std::vector<uint32_t> color(64, baseColor);
+
+    WHEN("The box is entirely behind the camera")
+    {
+      const math::box3 box{{-1.f, -1.f, 1.f}, {1.f, 1.f, 2.f}};
+      cpu::boxOutline(box, projView, eye, dir, false, nullptr, color.data(),
+          boxColor, 1u, 8u, 8u);
+
+      THEN("Nothing is drawn")
+      {
+        REQUIRE(std::all_of(color.begin(), color.end(), [&](uint32_t c) {
+          return c == baseColor;
+        }));
+      }
+    }
+
+    WHEN("The box straddles the eye plane")
+    {
+      const math::box3 box{{-1.f, -1.f, -4.f}, {1.f, 1.f, 1.f}};
+      cpu::boxOutline(box, projView, eye, dir, false, nullptr, color.data(),
+          boxColor, 1u, 8u, 8u);
+
+      THEN("The part in front of the camera is still drawn")
+      {
+        REQUIRE(std::any_of(color.begin(), color.end(), [&](uint32_t c) {
+          return c == boxColor;
+        }));
+      }
+    }
+
+    WHEN("The box is fully in front of the camera")
+    {
+      const math::box3 box{{-1.f, -1.f, -4.f}, {1.f, 1.f, -2.f}};
+      cpu::boxOutline(box, projView, eye, dir, false, nullptr, color.data(),
+          boxColor, 1u, 8u, 8u);
+
+      THEN("The projected front-face corners land at the expected pixels")
+      {
+        // Front face at z=-2: ndc = (+/-1 * oneOverTanFov) / 2 ~= +/-0.866;
+        // pixel = (ndc*0.5+0.5)*8 -> ~0.54 and ~7.46.
+        REQUIRE(color[1 * 8 + 0] != baseColor);
+        REQUIRE(color[6 * 8 + 7] != baseColor);
+      }
+    }
+
+    WHEN("A depth buffer nearer than the box is provided")
+    {
+      // Nearest box point (0, 0, -2) is 2 units from the eye (Euclidean).
+      const math::box3 box{{-1.f, -1.f, -4.f}, {1.f, 1.f, -2.f}};
+      std::vector<float> depth(64, 1.f);
+      cpu::boxOutline(box, projView, eye, dir, false, depth.data(),
+          color.data(), boxColor, 1u, 8u, 8u);
+
+      THEN("The Euclidean eye-distance test rejects every fragment")
+      {
+        REQUIRE(std::all_of(color.begin(), color.end(), [&](uint32_t c) {
+          return c == baseColor;
+        }));
+      }
+    }
+
+    WHEN("A depth buffer farther than the box is provided")
+    {
+      // Farthest box point is sqrt(1+1+16) ~= 4.24 units from the eye.
+      const math::box3 box{{-1.f, -1.f, -4.f}, {1.f, 1.f, -2.f}};
+      std::vector<float> depth(64, 50.f);
+      cpu::boxOutline(box, projView, eye, dir, false, depth.data(),
+          color.data(), boxColor, 1u, 8u, 8u);
+
+      THEN("The outline is drawn")
+      {
+        REQUIRE(std::any_of(color.begin(), color.end(), [&](uint32_t c) {
+          return c == boxColor;
+        }));
       }
     }
   }


### PR DESCRIPTION
Add a Box Outline image pass that rasterizes the 12 edges of a world-space AABB into the pipeline color buffer through perspective or orthographic view parameters, with configurable line width and color. Fragments are depth-tested against the eye-distance depth channel with a small relative bias (silent overlay fallback without a depth buffer), and edge segments behind a perspective eye are clipped.

CPU and CUDA kernels follow the existing cpu/cuda algorithm pair pattern. First consumer is a "Show Bounds" toggle (plus color/width widgets) in the Viewport World menu, driven by the ANARI world bounds property and persisted with the other viewport settings.