### PR TITLE
Fix and test primitive intersections

### DIFF
--- a/devices/rtx/apps/tests/CMakeLists.txt
+++ b/devices/rtx/apps/tests/CMakeLists.txt
@@ -34,3 +34,4 @@ if (NOT VISRTX_BUILD_TESTS)
 endif()
 
 add_subdirectory(api)
+add_subdirectory(unit)

--- a/devices/rtx/apps/tests/api/CMakeLists.txt
+++ b/devices/rtx/apps/tests/api/CMakeLists.txt
@@ -48,4 +48,5 @@ make_test(TestEvictGPUArray)
 make_test(TestMultiThreadedObjectCreation)
 make_test(TestSpheres)
 make_test(TestCylinderCaps)
+make_test(TestIsosurfaceRamp)
 

--- a/devices/rtx/apps/tests/api/CMakeLists.txt
+++ b/devices/rtx/apps/tests/api/CMakeLists.txt
@@ -47,4 +47,5 @@ make_test(TestDeviceInit)
 make_test(TestEvictGPUArray)
 make_test(TestMultiThreadedObjectCreation)
 make_test(TestSpheres)
+make_test(TestCylinderCaps)
 

--- a/devices/rtx/apps/tests/api/CMakeLists.txt
+++ b/devices/rtx/apps/tests/api/CMakeLists.txt
@@ -50,4 +50,5 @@ make_test(TestSpheres)
 make_test(TestCylinderCaps)
 make_test(TestIsosurfaceRamp)
 make_test(TestPrimitiveInterior)
+make_test(TestGroundSphereShadows)
 

--- a/devices/rtx/apps/tests/api/CMakeLists.txt
+++ b/devices/rtx/apps/tests/api/CMakeLists.txt
@@ -49,4 +49,5 @@ make_test(TestMultiThreadedObjectCreation)
 make_test(TestSpheres)
 make_test(TestCylinderCaps)
 make_test(TestIsosurfaceRamp)
+make_test(TestPrimitiveInterior)
 

--- a/devices/rtx/apps/tests/api/TestCylinderCaps.cpp
+++ b/devices/rtx/apps/tests/api/TestCylinderCaps.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// GPU regression for the capped-cylinder end-on bug: a cylinder viewed straight
+// down its axis must show its flat cap (previously the axis-parallel ray hit
+// nothing). Renders end-on with caps="both" (center pixel must be geometry) and
+// caps="none" (center pixel must be background), asserting both.
+
+// anari_cpp
+#define ANARI_EXTENSION_UTILITY_IMPL
+#include <anari/anari_cpp.hpp>
+#include <anari/anari_cpp/ext/std.h>
+// VisRTX
+#include <anari/ext/visrtx/makeVisRTXDevice.h>
+// std
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using uvec2 = std::array<unsigned int, 2>;
+using vec3 = std::array<float, 3>;
+using vec4 = std::array<float, 4>;
+
+static void statusFunc(const void *,
+    ANARIDevice,
+    ANARIObject source,
+    ANARIDataType,
+    ANARIStatusSeverity severity,
+    ANARIStatusCode,
+    const char *message)
+{
+  if (severity == ANARI_SEVERITY_FATAL_ERROR) {
+    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
+    std::exit(1);
+  } else if (severity == ANARI_SEVERITY_ERROR)
+    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
+}
+
+// Render a single unit cylinder end-on and return whether the center pixel is
+// covered by geometry (non-background).
+static bool centerPixelHit(anari::Device device, const char *caps)
+{
+  const uvec2 imageSize = {64, 64};
+  const vec4 background = {0.f, 0.f, 0.f, 1.f};
+
+  auto geometry = anari::newObject<anari::Geometry>(device, "cylinder");
+  {
+    // One cylinder along +z, [0,1], fat enough to cover the center pixel.
+    std::array<vec3, 2> positions = {vec3{0.f, 0.f, 0.f}, vec3{0.f, 0.f, 1.f}};
+    anari::setParameterArray1D(
+        device, geometry, "vertex.position", positions.data(), positions.size());
+    anari::setParameter(device, geometry, "radius", 0.4f);
+    anari::setParameter(device, geometry, "caps", caps);
+    anari::commitParameters(device, geometry);
+  }
+
+  auto material = anari::newObject<anari::Material>(device, "matte");
+  anari::setParameter(device, material, "color", vec3{1.f, 0.f, 0.f});
+  anari::commitParameters(device, material);
+
+  auto surface = anari::newObject<anari::Surface>(device);
+  anari::setAndReleaseParameter(device, surface, "geometry", geometry);
+  anari::setAndReleaseParameter(device, surface, "material", material);
+  anari::commitParameters(device, surface);
+
+  auto world = anari::newObject<anari::World>(device);
+  anari::setParameterArray1D(device, world, "surface", &surface, 1);
+  anari::release(device, surface);
+  anari::commitParameters(device, world);
+
+  // Camera looks straight down the +z axis at the near cap.
+  auto camera = anari::newObject<anari::Camera>(device, "perspective");
+  anari::setParameter(device, camera, "position", vec3{0.f, 0.f, -3.f});
+  anari::setParameter(device, camera, "direction", vec3{0.f, 0.f, 1.f});
+  anari::setParameter(device, camera, "up", vec3{0.f, 1.f, 0.f});
+  anari::setParameter(
+      device, camera, "aspect", imageSize[0] / float(imageSize[1]));
+  anari::commitParameters(device, camera);
+
+  auto renderer = anari::newObject<anari::Renderer>(device, "debug");
+  anari::setParameter(device, renderer, "background", background);
+  anari::setParameter(device, renderer, "method", "baseColor");
+  anari::commitParameters(device, renderer);
+
+  auto frame = anari::newObject<anari::Frame>(device);
+  anari::setParameter(device, frame, "size", imageSize);
+  anari::setParameter(device, frame, "channel.color", ANARI_UFIXED8_RGBA_SRGB);
+  anari::setAndReleaseParameter(device, frame, "world", world);
+  anari::setAndReleaseParameter(device, frame, "camera", camera);
+  anari::setAndReleaseParameter(device, frame, "renderer", renderer);
+  anari::commitParameters(device, frame);
+
+  anari::render(device, frame);
+  anari::wait(device, frame);
+
+  auto fb = anari::map<uint32_t>(device, frame, "channel.color");
+  const uint32_t center = fb.data[(imageSize[1] / 2) * fb.width + imageSize[0] / 2];
+  const uint32_t red = center & 0xFFu; // R channel (RGBA8, little-endian)
+  anari::unmap(device, frame, "channel.color");
+  anari::release(device, frame);
+
+  return red > 16u; // geometry (red) vs black background
+}
+
+int main()
+{
+  auto device = makeVisRTXDevice(statusFunc);
+
+  const bool cappedHit = centerPixelHit(device, "both");
+  const bool uncappedHit = centerPixelHit(device, "none");
+
+  anari::release(device, device);
+
+  int failures = 0;
+  if (!cappedHit) {
+    fprintf(stderr, "FAIL: end-on caps=both cylinder shows no cap (regression)\n");
+    ++failures;
+  }
+  if (uncappedHit) {
+    fprintf(stderr, "FAIL: end-on caps=none cylinder unexpectedly hit\n");
+    ++failures;
+  }
+  if (failures)
+    return 1;
+  printf("cylinder caps end-on regression passed\n");
+  return 0;
+}

--- a/devices/rtx/apps/tests/api/TestGroundSphereShadows.cpp
+++ b/devices/rtx/apps/tests/api/TestGroundSphereShadows.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// GPU regression for phantom self-shadowing on large analytic spheres
+// (concentric acne rings): an RTOW-scale ground sphere (r=1000) lit by a
+// directional light, with no occluders, must render uniformly lit. Shadow rays
+// start on the sphere's own surface and graze it, so any false self-hit shows
+// up as dark rings. Renders with the 'interactive' renderer (light-sample
+// shadow rays, AO off) and asserts that no pixel in the central region is
+// significantly darker than the region's brightest pixel.
+
+// anari_cpp
+#define ANARI_EXTENSION_UTILITY_IMPL
+#include <anari/anari_cpp/ext/std.h>
+#include <anari/anari_cpp.hpp>
+// VisRTX
+#include <anari/ext/visrtx/makeVisRTXDevice.h>
+// std
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+// stb_image
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include "stb_image_write.h"
+
+using uvec2 = std::array<unsigned int, 2>;
+using vec3 = std::array<float, 3>;
+using vec4 = std::array<float, 4>;
+
+static void statusFunc(const void *,
+    ANARIDevice,
+    ANARIObject source,
+    ANARIDataType,
+    ANARIStatusSeverity severity,
+    ANARIStatusCode,
+    const char *message)
+{
+  if (severity == ANARI_SEVERITY_FATAL_ERROR) {
+    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
+    std::exit(1);
+  } else if (severity == ANARI_SEVERITY_ERROR)
+    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
+}
+
+int main()
+{
+  auto device = makeVisRTXDevice(statusFunc);
+
+  const uvec2 imageSize = {512, 256};
+
+  // RTOW ground sphere: r=1000 centered at (0,-1000,0).
+  auto geometry = anari::newObject<anari::Geometry>(device, "sphere");
+  const vec3 center = {0.f, -1000.f, 0.f};
+  anari::setParameterArray1D(device, geometry, "vertex.position", &center, 1);
+  anari::setParameter(device, geometry, "radius", 1000.f);
+  anari::commitParameters(device, geometry);
+
+  auto material = anari::newObject<anari::Material>(device, "matte");
+  anari::setParameter(device, material, "color", vec3{0.8f, 0.8f, 0.8f});
+  anari::commitParameters(device, material);
+
+  auto surface = anari::newObject<anari::Surface>(device);
+  anari::setAndReleaseParameter(device, surface, "geometry", geometry);
+  anari::setAndReleaseParameter(device, surface, "material", material);
+  anari::commitParameters(device, surface);
+
+  auto light = anari::newObject<anari::Light>(device, "directional");
+  anari::setParameter(device, light, "direction", vec3{0.3f, -1.f, 0.2f});
+  anari::setParameter(device, light, "irradiance", 3.f);
+  anari::commitParameters(device, light);
+
+  auto world = anari::newObject<anari::World>(device);
+  anari::setParameterArray1D(device, world, "surface", &surface, 1);
+  anari::setParameterArray1D(device, world, "light", &light, 1);
+  anari::release(device, surface);
+  anari::release(device, light);
+  anari::commitParameters(device, world);
+
+  // Camera above the ground, looking out at a shallow angle so the visible
+  // ground spans near-to-far grazing shadow-ray geometry (the ring zone).
+  auto camera = anari::newObject<anari::Camera>(device, "perspective");
+  anari::setParameter(device, camera, "position", vec3{0.f, 2.f, 0.f});
+  anari::setParameter(device, camera, "direction", vec3{0.f, -0.25f, 1.f});
+  anari::setParameter(device, camera, "up", vec3{0.f, 1.f, 0.f});
+  anari::setParameter(
+      device, camera, "aspect", imageSize[0] / float(imageSize[1]));
+  anari::commitParameters(device, camera);
+
+  auto renderer = anari::newObject<anari::Renderer>(device, "interactive");
+  anari::setParameter(device, renderer, "background", vec4{0.f, 0.f, 0.f, 1.f});
+  anari::setParameter(device, renderer, "ambientSamples", 0);
+  anari::setParameter(device, renderer, "ambientRadiance", 0.f);
+  anari::setParameter(device, renderer, "pixelSamples", 16);
+  anari::commitParameters(device, renderer);
+
+  auto frame = anari::newObject<anari::Frame>(device);
+  anari::setParameter(device, frame, "size", imageSize);
+  anari::setParameter(device, frame, "channel.color", ANARI_UFIXED8_RGBA_SRGB);
+  anari::setAndReleaseParameter(device, frame, "world", world);
+  anari::setAndReleaseParameter(device, frame, "camera", camera);
+  anari::setAndReleaseParameter(device, frame, "renderer", renderer);
+  anari::commitParameters(device, frame);
+
+  anari::render(device, frame);
+  anari::wait(device, frame);
+
+  auto fb = anari::map<uint32_t>(device, frame, "channel.color");
+
+  stbi_flip_vertically_on_write(1);
+  stbi_write_png("testApp_groundSphereShadows.png",
+      fb.width,
+      fb.height,
+      4,
+      fb.data,
+      4 * fb.width);
+
+  // Bottom half only: all ground, no sky/silhouette (framebuffer row 0 is the
+  // image bottom). Lighting varies smoothly over the giant sphere, so a dark
+  // pixel == a phantom self-shadow ring.
+  uint32_t minR = 255, maxR = 0;
+  uint64_t dark = 0, total = 0;
+  for (uint32_t y = imageSize[1] / 8; y < imageSize[1] / 2; ++y) {
+    for (uint32_t x = imageSize[0] / 8; x < 7 * imageSize[0] / 8; ++x) {
+      const uint32_t r = fb.data[y * fb.width + x] & 0xFFu;
+      minR = std::min(minR, r);
+      maxR = std::max(maxR, r);
+      ++total;
+      if (r < 128u)
+        ++dark;
+    }
+  }
+  anari::unmap(device, frame, "channel.color");
+  anari::release(device, frame);
+  anari::release(device, device);
+
+  printf("ground region: minR=%u maxR=%u darkFraction=%f\n",
+      minR,
+      maxR,
+      double(dark) / double(total));
+
+  // Fully lit gray ground under a bright directional light: every pixel must
+  // be bright. Phantom rings pull pixels toward black.
+  if (maxR < 128u) {
+    fprintf(stderr, "FAIL: ground unexpectedly dark overall (bad scene?)\n");
+    return 1;
+  }
+  if (dark) {
+    fprintf(stderr,
+        "FAIL: %llu/%llu ground pixels shadowed with no occluder (acne)\n",
+        (unsigned long long)dark,
+        (unsigned long long)total);
+    return 1;
+  }
+  printf("ground sphere shadow acne regression passed\n");
+  return 0;
+}

--- a/devices/rtx/apps/tests/api/TestIsosurfaceRamp.cpp
+++ b/devices/rtx/apps/tests/api/TestIsosurfaceRamp.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// GPU end-to-end test for the isosurface intersector (DDA + macrocell-skip +
+// analytic linear crossing). A structuredRegular field holds a z-ramp
+// (value == z), so an isovalue selects a z-plane; a camera at z=-5 looking down
+// +z through the plane center lets us pin the center-pixel hit/miss and the
+// center depth (distance from camera to the plane). Covers: linear filter hit,
+// nearest filter hit, multi-isovalue nearest-wins, and out-of-range miss.
+
+// anari_cpp
+#define ANARI_EXTENSION_UTILITY_IMPL
+#include <anari/anari_cpp/ext/std.h>
+#include <anari/anari_cpp.hpp>
+// VisRTX
+#include <anari/ext/visrtx/makeVisRTXDevice.h>
+// std
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using uvec2 = std::array<unsigned int, 2>;
+using ivec3 = std::array<int, 3>;
+using vec3 = std::array<float, 3>;
+using vec4 = std::array<float, 4>;
+
+static void statusFunc(const void *,
+    ANARIDevice,
+    ANARIObject source,
+    ANARIDataType,
+    ANARIStatusSeverity severity,
+    ANARIStatusCode,
+    const char *message)
+{
+  if (severity == ANARI_SEVERITY_FATAL_ERROR) {
+    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
+    std::exit(1);
+  } else if (severity == ANARI_SEVERITY_ERROR)
+    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
+}
+
+struct CenterProbe
+{
+  bool hit;
+  float depth;
+};
+
+// Render the z-ramp isosurface and report the center-pixel hit + depth. A
+// single isovalue is set as a scalar FLOAT32 param; multiple isovalues use a
+// FLOAT32 Array1D — both parameter forms are exercised.
+static CenterProbe centerProbe(anari::Device device,
+    const char *filter,
+    const std::vector<float> &isovalues)
+{
+  const uvec2 imageSize = {64, 64};
+  const vec4 background = {0.f, 0.f, 0.f, 1.f};
+  const ivec3 dims = {8, 8, 8};
+
+  // Field data: a linear z-ramp, data[i,j,k] = float(k). ANARI Array3D is
+  // stored x-fastest.
+  std::vector<float> fieldData(size_t(dims[0]) * dims[1] * dims[2]);
+  for (int k = 0; k < dims[2]; ++k)
+    for (int j = 0; j < dims[1]; ++j)
+      for (int i = 0; i < dims[0]; ++i)
+        fieldData[size_t(i) + dims[0] * (size_t(j) + size_t(dims[1]) * k)] =
+            float(k);
+
+  auto field =
+      anari::newObject<anari::SpatialField>(device, "structuredRegular");
+  {
+    auto data =
+        anari::newArray3D(device, fieldData.data(), dims[0], dims[1], dims[2]);
+    anari::setAndReleaseParameter(device, field, "data", data);
+    anari::setParameter(device, field, "origin", vec3{0.f, 0.f, 0.f});
+    anari::setParameter(device, field, "spacing", vec3{1.f, 1.f, 1.f});
+    anari::setParameter(device, field, "filter", filter);
+    // Commit the field BEFORE the geometry that references it: the isosurface
+    // finalize needs the field's space-skipping grid, otherwise it warns
+    // "space-skipping grid not ready" and renders nothing.
+    anari::commitParameters(device, field);
+  }
+
+  auto geometry = anari::newObject<anari::Geometry>(device, "isosurface");
+  anari::setParameter(device, geometry, "field", field);
+  if (isovalues.size() == 1)
+    anari::setParameter(device, geometry, "isovalue", isovalues[0]);
+  else
+    anari::setParameterArray1D(
+        device, geometry, "isovalue", isovalues.data(), isovalues.size());
+  anari::commitParameters(device, geometry);
+  anari::release(device, field);
+
+  auto material = anari::newObject<anari::Material>(device, "matte");
+  anari::setParameter(device, material, "color", vec3{1.f, 0.f, 0.f});
+  anari::commitParameters(device, material);
+
+  auto surface = anari::newObject<anari::Surface>(device);
+  anari::setAndReleaseParameter(device, surface, "geometry", geometry);
+  anari::setAndReleaseParameter(device, surface, "material", material);
+  anari::commitParameters(device, surface);
+
+  auto world = anari::newObject<anari::World>(device);
+  anari::setParameterArray1D(device, world, "surface", &surface, 1);
+  anari::release(device, surface);
+  anari::commitParameters(device, world);
+
+  // Camera at z=-5 looking down +z at the center of the iso-plane.
+  auto camera = anari::newObject<anari::Camera>(device, "perspective");
+  anari::setParameter(device, camera, "position", vec3{3.5f, 3.5f, -5.f});
+  anari::setParameter(device, camera, "direction", vec3{0.f, 0.f, 1.f});
+  anari::setParameter(device, camera, "up", vec3{0.f, 1.f, 0.f});
+  anari::setParameter(
+      device, camera, "aspect", imageSize[0] / float(imageSize[1]));
+  anari::commitParameters(device, camera);
+
+  auto renderer = anari::newObject<anari::Renderer>(device, "debug");
+  anari::setParameter(device, renderer, "background", background);
+  anari::setParameter(device, renderer, "method", "baseColor");
+  anari::commitParameters(device, renderer);
+
+  auto frame = anari::newObject<anari::Frame>(device);
+  anari::setParameter(device, frame, "size", imageSize);
+  anari::setParameter(device, frame, "channel.color", ANARI_UFIXED8_RGBA_SRGB);
+  anari::setParameter(device, frame, "channel.depth", ANARI_FLOAT32);
+  anari::setAndReleaseParameter(device, frame, "world", world);
+  anari::setAndReleaseParameter(device, frame, "camera", camera);
+  anari::setAndReleaseParameter(device, frame, "renderer", renderer);
+  anari::commitParameters(device, frame);
+
+  anari::render(device, frame);
+  anari::wait(device, frame);
+
+  const size_t centerIdx =
+      (imageSize[1] / 2) * size_t(imageSize[0]) + imageSize[0] / 2;
+
+  auto fb = anari::map<uint32_t>(device, frame, "channel.color");
+  const uint32_t center = fb.data[centerIdx];
+  const uint32_t red = center & 0xFFu; // R channel (RGBA8, little-endian)
+  anari::unmap(device, frame, "channel.color");
+
+  auto depthBuf = anari::map<float>(device, frame, "channel.depth");
+  const float depth = depthBuf.data ? depthBuf.data[centerIdx] : -1.f;
+  anari::unmap(device, frame, "channel.depth");
+
+  anari::release(device, frame);
+
+  return {red > 16u, depth}; // geometry (red) vs black background
+}
+
+int main()
+{
+  auto device = makeVisRTXDevice(statusFunc);
+
+  const CenterProbe linearHit = centerProbe(device, "linear", {3.5f});
+  const CenterProbe nearestHit = centerProbe(device, "nearest", {3.5f});
+  const CenterProbe multiHit = centerProbe(device, "linear", {1.5f, 3.5f});
+  const CenterProbe miss = centerProbe(device, "linear", {100.f});
+
+  anari::release(device, device);
+
+  const float kDepthTol = 0.15f;
+  int failures = 0;
+
+  // 1. Linear filter, isovalue 3.5: plane at z=3.5, camera z=-5 -> depth 8.5.
+  if (!linearHit.hit) {
+    fprintf(stderr, "FAIL: linear-filter isovalue 3.5 center is background\n");
+    ++failures;
+  } else if (std::fabs(linearHit.depth - 8.5f) > kDepthTol) {
+    fprintf(stderr,
+        "FAIL: linear-filter depth %.3f, expected ~8.5\n",
+        linearHit.depth);
+    ++failures;
+  }
+
+  // 2. Nearest filter, isovalue 3.5: center must be geometry (depth loose).
+  if (!nearestHit.hit) {
+    fprintf(stderr, "FAIL: nearest-filter isovalue 3.5 center is background\n");
+    ++failures;
+  }
+
+  // 3. Multi-isovalue {1.5, 3.5}, linear: nearest plane (z=1.5) wins -> 6.5.
+  if (!multiHit.hit) {
+    fprintf(stderr, "FAIL: multi-isovalue center is background\n");
+    ++failures;
+  } else if (std::fabs(multiHit.depth - 6.5f) > kDepthTol) {
+    fprintf(stderr,
+        "FAIL: multi-isovalue depth %.3f, expected ~6.5 (nearest plane)\n",
+        multiHit.depth);
+    ++failures;
+  }
+
+  // 4. Isovalue 100 is outside the field range -> center is background.
+  if (miss.hit) {
+    fprintf(stderr, "FAIL: out-of-range isovalue 100 unexpectedly hit\n");
+    ++failures;
+  }
+
+  if (failures)
+    return 1;
+  printf("isosurface z-ramp intersector test passed\n");
+  return 0;
+}

--- a/devices/rtx/apps/tests/api/TestPrimitiveInterior.cpp
+++ b/devices/rtx/apps/tests/api/TestPrimitiveInterior.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// GPU regression for back-face (exit) crossings of the analytic primitives:
+// a camera placed INSIDE a sphere, capped cylinder, and cone must see the
+// primitive's interior (previously the IS programs reported only front-facing
+// entry crossings, so interiors rendered as background). An outside view of
+// the sphere is rendered as a control.
+
+// anari_cpp
+#define ANARI_EXTENSION_UTILITY_IMPL
+#include <anari/anari_cpp/ext/std.h>
+#include <anari/anari_cpp.hpp>
+// VisRTX
+#include <anari/ext/visrtx/makeVisRTXDevice.h>
+// std
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using uvec2 = std::array<unsigned int, 2>;
+using vec3 = std::array<float, 3>;
+using vec4 = std::array<float, 4>;
+
+static void statusFunc(const void *,
+    ANARIDevice,
+    ANARIObject source,
+    ANARIDataType,
+    ANARIStatusSeverity severity,
+    ANARIStatusCode,
+    const char *message)
+{
+  if (severity == ANARI_SEVERITY_FATAL_ERROR) {
+    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
+    std::exit(1);
+  } else if (severity == ANARI_SEVERITY_ERROR)
+    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
+}
+
+static anari::Geometry makeSphere(anari::Device device)
+{
+  auto geometry = anari::newObject<anari::Geometry>(device, "sphere");
+  const vec3 center = {0.f, 0.f, 0.f};
+  anari::setParameterArray1D(device, geometry, "vertex.position", &center, 1);
+  anari::setParameter(device, geometry, "radius", 1.f);
+  anari::commitParameters(device, geometry);
+  return geometry;
+}
+
+static anari::Geometry makeCylinder(anari::Device device)
+{
+  auto geometry = anari::newObject<anari::Geometry>(device, "cylinder");
+  std::array<vec3, 2> positions = {vec3{0.f, 0.f, -1.f}, vec3{0.f, 0.f, 1.f}};
+  anari::setParameterArray1D(
+      device, geometry, "vertex.position", positions.data(), positions.size());
+  anari::setParameter(device, geometry, "radius", 1.f);
+  anari::setParameter(device, geometry, "caps", "both");
+  anari::commitParameters(device, geometry);
+  return geometry;
+}
+
+static anari::Geometry makeCone(anari::Device device)
+{
+  auto geometry = anari::newObject<anari::Geometry>(device, "cone");
+  std::array<vec3, 2> positions = {vec3{0.f, 0.f, -1.f}, vec3{0.f, 0.f, 1.f}};
+  std::array<float, 2> radii = {1.5f, 0.5f};
+  anari::setParameterArray1D(
+      device, geometry, "vertex.position", positions.data(), positions.size());
+  anari::setParameterArray1D(
+      device, geometry, "vertex.radius", radii.data(), radii.size());
+  anari::setParameter(device, geometry, "caps", "both");
+  anari::commitParameters(device, geometry);
+  return geometry;
+}
+
+// Render the geometry with the camera at `eye` looking down +z and return
+// whether the center pixel is covered by geometry (non-background).
+static bool centerPixelHit(
+    anari::Device device, anari::Geometry geometry, const vec3 &eye)
+{
+  const uvec2 imageSize = {64, 64};
+  const vec4 background = {0.f, 0.f, 0.f, 1.f};
+
+  auto material = anari::newObject<anari::Material>(device, "matte");
+  anari::setParameter(device, material, "color", vec3{1.f, 0.f, 0.f});
+  anari::commitParameters(device, material);
+
+  auto surface = anari::newObject<anari::Surface>(device);
+  anari::setAndReleaseParameter(device, surface, "geometry", geometry);
+  anari::setAndReleaseParameter(device, surface, "material", material);
+  anari::commitParameters(device, surface);
+
+  auto world = anari::newObject<anari::World>(device);
+  anari::setParameterArray1D(device, world, "surface", &surface, 1);
+  anari::release(device, surface);
+  anari::commitParameters(device, world);
+
+  auto camera = anari::newObject<anari::Camera>(device, "perspective");
+  anari::setParameter(device, camera, "position", eye);
+  anari::setParameter(device, camera, "direction", vec3{0.f, 0.f, 1.f});
+  anari::setParameter(device, camera, "up", vec3{0.f, 1.f, 0.f});
+  anari::setParameter(
+      device, camera, "aspect", imageSize[0] / float(imageSize[1]));
+  anari::commitParameters(device, camera);
+
+  auto renderer = anari::newObject<anari::Renderer>(device, "debug");
+  anari::setParameter(device, renderer, "background", background);
+  anari::setParameter(device, renderer, "method", "baseColor");
+  anari::commitParameters(device, renderer);
+
+  auto frame = anari::newObject<anari::Frame>(device);
+  anari::setParameter(device, frame, "size", imageSize);
+  anari::setParameter(device, frame, "channel.color", ANARI_UFIXED8_RGBA_SRGB);
+  anari::setAndReleaseParameter(device, frame, "world", world);
+  anari::setAndReleaseParameter(device, frame, "camera", camera);
+  anari::setAndReleaseParameter(device, frame, "renderer", renderer);
+  anari::commitParameters(device, frame);
+
+  anari::render(device, frame);
+  anari::wait(device, frame);
+
+  auto fb = anari::map<uint32_t>(device, frame, "channel.color");
+  const uint32_t center =
+      fb.data[(imageSize[1] / 2) * fb.width + imageSize[0] / 2];
+  const uint32_t red = center & 0xFFu; // R channel (RGBA8, little-endian)
+  anari::unmap(device, frame, "channel.color");
+  anari::release(device, frame);
+
+  return red > 16u; // geometry (red) vs black background
+}
+
+int main()
+{
+  auto device = makeVisRTXDevice(statusFunc);
+
+  struct Case
+  {
+    const char *name;
+    bool hit;
+    bool expected;
+  };
+  const vec3 inside = {0.f, 0.f, 0.f};
+  const vec3 outside = {0.f, 0.f, -3.f};
+  const Case cases[] = {
+      {"sphere exterior (control)",
+          centerPixelHit(device, makeSphere(device), outside),
+          true},
+      {"sphere interior",
+          centerPixelHit(device, makeSphere(device), inside),
+          true},
+      {"cylinder interior",
+          centerPixelHit(device, makeCylinder(device), inside),
+          true},
+      {"cone interior", centerPixelHit(device, makeCone(device), inside), true},
+  };
+
+  anari::release(device, device);
+
+  int failures = 0;
+  for (const auto &c : cases) {
+    if (c.hit != c.expected) {
+      fprintf(stderr,
+          "FAIL: %s — expected %s, got %s\n",
+          c.name,
+          c.expected ? "hit" : "miss",
+          c.hit ? "hit" : "miss");
+      ++failures;
+    }
+  }
+  if (failures)
+    return 1;
+  printf("analytic primitive interior (back-face) regression passed\n");
+  return 0;
+}

--- a/devices/rtx/apps/tests/unit/CMakeLists.txt
+++ b/devices/rtx/apps/tests/unit/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Host-only unit tests for the pure analytic primitive solvers. No CUDA/OptiX/GPU
+# — these run on CPU and exercise devices/rtx/device/gpu/intersectPrimitives.h
+# directly, so the intersection math is testable without a device.
+
+project(rtx_test_Intersectors LANGUAGES CXX)
+
+add_executable(${PROJECT_NAME} test_Intersectors.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/../../../device)
+target_link_libraries(${PROJECT_NAME} PRIVATE visrtx::glm)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+add_test(NAME rtx::Intersectors COMMAND ${PROJECT_NAME})

--- a/devices/rtx/apps/tests/unit/CMakeLists.txt
+++ b/devices/rtx/apps/tests/unit/CMakeLists.txt
@@ -14,3 +14,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE visrtx::glm)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 add_test(NAME rtx::Intersectors COMMAND ${PROJECT_NAME})
+
+project(rtx_test_IsosurfaceLinear LANGUAGES CXX)
+
+add_executable(${PROJECT_NAME} test_IsosurfaceLinear.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/../../../device)
+target_link_libraries(${PROJECT_NAME} PRIVATE visrtx::glm)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+add_test(NAME rtx::IsosurfaceLinear COMMAND ${PROJECT_NAME})

--- a/devices/rtx/apps/tests/unit/test_Intersectors.cpp
+++ b/devices/rtx/apps/tests/unit/test_Intersectors.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Host unit tests for the pure analytic primitive solvers. No CUDA/OptiX/GPU —
+// exercises the geometry math directly and returns nonzero on any failure
+// (assert() is compiled out in Release, the repo default).
+
+#include "gpu/intersectPrimitives.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace visrtx;
+using glm::vec3;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);              \
+      ++g_failures;                                                            \
+    }                                                                          \
+  } while (0)
+
+static bool nearf(float a, float b, float eps = 1e-3f)
+{
+  return std::fabs(a - b) <= eps;
+}
+
+static bool isUnit(const vec3 &v)
+{
+  return nearf(glm::length(v), 1.f, 1e-3f);
+}
+
+// Return the crossing with smallest t among those with t >= tmin (forward hit),
+// or nullptr. Mirrors what OptiX closest-hit would keep.
+static const PrimHit *nearestForward(
+    const PrimHit *h, int n, float tmin = 0.f)
+{
+  const PrimHit *best = nullptr;
+  for (int i = 0; i < n; ++i)
+    if (h[i].t >= tmin && (!best || h[i].t < best->t))
+      best = &h[i];
+  return best;
+}
+
+static void testSphere()
+{
+  const vec3 c(0.f);
+  PrimHit h[2];
+
+  // Direct hit from outside: entry + exit.
+  int n = solveSphere(vec3(0, 0, -5), vec3(0, 0, 1), c, 1.f, h);
+  CHECK(n == 2);
+  const PrimHit *near = nearestForward(h, n);
+  CHECK(near && nearf(near->t, 4.f));
+  CHECK(near && isUnit(near->Ng) && glm::dot(near->Ng, vec3(0, 0, 1)) < 0.f);
+
+  // Miss.
+  CHECK(solveSphere(vec3(0, 3, -5), vec3(0, 0, 1), c, 1.f, h) == 0);
+
+  // Tangent -> single unique crossing (coincident roots de-duped).
+  n = solveSphere(vec3(0, 1, -5), vec3(0, 0, 1), c, 1.f, h);
+  CHECK(n == 1);
+  CHECK(n == 1 && nearf(h[0].t, 5.f) && isUnit(h[0].Ng));
+
+  // Origin inside: 2 algebraic roots, 1 forward-accepted.
+  n = solveSphere(vec3(0, 0, 0), vec3(0, 0, 1), c, 1.f, h);
+  CHECK(n == 2);
+  int forward = 0;
+  for (int i = 0; i < n; ++i)
+    if (h[i].t >= 0.f)
+      ++forward;
+  CHECK(forward == 1);
+
+  // Non-unit direction (instance-scale analogue): t rescales, hitpoint invariant.
+  n = solveSphere(vec3(0, 0, -5), vec3(0, 0, 2), c, 1.f, h);
+  const PrimHit *nf = nearestForward(h, n);
+  CHECK(nf && nearf(nf->t, 2.f)); // 2*(0,0,2) from -5 => z=-1 (entry)
+}
+
+static void testCylinder()
+{
+  const vec3 p0(0, 0, 0), p1(0, 0, 2); // axis +z, length 2
+  const float r = 1.f;
+  PrimHit h[4];
+
+  // Side hit: entry + exit on the curved wall.
+  int n = solveCylinder(vec3(-5, 0, 1), vec3(1, 0, 0), p0, p1, r, 0, h);
+  CHECK(n == 2);
+  const PrimHit *near = nearestForward(h, n);
+  CHECK(near && nearf(near->t, 4.f) && nearf(near->u, 0.5f));
+  CHECK(near && isUnit(near->Ng) && nearf(near->Ng.x, -1.f));
+
+  // Axis-parallel into caps=both: THE regression. Was 0 hits; must be 2.
+  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r,
+      CAP_FIRST | CAP_SECOND, h);
+  CHECK(n == 2);
+  const PrimHit *cnear = nearestForward(h, n);
+  CHECK(cnear && nearf(cnear->t, 5.f) && nearf(cnear->u, 0.f));
+  CHECK(cnear && isUnit(cnear->Ng) && nearf(cnear->Ng.z, -1.f));
+
+  // caps=none end-on -> nothing.
+  CHECK(solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r, 0, h) == 0);
+
+  // caps=first only -> just the p0 cap.
+  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r, CAP_FIRST, h);
+  CHECK(n == 1 && nearf(h[0].u, 0.f));
+
+  // caps=second only -> ray enters open p0 end, hits p1 cap (u=1).
+  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r, CAP_SECOND, h);
+  CHECK(n == 1 && nearf(h[0].u, 1.f));
+
+  // Perpendicular ray (sd==0): caps can't be hit; wall still gives 2.
+  n = solveCylinder(vec3(-5, 0, 1), vec3(1, 0, 0), p0, p1, r,
+      CAP_FIRST | CAP_SECOND, h);
+  CHECK(n == 2);
+
+  // Cap-edge clip: end-on but outside radius -> miss even with caps.
+  CHECK(solveCylinder(vec3(3, 0, -5), vec3(0, 0, 1), p0, p1, r,
+            CAP_FIRST | CAP_SECOND, h)
+      == 0);
+
+  // Degenerate p0==p1 -> no hit, no crash/NaN.
+  CHECK(solveCylinder(vec3(-5, 0, 0), vec3(1, 0, 0), p0, p0, r,
+            CAP_FIRST | CAP_SECOND, h)
+      == 0);
+
+  // Every reported normal is unit.
+  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r,
+      CAP_FIRST | CAP_SECOND, h);
+  for (int i = 0; i < n; ++i)
+    CHECK(isUnit(h[i].Ng));
+}
+
+static void testCone()
+{
+  PrimHit h[4];
+
+  // Truncated cone: p0 r=1 at z=0, apex r=0 at z=4. Side ray at z=1 where the
+  // cone radius is 0.75 -> entry x=-0.75 (t=4.25), exit x=0.75 (t=5.75).
+  const vec3 p0(0, 0, 0), apex(0, 0, 4);
+  int n = solveCone(vec3(-5, 0, 1), vec3(1, 0, 0), p0, apex, 1.f, 0.f, 0, h);
+  CHECK(n == 2);
+  const PrimHit *near = nearestForward(h, n);
+  CHECK(near && nearf(near->t, 4.25f) && nearf(near->u, 0.25f));
+  CHECK(near && isUnit(near->Ng) && glm::dot(near->Ng, vec3(1, 0, 0)) < 0.f);
+
+  // Equal-radius cone (== cylinder) hit axis-parallel: total-degeneracy body
+  // MISS. caps=none -> 0 crossings; caps=both -> 2 cap crossings.
+  const vec3 q0(0, 0, 0), q1(0, 0, 2);
+  CHECK(solveCone(vec3(0, 0, -5), vec3(0, 0, 1), q0, q1, 1.f, 1.f, 0, h) == 0);
+  n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), q0, q1, 1.f, 1.f,
+      CAP_FIRST | CAP_SECOND, h);
+  CHECK(n == 2);
+
+  // caps=none on the truncated cone with a cap-crossing axis ray still shows
+  // no cap; caps=both adds the base disk.
+  n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), p0, apex, 1.f, 0.f, 0, h);
+  const int bodyOnly = n;
+  n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), p0, apex, 1.f, 0.f,
+      CAP_FIRST, h);
+  CHECK(n == bodyOnly + 1); // base cap at p0 added
+
+  // Zero-radius apex end requests a cap -> degenerate disk, no cap hit.
+  n = solveCone(vec3(0, 0, 9), vec3(0, 0, -1), p0, apex, 1.f, 0.f,
+      CAP_SECOND, h);
+  for (int i = 0; i < n; ++i)
+    CHECK(!nearf(h[i].u, 1.f)); // no p1 (apex) cap emitted
+
+  // Non-unit direction: hitpoint invariant.
+  n = solveCone(vec3(-5, 0, 1), vec3(2, 0, 0), p0, apex, 1.f, 0.f, 0, h);
+  const PrimHit *nf = nearestForward(h, n);
+  CHECK(nf && nearf((vec3(-5, 0, 1) + nf->t * vec3(2, 0, 0)).x, -0.75f));
+
+  // Normals unit.
+  n = solveCone(vec3(-5, 0, 1), vec3(1, 0, 0), p0, apex, 1.f, 0.f, 0, h);
+  for (int i = 0; i < n; ++i)
+    CHECK(isUnit(h[i].Ng));
+}
+
+int main()
+{
+  testSphere();
+  testCylinder();
+  testCone();
+  if (g_failures) {
+    std::printf("%d CHECK(s) failed\n", g_failures);
+    return 1;
+  }
+  std::printf("all intersector host tests passed\n");
+  return 0;
+}

--- a/devices/rtx/apps/tests/unit/test_Intersectors.cpp
+++ b/devices/rtx/apps/tests/unit/test_Intersectors.cpp
@@ -64,8 +64,7 @@ static bool isUnit(const vec3 &v)
 
 // Return the crossing with smallest t among those with t >= tmin (forward hit),
 // or nullptr. Mirrors what OptiX closest-hit would keep.
-static const PrimHit *nearestForward(
-    const PrimHit *h, int n, float tmin = 0.f)
+static const PrimHit *nearestForward(const PrimHit *h, int n, float tmin = 0.f)
 {
   const PrimHit *best = nullptr;
   for (int i = 0; i < n; ++i)
@@ -103,7 +102,8 @@ static void testSphere()
       ++forward;
   CHECK(forward == 1);
 
-  // Non-unit direction (instance-scale analogue): t rescales, hitpoint invariant.
+  // Non-unit direction (instance-scale analogue): t rescales, hitpoint
+  // invariant.
   n = solveSphere(vec3(0, 0, -5), vec3(0, 0, 2), c, 1.f, h);
   const PrimHit *nf = nearestForward(h, n);
   CHECK(nf && nearf(nf->t, 2.f)); // 2*(0,0,2) from -5 => z=-1 (entry)
@@ -123,8 +123,8 @@ static void testCylinder()
   CHECK(near && isUnit(near->Ng) && nearf(near->Ng.x, -1.f));
 
   // Axis-parallel into caps=both: THE regression. Was 0 hits; must be 2.
-  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r,
-      CAP_FIRST | CAP_SECOND, h);
+  n = solveCylinder(
+      vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r, CAP_FIRST | CAP_SECOND, h);
   CHECK(n == 2);
   const PrimHit *cnear = nearestForward(h, n);
   CHECK(cnear && nearf(cnear->t, 5.f) && nearf(cnear->u, 0.f));
@@ -142,23 +142,23 @@ static void testCylinder()
   CHECK(n == 1 && nearf(h[0].u, 1.f));
 
   // Perpendicular ray (sd==0): caps can't be hit; wall still gives 2.
-  n = solveCylinder(vec3(-5, 0, 1), vec3(1, 0, 0), p0, p1, r,
-      CAP_FIRST | CAP_SECOND, h);
+  n = solveCylinder(
+      vec3(-5, 0, 1), vec3(1, 0, 0), p0, p1, r, CAP_FIRST | CAP_SECOND, h);
   CHECK(n == 2);
 
   // Cap-edge clip: end-on but outside radius -> miss even with caps.
-  CHECK(solveCylinder(vec3(3, 0, -5), vec3(0, 0, 1), p0, p1, r,
-            CAP_FIRST | CAP_SECOND, h)
+  CHECK(solveCylinder(
+            vec3(3, 0, -5), vec3(0, 0, 1), p0, p1, r, CAP_FIRST | CAP_SECOND, h)
       == 0);
 
   // Degenerate p0==p1 -> no hit, no crash/NaN.
-  CHECK(solveCylinder(vec3(-5, 0, 0), vec3(1, 0, 0), p0, p0, r,
-            CAP_FIRST | CAP_SECOND, h)
+  CHECK(solveCylinder(
+            vec3(-5, 0, 0), vec3(1, 0, 0), p0, p0, r, CAP_FIRST | CAP_SECOND, h)
       == 0);
 
   // Every reported normal is unit.
-  n = solveCylinder(vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r,
-      CAP_FIRST | CAP_SECOND, h);
+  n = solveCylinder(
+      vec3(0, 0, -5), vec3(0, 0, 1), p0, p1, r, CAP_FIRST | CAP_SECOND, h);
   for (int i = 0; i < n; ++i)
     CHECK(isUnit(h[i].Ng));
 }
@@ -180,21 +180,27 @@ static void testCone()
   // MISS. caps=none -> 0 crossings; caps=both -> 2 cap crossings.
   const vec3 q0(0, 0, 0), q1(0, 0, 2);
   CHECK(solveCone(vec3(0, 0, -5), vec3(0, 0, 1), q0, q1, 1.f, 1.f, 0, h) == 0);
-  n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), q0, q1, 1.f, 1.f,
-      CAP_FIRST | CAP_SECOND, h);
+  n = solveCone(vec3(0, 0, -5),
+      vec3(0, 0, 1),
+      q0,
+      q1,
+      1.f,
+      1.f,
+      CAP_FIRST | CAP_SECOND,
+      h);
   CHECK(n == 2);
 
   // caps=none on the truncated cone with a cap-crossing axis ray still shows
   // no cap; caps=both adds the base disk.
   n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), p0, apex, 1.f, 0.f, 0, h);
   const int bodyOnly = n;
-  n = solveCone(vec3(0, 0, -5), vec3(0, 0, 1), p0, apex, 1.f, 0.f,
-      CAP_FIRST, h);
+  n = solveCone(
+      vec3(0, 0, -5), vec3(0, 0, 1), p0, apex, 1.f, 0.f, CAP_FIRST, h);
   CHECK(n == bodyOnly + 1); // base cap at p0 added
 
   // Zero-radius apex end requests a cap -> degenerate disk, no cap hit.
-  n = solveCone(vec3(0, 0, 9), vec3(0, 0, -1), p0, apex, 1.f, 0.f,
-      CAP_SECOND, h);
+  n = solveCone(
+      vec3(0, 0, 9), vec3(0, 0, -1), p0, apex, 1.f, 0.f, CAP_SECOND, h);
   for (int i = 0; i < n; ++i)
     CHECK(!nearf(h[i].u, 1.f)); // no p1 (apex) cap emitted
 
@@ -209,11 +215,120 @@ static void testCone()
     CHECK(isUnit(h[i].Ng));
 }
 
+// Regression for phantom self-shadowing exits at grazing incidence (acne rings
+// on large ground spheres): shadow rays start ~1e-6*|P| above their origin
+// surface (epsilonFrom's lift) and run nearly tangent to it toward the light.
+// Near tangency the quadratic discriminant is fp noise, and before the
+// kGrazeRelEps gate a false-positive root pair emitted a back-facing exit at
+// t up to ~1e-3*r — far past tmin, shadowing the surface in rings. Scans many
+// surface points and above-horizon directions on RTOW-scale primitives and
+// requires that no forward crossing survives.
+static void testGrazeSelfShadow()
+{
+  constexpr float r = 1000.f; // RTOW ground-sphere scale
+  // epsilonFrom's lift for |P| ~ r: max(|P|,t*|dir|) * 0x1.fp-21
+  const float lift = r * 0x1.fp-21f;
+  const float tmin = lift; // renderers also set tmin = hit.epsilon
+
+  int phantoms = 0;
+  const auto countForward = [&](const PrimHit *h, int n) {
+    for (int i = 0; i < n; ++i)
+      if (h[i].t >= tmin)
+        ++phantoms;
+  };
+
+  // Sphere: surface points around the top of a giant ground sphere, shadow
+  // directions above the local horizon (any hit is geometrically impossible).
+  {
+    const vec3 c(0.f, -r, 0.f);
+    PrimHit h[2];
+    for (int ia = 0; ia < 100; ++ia) {
+      const float alpha = 0.0007f * float(ia); // polar angle from +y
+      const vec3 N(std::sin(alpha), std::cos(alpha), 0.f);
+      const vec3 T1(std::cos(alpha), -std::sin(alpha), 0.f);
+      const vec3 T2(0.f, 0.f, 1.f);
+      const vec3 org = c + (r + lift) * N;
+      for (int it = 0; it < 20; ++it) {
+        const float theta = 0.0005f + 0.0025f * float(it); // elevation
+        for (int ip = 0; ip < 8; ++ip) {
+          const float phi = 0.7853982f * float(ip);
+          const vec3 dir =
+              std::cos(theta) * (std::cos(phi) * T1 + std::sin(phi) * T2)
+              + std::sin(theta) * N;
+          countForward(h, solveSphere(org, dir, c, r, h));
+        }
+      }
+    }
+  }
+
+  // Cylinder wall: same scan on a giant cylinder, tangent-plane directions.
+  {
+    const vec3 p0(0.f, -r, -r), p1(0.f, -r, r);
+    PrimHit h[4];
+    for (int ia = 0; ia < 100; ++ia) {
+      const float alpha = 0.0007f * float(ia);
+      const vec3 N(std::sin(alpha), std::cos(alpha), 0.f);
+      const vec3 T1(std::cos(alpha), -std::sin(alpha), 0.f);
+      const vec3 T2(0.f, 0.f, 1.f);
+      const vec3 org = vec3(0.f, -r, 0.f) + (r + lift) * N;
+      for (int it = 0; it < 20; ++it) {
+        const float theta = 0.0005f + 0.0025f * float(it);
+        for (int ip = 0; ip < 8; ++ip) {
+          const float phi = 0.7853982f * float(ip);
+          const vec3 dir =
+              std::cos(theta) * (std::cos(phi) * T1 + std::sin(phi) * T2)
+              + std::sin(theta) * N;
+          countForward(h, solveCylinder(org, dir, p0, p1, r, 0, h));
+        }
+      }
+    }
+  }
+
+  // Cone slant: giant near-cylindrical truncated cone, directions above the
+  // slant surface's tangent plane.
+  {
+    const vec3 p0(0.f, -r, -r), p1(0.f, -r, r);
+    const float r0 = r, r1 = 0.9f * r;
+    // Slant makes angle beta with the axis plane; outward normal tilts by beta.
+    const float beta = std::atan((r0 - r1) / (2.f * r));
+    PrimHit h[4];
+    for (int ia = 0; ia < 100; ++ia) {
+      const float alpha = 0.0007f * float(ia);
+      const vec3 radial(std::sin(alpha), std::cos(alpha), 0.f);
+      const vec3 T1(std::cos(alpha), -std::sin(alpha), 0.f);
+      const vec3 axis(0.f, 0.f, 1.f);
+      const vec3 N = std::cos(beta) * radial + std::sin(beta) * axis;
+      const vec3 T2 = std::cos(beta) * axis - std::sin(beta) * radial;
+      const float rz = 0.5f * (r0 + r1); // radius at the axis midpoint (z=0)
+      const vec3 org = vec3(0.f, -r, 0.f) + rz * radial + lift * N;
+      for (int it = 0; it < 20; ++it) {
+        const float theta = 0.0005f + 0.0025f * float(it);
+        for (int ip = 0; ip < 8; ++ip) {
+          const float phi = 0.7853982f * float(ip);
+          const vec3 dir =
+              std::cos(theta) * (std::cos(phi) * T1 + std::sin(phi) * T2)
+              + std::sin(theta) * N;
+          countForward(h, solveCone(org, dir, p0, p1, r0, r1, 0, h));
+        }
+      }
+    }
+  }
+
+  if (phantoms) {
+    std::printf("FAIL %s:%d  %d phantom grazing self-shadow crossing(s)\n",
+        __FILE__,
+        __LINE__,
+        phantoms);
+    ++g_failures;
+  }
+}
+
 int main()
 {
   testSphere();
   testCylinder();
   testCone();
+  testGrazeSelfShadow();
   if (g_failures) {
     std::printf("%d CHECK(s) failed\n", g_failures);
     return 1;

--- a/devices/rtx/apps/tests/unit/test_IsosurfaceLinear.cpp
+++ b/devices/rtx/apps/tests/unit/test_IsosurfaceLinear.cpp
@@ -1,0 +1,517 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Host unit tests for the pure analytic isosurface core math. No CUDA/OptiX/GPU
+// — exercises the cubic solver + trilinear crossing directly and returns
+// nonzero on any failure (assert() is compiled out in Release, the repo
+// default).
+
+#include "geometry/IsosurfaceLinear.h"
+
+#include <cmath> // std::sqrt / std::cbrt / std::fabs used directly below
+
+#include <cstdint>
+#include <cstdio>
+
+using glm::vec3;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);              \
+      ++g_failures;                                                            \
+    }                                                                          \
+  } while (0)
+
+static bool nearf(float a, float b, float eps = 1e-3f)
+{
+  return std::fabs(a - b) <= eps;
+}
+
+static bool isUnit(const vec3 &v)
+{
+  return nearf(glm::length(v), 1.f, 1e-3f);
+}
+
+// Test-local mock field state types. `SpatialFieldGPUData` is only forward-
+// declared in the header; this TU links nothing else that defines it (only
+// glm), so completing it here is legal. sampleValue/sampleNormal are resolved
+// by ADL on the state type (which lives in `visrtx`) when linearCrossing
+// instantiates.
+namespace visrtx {
+
+struct SpatialFieldGPUData
+{
+}; // test-local completion of the fwd decl
+
+// Affine field f(p) = dot(grad, p) + offset; constant gradient.
+struct LinearFieldState
+{
+  vec3 grad;
+  float offset;
+};
+inline float sampleValue(
+    const LinearFieldState &st, const SpatialFieldGPUData &, const vec3 &p)
+{
+  return glm::dot(st.grad, p) + st.offset;
+}
+inline vec3 sampleNormal(
+    const LinearFieldState &st, const SpatialFieldGPUData &, const vec3 &)
+{
+  return st.grad;
+}
+
+// Quadratic along x: f = (p.x - x0)^2 (for the hybrid-bracket miss case).
+struct QuadFieldState
+{
+  float x0;
+};
+inline float sampleValue(
+    const QuadFieldState &st, const SpatialFieldGPUData &, const vec3 &p)
+{
+  const float d = p.x - st.x0;
+  return d * d;
+}
+inline vec3 sampleNormal(
+    const QuadFieldState &st, const SpatialFieldGPUData &, const vec3 &p)
+{
+  return vec3(2.f * (p.x - st.x0), 0.f, 0.f);
+}
+
+} // namespace visrtx
+
+using namespace visrtx;
+
+// g(s) = ((k3 s + k2) s + k1) s + k0 — reference monomial evaluation.
+static float evalCubic(float k0, float k1, float k2, float k3, float s)
+{
+  return ((k3 * s + k2) * s + k1) * s + k0;
+}
+
+// Sample a cubic at the four fixed nodes {0,1/3,2/3,1}.
+static void nodesOf(float k0, float k1, float k2, float k3, float n[4])
+{
+  n[0] = evalCubic(k0, k1, k2, k3, 0.f);
+  n[1] = evalCubic(k0, k1, k2, k3, 1.f / 3.f);
+  n[2] = evalCubic(k0, k1, k2, k3, 2.f / 3.f);
+  n[3] = evalCubic(k0, k1, k2, k3, 1.f);
+}
+
+static void testTrilinear()
+{
+  float c[8];
+  for (int m = 0; m < 8; ++m)
+    c[m] = float(m);
+
+  // Each corner c[i + 2j + 4k] reproduced at u = (i,j,k) in {0,1}^3.
+  for (int k = 0; k < 2; ++k)
+    for (int j = 0; j < 2; ++j)
+      for (int i = 0; i < 2; ++i) {
+        const vec3 u = vec3(float(i), float(j), float(k));
+        CHECK(nearf(trilinearValue(c, u), c[i + 2 * j + 4 * k]));
+      }
+
+  // Center equals the mean of all 8 corners.
+  float mean = 0.f;
+  for (int m = 0; m < 8; ++m)
+    mean += c[m];
+  mean /= 8.f;
+  CHECK(nearf(trilinearValue(c, vec3(0.5f)), mean));
+
+  // Edge midpoints equal the mean of the two edge corners (per-axis linearity).
+  CHECK(nearf(trilinearValue(c, vec3(0.5f, 0.f, 0.f)), 0.5f * (c[0] + c[1])));
+  CHECK(nearf(trilinearValue(c, vec3(0.f, 0.5f, 0.f)), 0.5f * (c[0] + c[2])));
+  CHECK(nearf(trilinearValue(c, vec3(0.f, 0.f, 0.5f)), 0.5f * (c[0] + c[4])));
+}
+
+static void testPrepareCubic()
+{
+  // 1. Exact fit: recover arbitrary monomial coefficients from node values.
+  {
+    const float k0 = 0.5f, k1 = -2.f, k2 = 3.f, k3 = 1.25f;
+    float n[4];
+    nodesOf(k0, k1, k2, k3, n);
+    const CubicPrep p = prepareCubic(n[0], n[1], n[2], n[3]);
+    CHECK(nearf(p.k0, k0, 1e-4f));
+    CHECK(nearf(p.k1, k1, 1e-4f));
+    CHECK(nearf(p.k2, k2, 1e-4f));
+    CHECK(nearf(p.k3, k3, 1e-4f));
+  }
+
+  // 2. Linear g = s - 0.5 -> k = (-0.5, 1, 0, 0), nb == 2, bounds {0,1}.
+  {
+    const CubicPrep p = prepareCubic(-0.5f, -1.f / 6.f, 1.f / 6.f, 0.5f);
+    CHECK(nearf(p.k0, -0.5f));
+    CHECK(nearf(p.k1, 1.f));
+    CHECK(nearf(p.k2, 0.f));
+    CHECK(nearf(p.k3, 0.f));
+    CHECK(p.nb == 2);
+    CHECK(nearf(p.bound[0], 0.f));
+    CHECK(nearf(p.bound[1], 1.f));
+  }
+
+  // 3. Interior extrema: g = (s-0.2)(s-0.5)(s-0.8). nb == 4 and the two
+  // interior bounds equal the roots of g'(s) = 3s^2 - 3s + 0.66.
+  {
+    // g = s^3 - 1.5 s^2 + 0.66 s - 0.08
+    const float k0 = -0.08f, k1 = 0.66f, k2 = -1.5f, k3 = 1.f;
+    float n[4];
+    nodesOf(k0, k1, k2, k3, n);
+    const CubicPrep p = prepareCubic(n[0], n[1], n[2], n[3]);
+    const float a = 3.f, b = -3.f, c = 0.66f;
+    const float sq = std::sqrt(b * b - 4.f * a * c);
+    const float r0 = (-b - sq) / (2.f * a);
+    const float r1 = (-b + sq) / (2.f * a);
+    CHECK(p.nb == 4);
+    CHECK(nearf(p.bound[0], 0.f));
+    CHECK(nearf(p.bound[1], r0));
+    CHECK(nearf(p.bound[2], r1));
+    CHECK(nearf(p.bound[3], 1.f));
+  }
+
+  // 4. Quadratic branch (k3 == 0): g = (s-0.5)^2 -> nb == 3, bound[1] == 0.5.
+  {
+    const CubicPrep p = prepareCubic(0.25f, 1.f / 36.f, 1.f / 36.f, 0.25f);
+    CHECK(nearf(p.k3, 0.f));
+    CHECK(p.nb == 3);
+    CHECK(nearf(p.bound[1], 0.5f));
+  }
+
+  // 5. Extremum within kExtremumMargin of an endpoint is dropped: g = s^2 has
+  // its g' root at s = 0 -> nb stays 2.
+  {
+    const CubicPrep p = prepareCubic(0.f, 1.f / 9.f, 4.f / 9.f, 1.f);
+    CHECK(p.nb == 2);
+  }
+}
+
+static void testSolveCubic()
+{
+  // 1. Three real roots in [0,1] (g = (s-0.2)(s-0.5)(s-0.8)) -> smallest ~0.2.
+  {
+    float n[4];
+    nodesOf(-0.08f, 0.66f, -1.5f, 1.f, n);
+    const CubicPrep p = prepareCubic(n[0], n[1], n[2], n[3]);
+    float s = 0.f;
+    CHECK(solveCubic(p, 0.f, s));
+    CHECK(nearf(s, 0.2f));
+  }
+
+  // 2. Multi-iso reuse: one prep for g = s solves several isovalues.
+  {
+    const CubicPrep p = prepareCubic(0.f, 1.f / 3.f, 2.f / 3.f, 1.f);
+    float s = 0.f;
+    CHECK(solveCubic(p, 0.25f, s) && nearf(s, 0.25f));
+    CHECK(solveCubic(p, 0.5f, s) && nearf(s, 0.5f));
+    CHECK(solveCubic(p, 0.9f, s) && nearf(s, 0.9f));
+  }
+
+  // 3. Boundary asymmetry + watertight carry.
+  {
+    // g = s - 1 (root at upper end, approached from below): found, s ~ 1.
+    float s = 0.f;
+    const CubicPrep pInc = prepareCubic(-1.f, -2.f / 3.f, -1.f / 3.f, 0.f);
+    CHECK(solveCubic(pInc, 0.f, s));
+    CHECK(nearf(s, 1.f));
+
+    // g = 1 - s (root at upper end, approached from above): miss.
+    const CubicPrep pDec = prepareCubic(1.f, 2.f / 3.f, 1.f / 3.f, 0.f);
+    CHECK(!solveCubic(pDec, 0.f, s));
+
+    // Watertight carry: next voxel's entry node value is exactly 0 -> hit s==0.
+    const CubicPrep pCarry = prepareCubic(0.f, -1.f / 3.f, -2.f / 3.f, -1.f);
+    CHECK(solveCubic(pCarry, 0.f, s));
+    CHECK(s == 0.f);
+  }
+
+  // 4. Root exactly at s=0 from either side -> s == 0.
+  {
+    float s = 1.f;
+    CHECK(solveCubic(prepareCubic(0.f, 1.f / 3.f, 2.f / 3.f, 1.f), 0.f, s));
+    CHECK(s == 0.f);
+    s = 1.f;
+    CHECK(solveCubic(prepareCubic(0.f, -1.f / 3.f, -2.f / 3.f, -1.f), 0.f, s));
+    CHECK(s == 0.f);
+  }
+
+  // 5. Tangent, exact vs lifted: g = (s-1/2)^2 at nodes {1/4,1/36,1/36,1/4}.
+  {
+    float s = 0.f;
+    const CubicPrep pTan = prepareCubic(0.25f, 1.f / 36.f, 1.f / 36.f, 0.25f);
+    CHECK(solveCubic(pTan, 0.f, s));
+    CHECK(s == 0.5f);
+
+    const float d = 1e-3f;
+    const CubicPrep pLift =
+        prepareCubic(0.25f + d, 1.f / 36.f + d, 1.f / 36.f + d, 0.25f + d);
+    CHECK(!solveCubic(pLift, 0.f, s));
+  }
+
+  // 6. No crossing (g strictly positive) -> false.
+  {
+    float s = 0.f;
+    const CubicPrep p = prepareCubic(
+        0.75f, 0.5f + 1.f / 36.f, 0.5f + 1.f / 36.f, 0.75f); // (s-1/2)^2 + 1/2
+    CHECK(!solveCubic(p, 0.f, s));
+  }
+
+  // 7. Scale independence: g = A (s^3 - 0.2) has root cbrt(0.2) for any A, but
+  // at A~1e4 the value residual (~1e4 * step) never drops below kRootTolerance
+  // (1e-6, absolute in value units), so the solver runs the full 8 Illinois
+  // iterations. The root estimate must not degrade vs the small-scale case that
+  // could early-exit -- regula-falsi converges in the s domain, independent of
+  // A.
+  {
+    const float root = std::cbrt(0.2f);
+    float n[4];
+    nodesOf(-0.2f, 0.f, 0.f, 1.f, n);
+    float sSmall = 0.f;
+    CHECK(solveCubic(prepareCubic(n[0], n[1], n[2], n[3]), 0.f, sSmall));
+    nodesOf(-2000.f, 0.f, 0.f, 1e4f, n);
+    float sLarge = 0.f;
+    CHECK(solveCubic(prepareCubic(n[0], n[1], n[2], n[3]), 0.f, sLarge));
+    // 8-iter regula-falsi on this cubic lands ~2e-3 from the true root; the key
+    // property is that the 1e4 scaling leaves that unchanged.
+    CHECK(nearf(sLarge, root, 5e-3f));
+    CHECK(nearf(sLarge, sSmall, 1e-5f));
+  }
+
+  // 8. Constant zero field (all nodes == iso) -> true, s == 0.
+  {
+    float s = 1.f;
+    CHECK(solveCubic(prepareCubic(0.f, 0.f, 0.f, 0.f), 0.f, s));
+    CHECK(s == 0.f);
+  }
+}
+
+static void testFirstTrilinearRootProperty()
+{
+  const float iso = 0.f;
+  const int kScanSteps = 2048;
+  const int kBisectIters = 40;
+
+  uint32_t x = 12345u;
+  auto nextUnit = [&]() {
+    x = x * 1664525u + 1013904223u;
+    return float(x) / 4294967296.f; // [0,1)
+  };
+  auto nextSigned = [&]() { return 2.f * nextUnit() - 1.f; }; // [-1,1)
+
+  for (int iter = 0; iter < 200; ++iter) {
+    float c[8];
+    for (int m = 0; m < 8; ++m)
+      c[m] = nextSigned();
+    const vec3 aEntry(nextUnit(), nextUnit(), nextUnit());
+    const vec3 aExit(nextUnit(), nextUnit(), nextUnit());
+    const vec3 d = aExit - aEntry;
+
+    auto v = [&](float s) { return trilinearValue(c, aEntry + s * d) - iso; };
+
+    const float v0 = v(0.f);
+    const float v1 = v(1.f);
+    // Contract is only defined when the endpoints straddle.
+    if ((v0 < 0.f) == (v1 < 0.f))
+      continue;
+
+    // Reference: dense scan for the first sign-change bracket, then bisect.
+    float lo = 0.f, hi = 1.f;
+    float prevS = 0.f, prevV = v0;
+    bool found = false;
+    for (int i = 1; i <= kScanSteps; ++i) {
+      const float s = float(i) / float(kScanSteps);
+      const float vs = v(s);
+      if ((prevV < 0.f) != (vs < 0.f)) {
+        lo = prevS;
+        hi = s;
+        found = true;
+        break;
+      }
+      prevS = s;
+      prevV = vs;
+    }
+    CHECK(found);
+    float sRef = 0.5f * (lo + hi);
+    {
+      float a = lo, b = hi, va = v(a);
+      for (int i = 0; i < kBisectIters; ++i) {
+        const float m = 0.5f * (a + b);
+        const float vm = v(m);
+        if ((vm < 0.f) == (va < 0.f)) {
+          a = m;
+          va = vm;
+        } else
+          b = m;
+      }
+      sRef = 0.5f * (a + b);
+    }
+
+    float s = 0.f;
+    CHECK(firstTrilinearRoot(c, aEntry, aExit, iso, s));
+    CHECK(nearf(v(s), 0.f, 1e-3f));
+    // Never returns a later root than the true first crossing (one-sided:
+    // it may legitimately return an earlier one the coarse scan missed).
+    CHECK(s <= sRef + 1e-3f);
+  }
+}
+
+static void testLinearCrossing()
+{
+  SpatialFieldGPUData field; // dummy; mocks ignore it
+  const vec3 ro(0.f), rd(1.f, 0.f, 0.f);
+
+  // 1. f(p) = p.x, iso 0.25: hit at t=0.25, gradient flipped to face the ray.
+  {
+    const LinearFieldState st{vec3(1.f, 0.f, 0.f), 0.f};
+    const float iso[] = {0.25f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 99u;
+    CHECK(linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 1, outT, outN, outIdx));
+    CHECK(nearf(outT, 0.25f));
+    CHECK(outIdx == 0u);
+    CHECK(nearf(outN.x, -1.f));
+    CHECK(isUnit(outN));
+    CHECK(glm::dot(outN, rd) <= 0.f);
+  }
+
+  // 2. Multi-isovalue nearest-wins.
+  {
+    const LinearFieldState st{vec3(1.f, 0.f, 0.f), 0.f};
+    const float iso[] = {0.75f, 0.25f, 0.5f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 99u;
+    CHECK(linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 3, outT, outN, outIdx));
+    CHECK(nearf(outT, 0.25f));
+    CHECK(outIdx == 1u);
+  }
+
+  // 3. No straddle -> false.
+  {
+    const LinearFieldState st{vec3(1.f, 0.f, 0.f), 0.f};
+    const float iso[] = {1.5f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 0u;
+    CHECK(!linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 1, outT, outN, outIdx));
+  }
+
+  // 4. Non-unit rd with matching tExit: hit point invariant, t rescales.
+  {
+    const LinearFieldState st{vec3(1.f, 0.f, 0.f), 0.f};
+    const vec3 rd2(2.f, 0.f, 0.f);
+    const float tExit = 0.5f;
+    const float iso[] = {0.25f};
+    const float vE = sampleValue(st, field, ro);
+    const float vX = sampleValue(st, field, ro + tExit * rd2);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 0u;
+    CHECK(linearCrossing(
+        st, field, ro, rd2, 0.f, tExit, vE, vX, iso, 1, outT, outN, outIdx));
+    CHECK(nearf(outT, 0.125f));
+    CHECK(isUnit(outN));
+    CHECK(glm::dot(outN, rd2) <= 0.f);
+  }
+
+  // 5. Decreasing field f = 1 - p.x, iso 0.75: gradient already faces the ray.
+  {
+    const LinearFieldState st{vec3(-1.f, 0.f, 0.f), 1.f};
+    const float iso[] = {0.75f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 99u;
+    CHECK(linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 1, outT, outN, outIdx));
+    CHECK(nearf(outT, 0.25f));
+    CHECK(nearf(outN.x, -1.f));
+    CHECK(isUnit(outN));
+    CHECK(glm::dot(outN, rd) <= 0.f);
+  }
+
+  // 6. Zero gradient constant field == iso: hit at tEntry, normal = -rd.
+  {
+    const LinearFieldState st{vec3(0.f), 0.5f};
+    const float iso[] = {0.5f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 99.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 99u;
+    CHECK(linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 1, outT, outN, outIdx));
+    CHECK(nearf(outT, 0.f));
+    CHECK(nearf(outN.x, glm::normalize(-rd).x) && isUnit(outN));
+    CHECK(glm::dot(outN, rd) <= 0.f);
+  }
+
+  // 7. Hybrid-bracket miss: f dips to 0 inside but both endpoints read 0.25, so
+  // iso 0.1 (crossed twice strictly inside) is skipped by design.
+  {
+    const QuadFieldState st{0.5f};
+    const float iso[] = {0.1f};
+    const float vE = sampleValue(st, field, ro),
+                vX = sampleValue(st, field, ro + rd);
+    float outT = 0.f;
+    vec3 outN(0.f);
+    uint32_t outIdx = 0u;
+    CHECK(!linearCrossing(
+        st, field, ro, rd, 0.f, 1.f, vE, vX, iso, 1, outT, outN, outIdx));
+  }
+}
+
+int main()
+{
+  testTrilinear();
+  testPrepareCubic();
+  testSolveCubic();
+  testFirstTrilinearRootProperty();
+  testLinearCrossing();
+  if (g_failures) {
+    std::printf("%d CHECK(s) failed\n", g_failures);
+    return 1;
+  }
+  std::printf("all isosurface linear host tests passed\n");
+  return 0;
+}

--- a/devices/rtx/device/geometry/Cone.cpp
+++ b/devices/rtx/device/geometry/Cone.cpp
@@ -31,10 +31,28 @@
 
 #include "Cone.h"
 
+#include "gpu/intersectPrimitives.h"
+
 namespace visrtx {
 
+// ANARI caps string -> per-endpoint bitmask (none/first/second/both).
+static uint8_t parseCapFlags(const std::string &s)
+{
+  if (s == "both")
+    return CAP_FIRST | CAP_SECOND;
+  if (s == "first")
+    return CAP_FIRST;
+  if (s == "second")
+    return CAP_SECOND;
+  return 0; // "none"
+}
+
 Cone::Cone(DeviceGlobalState *d)
-    : Geometry(d), m_index(this), m_radius(this), m_vertex(this)
+    : Geometry(d),
+      m_index(this),
+      m_radius(this),
+      m_vertex(this),
+      m_vertexCaps(this)
 {}
 
 Cone::~Cone() = default;
@@ -44,7 +62,8 @@ void Cone::commitParameters()
   Geometry::commitParameters();
   m_index = getParamObject<Array1D>("primitive.index");
   m_radius = getParamObject<Array1D>("vertex.radius");
-  m_caps = getParamString("caps", "none") != "none";
+  m_defaultCapFlags = parseCapFlags(getParamString("caps", "none"));
+  m_vertexCaps = getParamObject<Array1D>("vertex.cap");
   m_vertex = getParamObject<Array1D>("vertex.position");
   commitAttributes("vertex.", m_vertexAttributes);
 }
@@ -92,10 +111,8 @@ void Cone::finalize()
       indices.begin(), indices.end(), m_aabbs.begin(), [&](const uvec2 &c) {
         const vec3 &v0 = posBegin[c.x];
         const vec3 &v1 = posBegin[c.y];
-        const float &r0 = radius[c.x];
-        const float &r1 = radius[c.y];
-        return box3(glm::min(v0, v1) - glm::max(r0, r1),
-            glm::max(v0, v1) + glm::max(r0, r1));
+        const float r = glm::max(std::abs(radius[c.x]), std::abs(radius[c.y]));
+        return box3(glm::min(v0, v1) - r, glm::max(v0, v1) + r);
       });
 
   m_aabbs.upload();
@@ -136,6 +153,9 @@ GeometryGPUData Cone::gpuData() const
   cone.vertices = m_vertex->beginAs<vec3>(AddressSpace::GPU);
   cone.indices = m_index ? m_index->beginAs<uvec2>(AddressSpace::GPU) : nullptr;
   cone.radii = m_radius->beginAs<float>(AddressSpace::GPU);
+  cone.defaultCapFlags = m_defaultCapFlags;
+  cone.vertexCaps =
+      m_vertexCaps ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU) : nullptr;
   populateAttributeDataSet(m_vertexAttributes, cone.vertexAttr);
 
   return retval;

--- a/devices/rtx/device/geometry/Cone.cpp
+++ b/devices/rtx/device/geometry/Cone.cpp
@@ -118,6 +118,16 @@ void Cone::finalize()
   m_aabbs.upload();
   m_aabbsBufferPtr = (CUdeviceptr)m_aabbs.dataDevice();
 
+  // Coordinate scale of the intersector's arithmetic; floors hit.epsilon so
+  // secondary rays clear the solve's fp noise band (see
+  // GeometryGPUData::epsilonScale).
+  m_epsilonScale = 0.f;
+  for (auto it = m_aabbs.begin(); it != m_aabbs.end(); ++it) {
+    const vec3 m = glm::max(glm::abs(it->lower), glm::abs(it->upper));
+    m_epsilonScale =
+        std::max(m_epsilonScale, std::max(m.x, std::max(m.y, m.z)));
+  }
+
   upload();
 }
 
@@ -154,8 +164,9 @@ GeometryGPUData Cone::gpuData() const
   cone.indices = m_index ? m_index->beginAs<uvec2>(AddressSpace::GPU) : nullptr;
   cone.radii = m_radius->beginAs<float>(AddressSpace::GPU);
   cone.defaultCapFlags = m_defaultCapFlags;
-  cone.vertexCaps =
-      m_vertexCaps ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU) : nullptr;
+  cone.vertexCaps = m_vertexCaps
+      ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU)
+      : nullptr;
   populateAttributeDataSet(m_vertexAttributes, cone.vertexAttr);
 
   return retval;

--- a/devices/rtx/device/geometry/Cone.h
+++ b/devices/rtx/device/geometry/Cone.h
@@ -55,12 +55,13 @@ struct Cone : public Geometry
   helium::ChangeObserverPtr<Array1D> m_index;
   helium::ChangeObserverPtr<Array1D> m_radius;
   helium::ChangeObserverPtr<Array1D> m_vertex;
+  helium::ChangeObserverPtr<Array1D> m_vertexCaps;
   GeometryAttributes m_vertexAttributes;
 
   HostDeviceArray<box3> m_aabbs;
   CUdeviceptr m_aabbsBufferPtr{};
 
-  bool m_caps{false};
+  uint8_t m_defaultCapFlags{0};
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/geometry/Cylinder.cpp
+++ b/devices/rtx/device/geometry/Cylinder.cpp
@@ -31,10 +31,28 @@
 
 #include "Cylinder.h"
 
+#include "gpu/intersectPrimitives.h"
+
 namespace visrtx {
 
+// ANARI caps string -> per-endpoint bitmask (none/first/second/both).
+static uint8_t parseCapFlags(const std::string &s)
+{
+  if (s == "both")
+    return CAP_FIRST | CAP_SECOND;
+  if (s == "first")
+    return CAP_FIRST;
+  if (s == "second")
+    return CAP_SECOND;
+  return 0; // "none"
+}
+
 Cylinder::Cylinder(DeviceGlobalState *d)
-    : Geometry(d), m_index(this), m_radius(this), m_vertex(this)
+    : Geometry(d),
+      m_index(this),
+      m_radius(this),
+      m_vertex(this),
+      m_vertexCaps(this)
 {}
 
 Cylinder::~Cylinder() = default;
@@ -44,7 +62,8 @@ void Cylinder::commitParameters()
   Geometry::commitParameters();
   m_index = getParamObject<Array1D>("primitive.index");
   m_radius = getParamObject<Array1D>("primitive.radius");
-  m_caps = getParamString("caps", "none") != "none";
+  m_defaultCapFlags = parseCapFlags(getParamString("caps", "none"));
+  m_vertexCaps = getParamObject<Array1D>("vertex.cap");
   m_vertex = getParamObject<Array1D>("vertex.position");
   m_globalRadius = getParam<float>("radius", 1.f);
   commitAttributes("vertex.", m_vertexAttributes);
@@ -131,7 +150,9 @@ GeometryGPUData Cylinder::gpuData() const
   cylinder.radii =
       m_radius ? m_radius->beginAs<float>(AddressSpace::GPU) : nullptr;
   cylinder.radius = m_globalRadius;
-  cylinder.caps = m_caps;
+  cylinder.defaultCapFlags = m_defaultCapFlags;
+  cylinder.vertexCaps =
+      m_vertexCaps ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU) : nullptr;
   populateAttributeDataSet(m_vertexAttributes, cylinder.vertexAttr);
 
   return retval;

--- a/devices/rtx/device/geometry/Cylinder.cpp
+++ b/devices/rtx/device/geometry/Cylinder.cpp
@@ -117,6 +117,16 @@ void Cylinder::finalize()
   m_aabbs.upload();
   m_aabbsBufferPtr = (CUdeviceptr)m_aabbs.dataDevice();
 
+  // Coordinate scale of the intersector's arithmetic; floors hit.epsilon so
+  // secondary rays clear the solve's fp noise band (see
+  // GeometryGPUData::epsilonScale).
+  m_epsilonScale = 0.f;
+  for (auto it = m_aabbs.begin(); it != m_aabbs.end(); ++it) {
+    const vec3 m = glm::max(glm::abs(it->lower), glm::abs(it->upper));
+    m_epsilonScale =
+        std::max(m_epsilonScale, std::max(m.x, std::max(m.y, m.z)));
+  }
+
   upload();
 }
 
@@ -151,8 +161,9 @@ GeometryGPUData Cylinder::gpuData() const
       m_radius ? m_radius->beginAs<float>(AddressSpace::GPU) : nullptr;
   cylinder.radius = m_globalRadius;
   cylinder.defaultCapFlags = m_defaultCapFlags;
-  cylinder.vertexCaps =
-      m_vertexCaps ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU) : nullptr;
+  cylinder.vertexCaps = m_vertexCaps
+      ? m_vertexCaps->beginAs<uint8_t>(AddressSpace::GPU)
+      : nullptr;
   populateAttributeDataSet(m_vertexAttributes, cylinder.vertexAttr);
 
   return retval;

--- a/devices/rtx/device/geometry/Cylinder.h
+++ b/devices/rtx/device/geometry/Cylinder.h
@@ -56,6 +56,7 @@ struct Cylinder : public Geometry
   helium::ChangeObserverPtr<Array1D> m_index;
   helium::ChangeObserverPtr<Array1D> m_radius;
   helium::ChangeObserverPtr<Array1D> m_vertex;
+  helium::ChangeObserverPtr<Array1D> m_vertexCaps;
   GeometryAttributes m_vertexAttributes;
 
   HostDeviceArray<box3> m_aabbs;
@@ -63,7 +64,7 @@ struct Cylinder : public Geometry
 
   float m_globalRadius{1.f};
 
-  bool m_caps{false};
+  uint8_t m_defaultCapFlags{0};
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/geometry/Geometry.cpp
+++ b/devices/rtx/device/geometry/Geometry.cpp
@@ -151,6 +151,7 @@ GeometryGPUData Geometry::gpuData() const
   populateAttributeDataSet(m_primitiveAttributes, retval.attr);
   retval.primitiveId =
       (const uint32_t *)(m_primitiveId ? m_primitiveId->dataGPU() : nullptr);
+  retval.epsilonScale = m_epsilonScale;
 
   return retval;
 }

--- a/devices/rtx/device/geometry/Geometry.h
+++ b/devices/rtx/device/geometry/Geometry.h
@@ -86,6 +86,9 @@ struct Geometry : public RegisteredObject<GeometryGPUData>
   GeometryAttributes m_primitiveAttributes;
   UniformAttributes m_uniformAttributes;
   helium::IntrusivePtr<Array1D> m_primitiveId;
+  // Set by analytic-primitive subtypes in finalize(); see
+  // GeometryGPUData::epsilonScale.
+  float m_epsilonScale{0.f};
 };
 
 } // namespace visrtx

--- a/devices/rtx/device/geometry/Intersectors_ptx.cu
+++ b/devices/rtx/device/geometry/Intersectors_ptx.cu
@@ -31,10 +31,11 @@
 
 #include "geometry/IsosurfaceLinear.h"
 #include "geometry/IsosurfaceSample.h"
-#include "spatial_field/CustomFieldSamplerInline.h"
 #include "gpu/gpu_math.h"
 #include "gpu/gridTraversal.h"
+#include "gpu/intersectPrimitives.h"
 #include "gpu/shading_api.h"
+#include "spatial_field/CustomFieldSamplerInline.h"
 
 // glm
 #include <glm/gtx/norm.hpp>
@@ -56,6 +57,17 @@ VISRTX_DEVICE void reportIntersection(float t, const vec3 &normal, float u)
       bit_cast<uint32_t>(normal.x),
       bit_cast<uint32_t>(normal.y),
       bit_cast<uint32_t>(normal.z));
+}
+
+// Report only front-facing (entry) crossings of an analytic solid. For a ray
+// from outside a convex primitive the entry crossing is the visible surface;
+// the back-facing exit crossing is never nearest and, for a ray grazing its own
+// origin surface, is a spurious self-occlusion. rd is the (object-space) ray
+// direction the crossing normal is tested against.
+VISRTX_DEVICE void reportEntryCrossing(const PrimHit &h, const vec3 &rd)
+{
+  if (dot(h.Ng, rd) < 0.f)
+    reportIntersection(h.t, h.Ng, h.u);
 }
 
 VISRTX_DEVICE void reportIntersection(float t)
@@ -87,6 +99,21 @@ VISRTX_DEVICE void reportIntersectionIsosurface(
 
 // Primitive intersectors /////////////////////////////////////////////////////
 
+// Per-endpoint cap enablement: vertex.cap array (element!=0 enables that
+// endpoint's cap) overrides the geometry-wide default when present.
+VISRTX_DEVICE uint8_t resolveCapBits(
+    uint8_t defaultCapFlags, const uint8_t *vertexCaps, const uvec2 &pidx)
+{
+  if (!vertexCaps)
+    return defaultCapFlags;
+  uint8_t caps = 0;
+  if (vertexCaps[pidx.x])
+    caps |= CAP_FIRST;
+  if (vertexCaps[pidx.y])
+    caps |= CAP_SECOND;
+  return caps;
+}
+
 VISRTX_DEVICE void intersectSphere(const GeometryGPUData &geometryData)
 {
   const auto &sphereData = geometryData.sphere;
@@ -98,20 +125,12 @@ VISRTX_DEVICE void intersectSphere(const GeometryGPUData &geometryData)
   const auto radius =
       sphereData.radii ? sphereData.radii[primID] : sphereData.radius;
 
-  const vec3 d = ray::localDirection();
-  const float rd2 = 1.f / dot(d, d);
-  const vec3 CO = center - ray::localOrigin();
-  const float projCO = dot(CO, d) * rd2;
-  const vec3 perp = CO - projCO * d;
-  const float l2 = glm::dot(perp, perp);
-  const float r2 = radius * radius;
-  if (l2 > r2)
-    return;
-  const float td = glm::sqrt((r2 - l2) * rd2);
-  const float t = projCO - td;
-  const vec3 h = ray::localOrigin() + t * ray::localDirection();
-  const vec3 n = h - center;
-  reportIntersection(t, n, 0.f);
+  const vec3 rd = ray::localDirection();
+  forEachSphereCrossing(ray::localOrigin(),
+      rd,
+      center,
+      radius,
+      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
 }
 
 VISRTX_DEVICE void intersectCylinder(const GeometryGPUData &geometryData)
@@ -124,85 +143,19 @@ VISRTX_DEVICE void intersectCylinder(const GeometryGPUData &geometryData)
   const auto p0 = cylinderData.vertices[pidx.x];
   const auto p1 = cylinderData.vertices[pidx.y];
 
-  const float radius =
-      glm::abs(cylinderData.radii ? cylinderData.radii[ray::primID()]
-                                  : cylinderData.radius);
-  const bool caps = cylinderData.caps;
+  const float radius = cylinderData.radii ? cylinderData.radii[ray::primID()]
+                                          : cylinderData.radius;
+  const uint8_t caps = resolveCapBits(
+      cylinderData.defaultCapFlags, cylinderData.vertexCaps, pidx);
 
-  const vec3 ro = ray::localOrigin();
   const vec3 rd = ray::localDirection();
-
-  const vec3 s = p1 - p0; // axis
-  const vec3 sxd = glm::cross(s, rd);
-  const float a = glm::dot(sxd, sxd); // (s x d)^2
-
-  if (a == 0.f)
-    return;
-
-  const vec3 f = p0 - ro;
-  const vec3 sxf = glm::cross(s, f);
-  const float ra = 1.0f / a;
-  const float ts =
-      glm::dot(sxd, sxf) * ra; // (s x d)(s x f) / (s x d)^2, in ray-space
-  const vec3 fp = f - ts * rd; // f' = p0 - closest point to axis
-
-  const float s2 = glm::dot(s, s); // s^2
-  const vec3 perp = glm::cross(s, fp); // s x f'
-  const float c =
-      (radius * radius) * s2 - glm::dot(perp, perp); //  r^2 s^2 - (s x f')^2
-
-  if (c < 0.f)
-    return;
-
-  float td = glm::sqrt(c * ra);
-  const float tin = ts - td;
-  const float tout = ts + td;
-
-  // clip to cylinder caps
-  const float sf = glm::dot(s, f);
-  const float sd = glm::dot(s, rd);
-
-  const float u_in = (tin * sd - sf) * (1.f / s2);
-  const vec3 N_in = -td * rd - fp - u_in * s;
-  const float u_out = (tout * sd - sf) * (1.f / s2);
-  const vec3 N_out = td * rd - fp - u_out * s;
-
-  if (sd != 0.0f) { // Note: sd will become zero if cylinder is oriented
-                    // perpendicular to ray direction.
-    const float rsd = 1.f / sd;
-    const float tA = sf * rsd;
-    const float tB = tA + s2 * rsd;
-
-    const float cap_tin = glm::min(tA, tB);
-    const float cap_tout = glm::max(tA, tB);
-
-    if (tin > cap_tin && tin < cap_tout)
-      reportIntersection(tin, N_in, u_in);
-    if (tout > cap_tin && tout < cap_tout)
-      reportIntersection(tout, N_out, u_out);
-  } else if (sf <= 0.0f && sf >= -s2) {
-    reportIntersection(tin, N_in, u_in);
-    reportIntersection(tout, N_out, u_out);
-  }
-
-  if (caps) {
-    const float a = s2 - sd * sd;
-    const float b = s2 * glm::dot(-f, rd) + (sf * sd);
-    const float c = s2 * glm::dot(-f, -f) - (sf * sf) - (radius * radius * s2);
-    float h = b * b - a * c;
-
-    if (h < 0.f)
-      return;
-
-    h = glm::sqrt(h);
-    const float y = ((-b - h) / a) * sd - sf;
-    const float d = ((y < 0.f ? 0.f : s2) + sf) / sd;
-
-    if (glm::abs(b + a * d) < h) {
-      auto n = s * glm::sign(y) / s2;
-      reportIntersection(d, n, y < 0.f ? 0.f : 1.f);
-    }
-  }
+  forEachCylinderCrossing(ray::localOrigin(),
+      rd,
+      p0,
+      p1,
+      radius,
+      caps,
+      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
 }
 
 VISRTX_DEVICE void intersectCone(const GeometryGPUData &geometryData)
@@ -215,50 +168,21 @@ VISRTX_DEVICE void intersectCone(const GeometryGPUData &geometryData)
   const auto p0 = coneData.vertices[pidx.x];
   const auto p1 = coneData.vertices[pidx.y];
 
-  const float ra = coneData.radii[pidx.x];
-  const float rb = coneData.radii[pidx.y];
+  const float r0 = coneData.radii[pidx.x];
+  const float r1 = coneData.radii[pidx.y];
 
-  const vec3 ro = ray::localOrigin();
+  const uint8_t caps =
+      resolveCapBits(coneData.defaultCapFlags, coneData.vertexCaps, pidx);
+
   const vec3 rd = ray::localDirection();
-
-  const vec3 ba = p1 - p0;
-  const vec3 oa = ro - p0;
-  const vec3 ob = ro - p1;
-
-  const float m0 = glm::dot(ba, ba);
-  const float m1 = glm::dot(oa, ba);
-  const float m2 = glm::dot(ob, ba);
-  const float m3 = glm::dot(rd, ba);
-
-  if (m1 < 0.0f) {
-    if (glm::length2(oa * m3 - rd * m1) < (ra * ra * m3 * m3))
-      reportIntersection(-m1 / m3, -ba * glm::inversesqrt(m0), 0.f);
-  } else if (m2 > 0.0f) {
-    if (glm::length2(ob * m3 - rd * m2) < (rb * rb * m3 * m3))
-      reportIntersection(-m2 / m3, ba * glm::inversesqrt(m0), 1.f);
-  }
-
-  const float m4 = glm::dot(rd, oa);
-  const float m5 = glm::dot(oa, oa);
-  const float rr = ra - rb;
-  const float hy = m0 + rr * rr;
-
-  float k2 = m0 * m0 - m3 * m3 * hy;
-  float k1 = m0 * m0 * m4 - m1 * m3 * hy + m0 * ra * (rr * m3 * 1.0f);
-  float k0 = m0 * m0 * m5 - m1 * m1 * hy + m0 * ra * (rr * m1 * 2.0f - m0 * ra);
-
-  const float h = k1 * k1 - k2 * k0;
-  if (h < 0.0f)
-    return;
-
-  const float t = (-k1 - glm::sqrt(h)) / k2;
-
-  const float y = m1 + t * m3;
-  if (y > 0.0f && y < m0) {
-    reportIntersection(t,
-        glm::normalize(m0 * (m0 * (oa + t * rd) + rr * ba * ra) - ba * hy * y),
-        position(y, box1(0.f, m0)));
-  }
+  forEachConeCrossing(ray::localOrigin(),
+      rd,
+      p0,
+      p1,
+      r0,
+      r1,
+      caps,
+      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
 }
 
 VISRTX_DEVICE bool rayBoxIntersection(
@@ -474,8 +398,8 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
     // Find the nearest isovalue crossing within (tPrev, t]. The field is
     // monotone across one sub-voxel step, so the crossings order by their
     // linear-interpolated t -- pick the nearest from those estimates (no extra
-    // samples) and refine only that one by bisection below, instead of bisecting
-    // every bracketing isovalue (N root-finds -> 1).
+    // samples) and refine only that one by bisection below, instead of
+    // bisecting every bracketing isovalue (N root-finds -> 1).
     float bestEst = t1 + 1.f;
     float bestIv = 0.f;
     uint32_t bestIdx = 0;
@@ -500,8 +424,8 @@ VISRTX_DEVICE bool marchIsosurfaceSegment(const IsosurfaceGeometryData &iso,
     }
 
     if (found) {
-      // Refine the nearest crossing's root in [tPrev, t] by value-only bisection
-      // (skipped when it sits exactly on the previous sample).
+      // Refine the nearest crossing's root in [tPrev, t] by value-only
+      // bisection (skipped when it sits exactly on the previous sample).
       float bestT = bestEst;
       if (bestT > tPrev) {
         float la = tPrev, lb = t, va = vPrev - bestIv, tm = bestT;
@@ -617,13 +541,14 @@ VISRTX_DEVICE void marchIsosurface(const IsosurfaceGeometryData &iso,
 // below — the only per-filter logic, factored out so the four overloads differ
 // only in their traversal mechanics. st.filter is a per-field constant, so the
 // branch is warp-uniform. Nearest = piecewise-constant face test (one midpoint
-// sample; report the entry-face normal at tEntry). Linear = the trilinear-along-
-// ray cubic (linearCrossing). Returns true and reports the hit on a crossing;
-// otherwise carries the predecessor sample `vPrev` (voxel midpoint for nearest,
-// exit-face value for linear) and returns false. crossedAxis is the face the ray
-// entered this voxel through. Callers seed vPrev per-filter before the first
-// voxel (nearest a quarter-voxel back; linear the exact entry-face value, since
-// linearCrossing consumes it as the cubic's node-0).
+// sample; report the entry-face normal at tEntry). Linear = the
+// trilinear-along- ray cubic (linearCrossing). Returns true and reports the hit
+// on a crossing; otherwise carries the predecessor sample `vPrev` (voxel
+// midpoint for nearest, exit-face value for linear) and returns false.
+// crossedAxis is the face the ray entered this voxel through. Callers seed
+// vPrev per-filter before the first voxel (nearest a quarter-voxel back; linear
+// the exact entry-face value, since linearCrossing consumes it as the cubic's
+// node-0).
 template <typename SamplerState>
 VISRTX_DEVICE bool crossingTest(const SamplerState &st,
     const SpatialFieldGPUData &field,
@@ -640,8 +565,9 @@ VISRTX_DEVICE bool crossingTest(const SamplerState &st,
   if (st.filter == SpatialFieldFilter::Nearest) {
     const float tMid = 0.5f * (tEntry + tExit);
     const float vCur = sampleValue(st, field, ro + tMid * rd);
-    // Scan all isovalues (no divergent in-loop early-out; the uniform trip count
-    // lets ptxas unroll). Every bracket shares this face's t, so report the first.
+    // Scan all isovalues (no divergent in-loop early-out; the uniform trip
+    // count lets ptxas unroll). Every bracket shares this face's t, so report
+    // the first.
     int hitIdx = -1;
     for (uint32_t i = 0; i < numIsovalues; ++i) {
       const float iv = isovals[i];
@@ -659,13 +585,25 @@ VISRTX_DEVICE bool crossingTest(const SamplerState &st,
     vPrev = vCur;
   } else {
     // Exit-face value sampled only on the linear path (nearest keeps its single
-    // midpoint sample). Carried as the next voxel's entry value -> one fetch/voxel.
+    // midpoint sample). Carried as the next voxel's entry value -> one
+    // fetch/voxel.
     const float vExit = sampleValue(st, field, ro + tExit * rd);
     float hitT;
     vec3 hitN;
     uint32_t hitIdx;
-    if (linearCrossing(st, field, ro, rd, tEntry, tExit, vPrev, vExit, isovals,
-            numIsovalues, hitT, hitN, hitIdx)) {
+    if (linearCrossing(st,
+            field,
+            ro,
+            rd,
+            tEntry,
+            tExit,
+            vPrev,
+            vExit,
+            isovals,
+            numIsovalues,
+            hitT,
+            hitN,
+            hitIdx)) {
       reportIntersectionIsosurface(hitT, hitN, hitIdx);
       return true;
     }
@@ -708,17 +646,26 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
     return false;
 
   const float firstSpan = trav.tExit - trav.tEntry;
-  // Nearest seeds a quarter-voxel before entry (an entry-side value for the face
-  // sign-test); linear needs the EXACT entry-face value — linearCrossing consumes
-  // vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample would
-  // corrupt the first voxel's root in every active segment.
+  // Nearest seeds a quarter-voxel before entry (an entry-side value for the
+  // face sign-test); linear needs the EXACT entry-face value — linearCrossing
+  // consumes vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample
+  // would corrupt the first voxel's root in every active segment.
   float vPrev = st.filter == SpatialFieldFilter::Nearest
       ? sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd)
       : sampleValue(st, field, ro + trav.tEntry * rd);
 
   while (trav.valid()) {
-    if (crossingTest(st, field, ro, rd, trav.tEntry, trav.tExit,
-            trav.crossedAxis, isovals, numIsovalues, vPrev, ss))
+    if (crossingTest(st,
+            field,
+            ro,
+            rd,
+            trav.tEntry,
+            trav.tExit,
+            trav.crossedAxis,
+            isovals,
+            numIsovalues,
+            vPrev,
+            ss))
       return true;
     trav.next();
   }
@@ -764,17 +711,26 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
     return false;
 
   const float firstSpan = trav.tExit - trav.tEntry;
-  // Nearest seeds a quarter-voxel before entry (an entry-side value for the face
-  // sign-test); linear needs the EXACT entry-face value — linearCrossing consumes
-  // vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample would
-  // corrupt the first voxel's root in every active segment.
+  // Nearest seeds a quarter-voxel before entry (an entry-side value for the
+  // face sign-test); linear needs the EXACT entry-face value — linearCrossing
+  // consumes vPrev as vEntry == the cubic's node-0 (f0), so a pre-entry sample
+  // would corrupt the first voxel's root in every active segment.
   float vPrev = st.filter == SpatialFieldFilter::Nearest
       ? sampleValue(st, field, ro + (trav.tEntry - 0.25f * firstSpan) * rd)
       : sampleValue(st, field, ro + trav.tEntry * rd);
 
   while (trav.valid()) {
-    if (crossingTest(st, field, ro, rd, trav.tEntry, trav.tExit,
-            trav.crossedAxis, isovals, numIsovalues, vPrev, ss))
+    if (crossingTest(st,
+            field,
+            ro,
+            rd,
+            trav.tEntry,
+            trav.tExit,
+            trav.crossedAxis,
+            isovals,
+            numIsovalues,
+            vPrev,
+            ss))
       return true;
     trav.next();
   }
@@ -835,7 +791,8 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
   constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
   for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
     float tExit = t1;
-    int exitAxis = -1; // set below to the exit-boundary axis; -1 => none before t1
+    int exitAxis =
+        -1; // set below to the exit-boundary axis; -1 => none before t1
     // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
     // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
     // risking a re-picked boundary / stalled segment in larger scenes.
@@ -863,8 +820,17 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
           : sampleValue(st, field, ro + t * rd);
       seeded = true;
     }
-    if (crossingTest(st, field, ro, rd, t, tExitSeg, crossedAxis, isovals,
-            numIsovalues, vPrev, ss))
+    if (crossingTest(st,
+            field,
+            ro,
+            rd,
+            t,
+            tExitSeg,
+            crossedAxis,
+            isovals,
+            numIsovalues,
+            vPrev,
+            ss))
       return true;
     if (exitAxis < 0) // no forward boundary before t1: the segment ends here
       break;
@@ -931,7 +897,8 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
   constexpr int kMaxVoxelSteps = 4096; // hard cap: never hang the intersector
   for (int s = 0; s < kMaxVoxelSteps && t < t1; ++s) {
     float tExit = t1;
-    int exitAxis = -1; // set below to the exit-boundary axis; -1 => none before t1
+    int exitAxis =
+        -1; // set below to the exit-boundary axis; -1 => none before t1
     // Scale-relative advance guard: a fixed 1e-6 falls below ULP(t) once t
     // exceeds ~10 (e.g. coords in the tens), collapsing the test to te > t and
     // risking a re-picked boundary / stalled segment in larger scenes.
@@ -959,8 +926,17 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
           : sampleValue(st, field, ro + t * rd);
       seeded = true;
     }
-    if (crossingTest(st, field, ro, rd, t, tExitSeg, crossedAxis, isovals,
-            numIsovalues, vPrev, ss))
+    if (crossingTest(st,
+            field,
+            ro,
+            rd,
+            t,
+            tExitSeg,
+            crossedAxis,
+            isovals,
+            numIsovalues,
+            vPrev,
+            ss))
       return true;
     if (exitAxis < 0) // no forward boundary before t1: the segment ends here
       break;
@@ -972,10 +948,11 @@ VISRTX_DEVICE bool voxelDDASegment(const IsosurfaceGeometryData &iso,
 }
 
 // Two-level traversal: walk the coarse macrocell grid (empty-space skipping via
-// its value ranges) and only run the per-voxel DDA inside macrocells whose range
-// brackets an isovalue. Each active segment is extended one voxel past the cell
-// exit so a crossing on the shared face with a skipped neighbour is still found;
-// front-to-back keeps the nearest hit. (`voxelDDASegment` resolves per grid.)
+// its value ranges) and only run the per-voxel DDA inside macrocells whose
+// range brackets an isovalue. Each active segment is extended one voxel past
+// the cell exit so a crossing on the shared face with a skipped neighbour is
+// still found; front-to-back keeps the nearest hit. (`voxelDDASegment` resolves
+// per grid.)
 template <typename SamplerState>
 VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
     const SpatialFieldGPUData &field,
@@ -985,8 +962,8 @@ VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
 {
   const float *const isovals = iso.isovalues;
   const uint32_t numIsovalues = iso.numIsovalues;
-  // ~one voxel, to cover the exit face. iso.stepSize is object-space; objRay.dir
-  // is non-unit under instance scaling, so convert to ray-t units.
+  // ~one voxel, to cover the exit face. iso.stepSize is object-space;
+  // objRay.dir is non-unit under instance scaling, so convert to ray-t units.
   const float margin = 2.f * iso.stepSize / length(objRay.dir);
 
   GridTraversal mc(objRay, field.grid.dims, field.grid.objectBounds);
@@ -1022,8 +999,8 @@ VISRTX_DEVICE void marchVoxelsMacrocellSkip(const IsosurfaceGeometryData &iso,
 // Voxel-DDA isosurface intersection for built-in grids. Concrete grid samplers
 // run the two-level macrocell-skip + per-voxel DDA for BOTH filters: nearest
 // does the piecewise-constant face test, linear solves the per-voxel trilinear
-// cubic (linearCrossing). The fixed-step ray march below is no longer reached by
-// built-in fields. This generic form is the ray-march fallback for fields
+// cubic (linearCrossing). The fixed-step ray march below is no longer reached
+// by built-in fields. This generic form is the ray-march fallback for fields
 // without analytic voxel boundaries (e.g. custom fields); built-in fields are
 // gated to require a space-skipping grid in Isosurface::finalize.
 template <typename SamplerState>
@@ -1054,7 +1031,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel
+  // cubic).
   marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
@@ -1064,7 +1042,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel
+  // cubic).
   marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
@@ -1075,7 +1054,8 @@ VISRTX_DEVICE void marchIsosurfaceVoxels(const IsosurfaceGeometryData &iso,
     const Ray &objRay,
     ScreenSample &ss)
 {
-  // Both filters traverse the voxel-DDA now (linear solves the per-voxel cubic).
+  // Both filters traverse the voxel-DDA now (linear solves the per-voxel
+  // cubic).
   marchVoxelsMacrocellSkip(iso, field, st, objRay, ss);
 }
 
@@ -1127,8 +1107,9 @@ VISRTX_DEVICE void intersectIsosurface(const GeometryGPUData &geometryData)
 #undef X
   case SbtCallableEntryPoints::SpatialFieldSamplerCustom:
     // Custom fields have no inline sampler; sample via the SBT callables
-    // (initSamplerState/sampleValue/sampleNormal route through optixDirectCall).
-    // The generic marchIsosurfaceVoxels falls back to the fixed-step ray march.
+    // (initSamplerState/sampleValue/sampleNormal route through
+    // optixDirectCall). The generic marchIsosurfaceVoxels falls back to the
+    // fixed-step ray march.
     initSamplerState(st, field);
     marchIsosurfaceVoxels(iso, field, st, objRay, ss);
     return;

--- a/devices/rtx/device/geometry/Intersectors_ptx.cu
+++ b/devices/rtx/device/geometry/Intersectors_ptx.cu
@@ -49,25 +49,39 @@ namespace visrtx {
 
 // Helper functions ///////////////////////////////////////////////////////////
 
-VISRTX_DEVICE void reportIntersection(float t, const vec3 &normal, float u)
+// Analytic-primitive hit kinds: facing in bit 0 so front/back survives into
+// AH/CH (and optixIsFrontFaceHit's custom-primitive LSB convention matches).
+// The CH side re-derives facing from the outward normal regardless
+// (populateHit.h), so nothing correctness-critical rides on the OptiX LSB
+// behavior.
+constexpr uint32_t HIT_KIND_FRONT = 0u;
+constexpr uint32_t HIT_KIND_BACK = 1u;
+
+VISRTX_DEVICE void reportIntersection(
+    float t, const vec3 &normal, float u, uint32_t hitKind = HIT_KIND_FRONT)
 {
   optixReportIntersection(t,
-      0,
+      hitKind,
       bit_cast<uint32_t>(u),
       bit_cast<uint32_t>(normal.x),
       bit_cast<uint32_t>(normal.y),
       bit_cast<uint32_t>(normal.z));
 }
 
-// Report only front-facing (entry) crossings of an analytic solid. For a ray
-// from outside a convex primitive the entry crossing is the visible surface;
-// the back-facing exit crossing is never nearest and, for a ray grazing its own
-// origin surface, is a spurious self-occlusion. rd is the (object-space) ray
-// direction the crossing normal is tested against.
-VISRTX_DEVICE void reportEntryCrossing(const PrimHit &h, const vec3 &rd)
+// Report every boundary crossing of an analytic solid — entry (front-facing)
+// and exit (back-facing) alike — and let OptiX keep the nearest in
+// [tmin, tmax]. Back-facing crossings make interiors visible (camera inside a
+// primitive, cut planes) and give transmission rays their exit event. The
+// normal stays outward; the CH side orients it toward the ray and records
+// facing (populateHit.h), mirroring the triangle convention. A secondary ray
+// grazing its own origin surface can reach the surface's own exit crossing —
+// the hit.epsilon origin offset + tmin guards against it, exactly as for
+// triangles. rd is the (object-space) ray direction the facing is tested
+// against.
+VISRTX_DEVICE void reportCrossing(const PrimHit &h, const vec3 &rd)
 {
-  if (dot(h.Ng, rd) < 0.f)
-    reportIntersection(h.t, h.Ng, h.u);
+  const bool isFront = dot(h.Ng, rd) < 0.f;
+  reportIntersection(h.t, h.Ng, h.u, isFront ? HIT_KIND_FRONT : HIT_KIND_BACK);
 }
 
 VISRTX_DEVICE void reportIntersection(float t)
@@ -126,11 +140,10 @@ VISRTX_DEVICE void intersectSphere(const GeometryGPUData &geometryData)
       sphereData.radii ? sphereData.radii[primID] : sphereData.radius;
 
   const vec3 rd = ray::localDirection();
-  forEachSphereCrossing(ray::localOrigin(),
-      rd,
-      center,
-      radius,
-      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
+  forEachSphereCrossing(
+      ray::localOrigin(), rd, center, radius, [&](const PrimHit &h) {
+        reportCrossing(h, rd);
+      });
 }
 
 VISRTX_DEVICE void intersectCylinder(const GeometryGPUData &geometryData)
@@ -149,13 +162,10 @@ VISRTX_DEVICE void intersectCylinder(const GeometryGPUData &geometryData)
       cylinderData.defaultCapFlags, cylinderData.vertexCaps, pidx);
 
   const vec3 rd = ray::localDirection();
-  forEachCylinderCrossing(ray::localOrigin(),
-      rd,
-      p0,
-      p1,
-      radius,
-      caps,
-      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
+  forEachCylinderCrossing(
+      ray::localOrigin(), rd, p0, p1, radius, caps, [&](const PrimHit &h) {
+        reportCrossing(h, rd);
+      });
 }
 
 VISRTX_DEVICE void intersectCone(const GeometryGPUData &geometryData)
@@ -175,14 +185,10 @@ VISRTX_DEVICE void intersectCone(const GeometryGPUData &geometryData)
       resolveCapBits(coneData.defaultCapFlags, coneData.vertexCaps, pidx);
 
   const vec3 rd = ray::localDirection();
-  forEachConeCrossing(ray::localOrigin(),
-      rd,
-      p0,
-      p1,
-      r0,
-      r1,
-      caps,
-      [&](const PrimHit &h) { reportEntryCrossing(h, rd); });
+  forEachConeCrossing(
+      ray::localOrigin(), rd, p0, p1, r0, r1, caps, [&](const PrimHit &h) {
+        reportCrossing(h, rd);
+      });
 }
 
 VISRTX_DEVICE bool rayBoxIntersection(

--- a/devices/rtx/device/geometry/IsosurfaceLinear.h
+++ b/devices/rtx/device/geometry/IsosurfaceLinear.h
@@ -3,6 +3,7 @@
 
 #include "gpu/gpu_decl.h"  // VISRTX_DEVICE (== inline on host)
 #include <glm/glm.hpp>
+#include <cmath>  // fabsf/sqrtf/fminf/fmaxf — self-contained, not via glm's transitive include
 #include <cstdint>
 
 namespace visrtx {

--- a/devices/rtx/device/geometry/Sphere.cu
+++ b/devices/rtx/device/geometry/Sphere.cu
@@ -32,8 +32,10 @@
 #include "Sphere.h"
 // thrust
 #include <thrust/device_ptr.h>
+#include <thrust/functional.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
 
 namespace visrtx {
 
@@ -110,6 +112,21 @@ void Sphere::finalize()
   }
 
   m_aabbsBufferPtr = (CUdeviceptr)m_aabbs.ptr();
+
+  // Coordinate scale of the intersector's arithmetic; floors hit.epsilon so
+  // secondary rays clear the solve's fp noise band (see
+  // GeometryGPUData::epsilonScale).
+  auto aabbsBegin = thrust::device_pointer_cast<box3>((box3 *)m_aabbs.ptr());
+  m_epsilonScale = thrust::transform_reduce(
+      thrust::cuda::par.on(state.stream),
+      aabbsBegin,
+      aabbsBegin + m_numSpheres,
+      [] __device__(const box3 &b) -> float {
+        const vec3 m = glm::max(glm::abs(b.lower), glm::abs(b.upper));
+        return glm::max(m.x, glm::max(m.y, m.z));
+      },
+      0.f,
+      thrust::maximum<float>());
 
   upload();
 }

--- a/devices/rtx/device/geometry/Sphere.cu
+++ b/devices/rtx/device/geometry/Sphere.cu
@@ -88,7 +88,7 @@ void Sphere::finalize()
         thrust::device_pointer_cast<box3>((box3 *)m_aabbs.ptr()),
         [=] __device__(uint32_t i) {
           const auto &v = vertices[i];
-          const float r = radii ? radii[i] : globalRadius;
+          const float r = glm::abs(radii ? radii[i] : globalRadius);
           return box3(v - r, v + r);
         });
   } else {
@@ -104,7 +104,7 @@ void Sphere::finalize()
         thrust::device_pointer_cast<box3>((box3 *)m_aabbs.ptr()),
         [=] __device__(uint32_t i) {
           const auto &v = vertices[i];
-          const float r = radii ? radii[i] : globalRadius;
+          const float r = glm::abs(radii ? radii[i] : globalRadius);
           return box3(v - r, v + r);
         });
   }

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -289,6 +289,11 @@ struct GeometryGPUData
   AttributeDataSet attr;
   AttributeDataSetUniform attrUniform;
   const uint32_t *primitiveId;
+  // Object-space coordinate magnitude the analytic intersectors' arithmetic
+  // runs at (max |AABB corner| over the geometry's primitives); 0 when unused.
+  // Floors hit.epsilon so secondary-ray offsets clear the solve's fp noise
+  // band even where the hitpoint's own coordinates are small (populateHit.h).
+  float epsilonScale{0.f};
   union
   {
     TriangleGeometryData tri{};
@@ -550,7 +555,8 @@ struct NVdbRectilinearData
   const void *gridData;
   bool cellCentered;
   SpatialFieldFilter filter;
-  cudaTextureObject_t axisLUT[3]; // normalized uniform index -> rectilinear index
+  cudaTextureObject_t
+      axisLUT[3]; // normalized uniform index -> rectilinear index
   cudaTextureObject_t invAxisLUT[3]; // inverse (isosurface voxel-DDA)
   vec3 invAvgVoxelSize;
 
@@ -834,10 +840,12 @@ struct RendererGPUData
   float occlusionDistance;
   bool cullTriangleBF;
   bool premultiplyBackground;
-  FireflyFilterMode fireflyFilterMode; // per-sample outlier suppression strategy
+  FireflyFilterMode
+      fireflyFilterMode; // per-sample outlier suppression strategy
   float fireflyFilterSigma; // CLAMP/TRIM: k in threshold = mean + k*stddev
   int fireflyFilterWarmup; // CLAMP mode: samples before the Welford cap engages
-  int fireflyFilterTrim; // TRIM mode: count of brightest samples tracked/trimmed
+  int fireflyFilterTrim; // TRIM mode: count of brightest samples
+                         // tracked/trimmed
   glm::vec4 cutPlane; // cutting plane (nx,ny,nz,d); disabled when all zero (GPU
                       // default)
 };
@@ -856,8 +864,8 @@ enum class FrameFormat
 // channel so a single-channel (chromatic) outlier is caught even when its
 // luminance is unremarkable. `n` is the shared sample count — kept here because
 // checkerboarding makes frameID a poor proxy for "how many samples this pixel
-// has seen". CLAMP uses all three channels; TRIM uses only the luminance Welford
-// in channel x and reads n as its sample divisor.
+// has seen". CLAMP uses all three channels; TRIM uses only the luminance
+// Welford in channel x and reads n as its sample divisor.
 struct PixelLumStats
 {
   glm::vec3 mean; // per-channel running mean

--- a/devices/rtx/device/gpu/gpu_objects.h
+++ b/devices/rtx/device/gpu/gpu_objects.h
@@ -211,6 +211,10 @@ struct QuadGeometryData
   bool cullBackfaces;
 };
 
+// Cap enablement is a per-endpoint bitmask (bit0 = first/p0 end,
+// bit1 = second/p1 end; see CapBit in intersectPrimitives.h). vertexCaps, when
+// non-null, overrides defaultCapFlags per endpoint: element!=0 enables that
+// endpoint's cap (spec vertex.cap: 0=no cap, 1=flat).
 struct CylinderGeometryData
 {
   const uvec2 *indices;
@@ -218,7 +222,8 @@ struct CylinderGeometryData
   AttributeDataSet vertexAttr;
   const float *radii;
   float radius;
-  bool caps;
+  uint8_t defaultCapFlags;
+  const uint8_t *vertexCaps;
 };
 
 struct ConeGeometryData
@@ -227,6 +232,8 @@ struct ConeGeometryData
   const vec3 *vertices;
   const float *radii;
   AttributeDataSet vertexAttr;
+  uint8_t defaultCapFlags;
+  const uint8_t *vertexCaps;
 };
 
 struct CurveGeometryData

--- a/devices/rtx/device/gpu/intersectPrimitives.h
+++ b/devices/rtx/device/gpu/intersectPrimitives.h
@@ -83,6 +83,21 @@ constexpr float kRelEps = 1e-6f;
 // by two surface patches.
 constexpr float kDedupRelEps = 4e-6f;
 
+// Noise floor for the quadratic discriminant, relative to its operands' scale
+// (~32 fp32 ulps). Near tangency the discriminant is a catastrophic
+// cancellation of ~equal squared terms, so below this floor its SIGN is fp
+// noise. That matters for rays grazing their own origin surface: secondary
+// rays are lifted only ~1e-6*|P| off the surface (epsilonFrom), which puts the
+// true discriminant (~ -2*r*lift for a sphere of radius r) inside the noise
+// band, and a false-positive root pair yields a phantom back-facing EXIT
+// crossing at t up to ~1e-3*r — far beyond any tmin, self-shadowing the
+// primitive (concentric acne rings on large ground spheres). Exit crossings
+// are therefore only emitted when the discriminant clears this floor; entry
+// crossings stay ungated (a phantom entry lies behind the origin and is culled
+// by tmin, a genuine graze entry shades correctly). The cost is real exits
+// within ~sqrt(kGrazeRelEps) ≈ 0.1 degree of tangency — visually nil.
+constexpr float kGrazeRelEps = 4e-6f;
+
 // True for finite floats only: the comparison is false for both inf and NaN
 // (NaN compares false to everything). Works identically on host and device
 // without pulling in <cmath>/isfinite intrinsics.
@@ -198,8 +213,12 @@ VISRTX_HOST_DEVICE void forEachSphereCrossing(const vec3 &ro,
   DedupT dedup;
   emitCrossing(
       dedup, report, PrimHit{t0, (ro + t0 * rd - center) / radius, 0.f});
-  emitCrossing(
-      dedup, report, PrimHit{t1, (ro + t1 * rd - center) / radius, 0.f});
+  // t1 is always the exit; gate it on the discriminant noise floor (see
+  // kGrazeRelEps) so a graze of the ray's own origin sphere can't emit a
+  // phantom self-shadowing exit.
+  if (halfChord2 > kGrazeRelEps * radius * radius)
+    emitCrossing(
+        dedup, report, PrimHit{t1, (ro + t1 * rd - center) / radius, 0.f});
 }
 
 // Cylinder: curved wall (within the axis span) + enabled flat caps. radius is
@@ -238,7 +257,11 @@ VISRTX_HOST_DEVICE void forEachCylinderCrossing(const vec3 &ro,
     if (cc >= 0.f) {
       const float td = glm::sqrt(cc * ra);
       const float tw[2] = {ts - td, ts + td};
-      for (int i = 0; i < 2; ++i) {
+      // tw[1] is always the exit; gate it on the discriminant noise floor (see
+      // kGrazeRelEps) so a graze of the ray's own origin wall can't emit a
+      // phantom self-shadowing exit.
+      const int nw = cc > kGrazeRelEps * radius * radius * s2 ? 2 : 1;
+      for (int i = 0; i < nw; ++i) {
         const vec3 h = ro + tw[i] * rd;
         const float u = glm::dot(h - p0, s) / s2;
         if (u >= 0.f && u <= 1.f)
@@ -301,6 +324,11 @@ VISRTX_HOST_DEVICE void forEachConeCrossing(const vec3 &ro,
 
   float tn0 = 0.f, tn1 = 0.f;
   int nroots = 0;
+  // Exit-side reliability of the quadratic solve; see kGrazeRelEps. The exit
+  // root isn't positionally fixed for a cone (k2's sign orders the roots), so
+  // the gate is applied by facing in emitBody below. The linear (k2~0) path
+  // has no discriminant and keeps its single root.
+  bool exitReliable = true;
   const float k2scale = glm::max(m0 * m0, glm::abs(m3 * m3 * hy));
   if (glm::abs(k2) <= kRelEps * k2scale) {
     // Near-parallel to the slant generator: 2 k1 t + k0 = 0. Gate |k1| against
@@ -320,6 +348,7 @@ VISRTX_HOST_DEVICE void forEachConeCrossing(const vec3 &ro,
       tn0 = qq / k2;
       tn1 = k0 / qq; // qq==0 -> non-finite -> dropped by emitCrossing
       nroots = 2;
+      exitReliable = h > kGrazeRelEps * glm::max(k1 * k1, glm::abs(k2 * k0));
     }
   }
 
@@ -330,6 +359,8 @@ VISRTX_HOST_DEVICE void forEachConeCrossing(const vec3 &ro,
     if (y > 0.f && y < m0) {
       const vec3 nrm = glm::normalize(
           m0 * (m0 * (oa + tn * rdn) + rr * ba * ra) - ba * hy * y);
+      if (!exitReliable && glm::dot(nrm, rdn) > 0.f)
+        return; // graze-noise exit: phantom self-shadow (see kGrazeRelEps)
       emitCrossing(dedup, report, PrimHit{tn / rlen, nrm, y / m0});
     }
   };

--- a/devices/rtx/device/gpu/intersectPrimitives.h
+++ b/devices/rtx/device/gpu/intersectPrimitives.h
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Pure analytic primitive intersectors (sphere, cylinder, cone), independent of
+// OptiX/CUDA so they compile & run on the host for unit testing. Each
+// forEach*Crossing enumerates a solid's boundary crossings (entry AND exit) and
+// emits them straight into `report`, unclipped by tmin/tmax and in no
+// particular order (no per-thread hit buffer to spill in the IS hot path). The
+// OptiX IS wrapper applies the rendering policy — it reports only the
+// front-facing (entry) crossing (see reportEntryCrossing). The solve* array
+// overloads collect all crossings for host unit tests. Normals are outward and
+// unit. Cap enablement is a per-endpoint bitmask (bit0 = the p0 end / "first",
+// bit1 = the p1 end / "second").
+//
+// Capped cylinders/cones are convex solids: a ray has at most 2 true boundary
+// crossings. Up to 4 *candidates* exist before span/disk clipping and
+// coincident-t de-dup (2 quadratic roots + 2 cap-plane hits), which sizes the
+// solve* output arrays.
+
+#pragma once
+
+#include "gpu/gpu_decl.h"
+
+#include <glm/glm.hpp>
+
+namespace visrtx {
+
+using glm::vec3;
+
+struct PrimHit
+{
+  float t;
+  vec3 Ng; // outward, unit
+  float u; // attribute0 parameter
+};
+
+enum CapBit : uint8_t
+{
+  CAP_FIRST = 1u << 0, // p0 end
+  CAP_SECOND = 1u << 1, // p1 end
+};
+
+namespace detail {
+
+constexpr float kFltMax = 3.402823466e38f;
+
+// Relative slack for degeneracy gates (dimensionless; compared against a
+// quantity's natural squared scale).
+constexpr float kRelEps = 1e-6f;
+
+// Coincident-t de-dup: ~32 float ulps, relative to the larger |t| of the
+// compared pair. Tight enough that genuine entry/exit crossings of thin
+// primitives stay distinct, loose enough to merge a tangent/rim corner counted
+// by two surface patches.
+constexpr float kDedupRelEps = 4e-6f;
+
+// True for finite floats only: the comparison is false for both inf and NaN
+// (NaN compares false to everything). Works identically on host and device
+// without pulling in <cmath>/isfinite intrinsics.
+VISRTX_HOST_DEVICE bool isFiniteF(float x)
+{
+  return glm::abs(x) <= kFltMax;
+}
+
+VISRTX_HOST_DEVICE bool isFiniteVec(const vec3 &v)
+{
+  return isFiniteF(v.x) && isFiniteF(v.y) && isFiniteF(v.z);
+}
+
+// Coincident-t filter held in scalar slots — no dynamically indexed array, so
+// it stays in registers inside an OptiX IS program. Three slots cover the
+// worst case of four candidate crossings.
+struct DedupT
+{
+  float ta{kFltMax}, tb{kFltMax}, tc{kFltMax};
+
+  VISRTX_HOST_DEVICE static bool coincides(float t, float prev)
+  {
+    return glm::abs(t - prev)
+        <= kDedupRelEps * glm::max(glm::abs(t), glm::abs(prev));
+  }
+
+  VISRTX_HOST_DEVICE bool insert(float t)
+  {
+    if (coincides(t, ta) || coincides(t, tb) || coincides(t, tc))
+      return false;
+    tc = tb;
+    tb = ta;
+    ta = t;
+    return true;
+  }
+};
+
+// Emit one crossing: drop non-finite results and any that coincide (in t) with
+// one already emitted — a tangent/graze must count once, not twice (duplicate
+// anyhit reports would double-count opacity).
+template <typename ReportFn>
+VISRTX_HOST_DEVICE void emitCrossing(
+    DedupT &dedup, ReportFn &&report, const PrimHit &h)
+{
+  if (!isFiniteF(h.t) || !isFiniteVec(h.Ng))
+    return;
+  if (!dedup.insert(h.t))
+    return;
+  report(h);
+}
+
+// Ray vs a flat cap disk: plane through pc with normal `axis` (need not be
+// unit), disk radius `radius`. axis2 = dot(axis,axis) and dir2 = dot(rd,rd)
+// are passed in (both callers already have them). `outwardN` is the unit
+// outward normal for this end. Divides by sd=dot(rd,axis) — guarded against a
+// perpendicular ray.
+VISRTX_HOST_DEVICE bool capDiskHit(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &pc,
+    const vec3 &axis,
+    float axis2,
+    float dir2,
+    float radius,
+    const vec3 &outwardN,
+    float u,
+    PrimHit &h)
+{
+  const float sd = glm::dot(rd, axis);
+  if (sd * sd <= kRelEps * axis2 * dir2) // ray parallel to the cap plane
+    return false;
+  const float t = glm::dot(pc - ro, axis) / sd;
+  const vec3 rel = (ro + t * rd) - pc; // lies in the cap plane
+  if (glm::dot(rel, rel) > radius * radius)
+    return false;
+  h = PrimHit{t, outwardN, u};
+  return true;
+}
+
+} // namespace detail
+
+// Sphere: emits both roots (the IS wrapper keeps the front one). u is unused.
+// Roots are the closest-approach parameter tmid = -b/a plus/minus a half-chord
+// thalf = sqrt((r^2 - |perp|^2)/a), with perp = oc + tmid*rd the ray-to-center
+// rejection. This never forms c = |oc|^2 - r^2 (which cancels catastrophically
+// when the origin is near a large sphere's surface, |oc| ~ r — the source of
+// the concentric shading rings on large ground spheres): the near-root normal
+// there routes through c/q and its lost precision bands the normal. The perp
+// form of the discriminant also avoids the b^2 - a*c cancellation of small
+// distant spheres, and tmid -/+ thalf is exact to the inputs off grazing rays
+// (thalf << |tmid|), cancelling only benignly at grazing (Sterbenz).
+template <typename ReportFn>
+VISRTX_HOST_DEVICE void forEachSphereCrossing(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &center,
+    float radius,
+    ReportFn &&report)
+{
+  using namespace detail;
+  radius = glm::abs(radius);
+  const vec3 oc = ro - center;
+  const float a = glm::dot(rd, rd);
+  if (a <= 0.f)
+    return;
+  const float b = glm::dot(oc, rd); // half-b of a t^2 + 2b t + c = 0
+  const float tmid = -b / a; // parameter of closest approach to center
+  const vec3 perp = oc + tmid * rd; // ray-to-center rejection at tmid
+  const float halfChord2 = radius * radius - glm::dot(perp, perp);
+  if (halfChord2 < 0.f)
+    return;
+  const float thalf = glm::sqrt(halfChord2 / a);
+  const float t0 = tmid - thalf;
+  const float t1 = tmid + thalf;
+  DedupT dedup;
+  emitCrossing(
+      dedup, report, PrimHit{t0, (ro + t0 * rd - center) / radius, 0.f});
+  emitCrossing(
+      dedup, report, PrimHit{t1, (ro + t1 * rd - center) / radius, 0.f});
+}
+
+// Cylinder: curved wall (within the axis span) + enabled flat caps. radius is
+// treated as a magnitude. u along the wall is the axial fraction; caps use
+// 0/1. The wall quadratic is recentered at the ray's closest approach to the
+// axis (fp) before forming the discriminant — forming it at the ray origin
+// cancels catastrophically for distant origins.
+template <typename ReportFn>
+VISRTX_HOST_DEVICE void forEachCylinderCrossing(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &p0,
+    const vec3 &p1,
+    float radius,
+    uint8_t capBits,
+    ReportFn &&report)
+{
+  using namespace detail;
+  const vec3 s = p1 - p0; // axis
+  const float s2 = glm::dot(s, s);
+  const float d2 = glm::dot(rd, rd);
+  radius = glm::abs(radius);
+  if (s2 <= 0.f || d2 <= 0.f) // degenerate (p0==p1) or null ray
+    return;
+
+  DedupT dedup;
+
+  const vec3 f = p0 - ro;
+  const vec3 sxd = glm::cross(s, rd);
+  const float a = glm::dot(sxd, sxd); // s2*d2*sin^2(axis,rd)
+  if (a > kRelEps * s2 * d2) { // skip when ray ~parallel to axis (a->0)
+    const float ra = 1.f / a;
+    const float ts = glm::dot(sxd, glm::cross(s, f)) * ra; // closest approach
+    const vec3 fp = f - ts * rd; // p0 relative to the closest-approach point
+    const vec3 perp = glm::cross(s, fp);
+    const float cc = radius * radius * s2 - glm::dot(perp, perp);
+    if (cc >= 0.f) {
+      const float td = glm::sqrt(cc * ra);
+      const float tw[2] = {ts - td, ts + td};
+      for (int i = 0; i < 2; ++i) {
+        const vec3 h = ro + tw[i] * rd;
+        const float u = glm::dot(h - p0, s) / s2;
+        if (u >= 0.f && u <= 1.f)
+          emitCrossing(
+              dedup, report, PrimHit{tw[i], (h - (p0 + u * s)) / radius, u});
+      }
+    }
+  }
+
+  if (capBits) {
+    const vec3 axisN = s * glm::inversesqrt(s2);
+    PrimHit h;
+    if ((capBits & CAP_FIRST)
+        && capDiskHit(ro, rd, p0, s, s2, d2, radius, -axisN, 0.f, h))
+      emitCrossing(dedup, report, h);
+    if ((capBits & CAP_SECOND)
+        && capDiskHit(ro, rd, p1, s, s2, d2, radius, axisN, 1.f, h))
+      emitCrossing(dedup, report, h);
+  }
+}
+
+// Cone (truncated): tapered body (both roots, within the axis span) + enabled
+// flat caps sized to each endpoint radius. Radii treated as magnitudes. The
+// body solve normalizes rd so it is correct under non-unit (instance-scaled)
+// directions; t is rescaled back on output.
+template <typename ReportFn>
+VISRTX_HOST_DEVICE void forEachConeCrossing(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &p0,
+    const vec3 &p1,
+    float r0,
+    float r1,
+    uint8_t capBits,
+    ReportFn &&report)
+{
+  using namespace detail;
+  const float ra = glm::abs(r0);
+  const float rb = glm::abs(r1);
+  const vec3 ba = p1 - p0;
+  const float m0 = glm::dot(ba, ba);
+  const float d2 = glm::dot(rd, rd);
+  if (m0 <= 0.f || d2 <= 0.f) // degenerate axis or null ray
+    return;
+  const float rlen = glm::sqrt(d2);
+
+  const vec3 rdn = rd / rlen; // unit direction; scale t back by 1/rlen
+  const vec3 oa = ro - p0;
+  const float m1 = glm::dot(oa, ba);
+  const float m3 = glm::dot(rdn, ba);
+  const float m4 = glm::dot(rdn, oa);
+  const float m5 = glm::dot(oa, oa);
+  const float rr = ra - rb;
+  const float hy = m0 + rr * rr;
+
+  // k2 t^2 + 2 k1 t + k0 = 0 (rd unit here).
+  const float k2 = m0 * m0 - m3 * m3 * hy;
+  const float k1 = m0 * m0 * m4 - m1 * m3 * hy + m0 * ra * rr * m3;
+  const float k0 =
+      m0 * m0 * m5 - m1 * m1 * hy + m0 * ra * (rr * m1 * 2.0f - m0 * ra);
+
+  float tn0 = 0.f, tn1 = 0.f;
+  int nroots = 0;
+  const float k2scale = glm::max(m0 * m0, glm::abs(m3 * m3 * hy));
+  if (glm::abs(k2) <= kRelEps * k2scale) {
+    // Near-parallel to the slant generator: 2 k1 t + k0 = 0. Gate |k1| against
+    // the magnitudes of its own terms (same units, any scene scale) — the root
+    // is only unreliable when k1 itself is a catastrophic cancellation.
+    const float k1scale = glm::max(glm::abs(m0 * m0 * m4),
+        glm::max(glm::abs(m1 * m3 * hy), glm::abs(m0 * ra * rr * m3)));
+    if (glm::abs(k1) > kRelEps * k1scale) {
+      tn0 = -k0 / (2.0f * k1);
+      nroots = 1;
+    }
+  } else {
+    const float h = k1 * k1 - k2 * k0;
+    if (h >= 0.f) {
+      // Stable pairing (qq/k2, k0/qq): avoids the -k1 + sqrt cancellation.
+      const float qq = -(k1 + (k1 >= 0.f ? 1.f : -1.f) * glm::sqrt(h));
+      tn0 = qq / k2;
+      tn1 = k0 / qq; // qq==0 -> non-finite -> dropped by emitCrossing
+      nroots = 2;
+    }
+  }
+
+  DedupT dedup;
+
+  const auto emitBody = [&](float tn) {
+    const float y = m1 + tn * m3;
+    if (y > 0.f && y < m0) {
+      const vec3 nrm = glm::normalize(
+          m0 * (m0 * (oa + tn * rdn) + rr * ba * ra) - ba * hy * y);
+      emitCrossing(dedup, report, PrimHit{tn / rlen, nrm, y / m0});
+    }
+  };
+  if (nroots > 0)
+    emitBody(tn0);
+  if (nroots > 1)
+    emitBody(tn1);
+
+  // Flat caps sized per endpoint (magnitude radii).
+  if (capBits) {
+    const vec3 axisN = ba * glm::inversesqrt(m0);
+    PrimHit hh;
+    if ((capBits & CAP_FIRST) && ra > 0.f
+        && capDiskHit(ro, rd, p0, ba, m0, d2, ra, -axisN, 0.f, hh))
+      emitCrossing(dedup, report, hh);
+    if ((capBits & CAP_SECOND) && rb > 0.f
+        && capDiskHit(ro, rd, p1, ba, m0, d2, rb, axisN, 1.f, hh))
+      emitCrossing(dedup, report, hh);
+  }
+}
+
+// Array-collecting overloads for host unit tests (and any caller that wants
+// the crossings materialized). Emission counts are bounded by the candidate
+// counts documented above, so the fixed-size outputs cannot overflow.
+
+VISRTX_HOST_DEVICE int solveSphere(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &center,
+    float radius,
+    PrimHit out[2])
+{
+  int n = 0;
+  forEachSphereCrossing(
+      ro, rd, center, radius, [&](const PrimHit &h) { out[n++] = h; });
+  return n;
+}
+
+VISRTX_HOST_DEVICE int solveCylinder(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &p0,
+    const vec3 &p1,
+    float radius,
+    uint8_t capBits,
+    PrimHit out[4])
+{
+  int n = 0;
+  forEachCylinderCrossing(
+      ro, rd, p0, p1, radius, capBits, [&](const PrimHit &h) { out[n++] = h; });
+  return n;
+}
+
+VISRTX_HOST_DEVICE int solveCone(const vec3 &ro,
+    const vec3 &rd,
+    const vec3 &p0,
+    const vec3 &p1,
+    float r0,
+    float r1,
+    uint8_t capBits,
+    PrimHit out[4])
+{
+  int n = 0;
+  forEachConeCrossing(
+      ro, rd, p0, p1, r0, r1, capBits, [&](const PrimHit &h) { out[n++] = h; });
+  return n;
+}
+
+} // namespace visrtx

--- a/devices/rtx/device/gpu/intersectPrimitives.h
+++ b/devices/rtx/device/gpu/intersectPrimitives.h
@@ -34,11 +34,12 @@
 // forEach*Crossing enumerates a solid's boundary crossings (entry AND exit) and
 // emits them straight into `report`, unclipped by tmin/tmax and in no
 // particular order (no per-thread hit buffer to spill in the IS hot path). The
-// OptiX IS wrapper applies the rendering policy — it reports only the
-// front-facing (entry) crossing (see reportEntryCrossing). The solve* array
-// overloads collect all crossings for host unit tests. Normals are outward and
-// unit. Cap enablement is a per-endpoint bitmask (bit0 = the p0 end / "first",
-// bit1 = the p1 end / "second").
+// OptiX IS wrapper reports every crossing — entry and exit — tagging each with
+// its facing (see reportCrossing); OptiX keeps the nearest in [tmin, tmax], so
+// interiors and transmission exits resolve like triangle back faces. The
+// solve* array overloads collect all crossings for host unit tests. Normals
+// are outward and unit. Cap enablement is a per-endpoint bitmask (bit0 = the
+// p0 end / "first", bit1 = the p1 end / "second").
 //
 // Capped cylinders/cones are convex solids: a ray has at most 2 true boundary
 // crossings. Up to 4 *candidates* exist before span/disk clipping and

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -250,12 +250,10 @@ VISRTX_DEVICE void computeTangentSpace(
     const bool hasTangentsFV = ggd.tri.vertexTangentsFV != nullptr;
     const bool hasTangentsV = ggd.tri.vertexTangents != nullptr;
     if (hasTangentsFV || hasTangentsV) {
-      const uvec3 tIdx = hasTangentsFV
-          ? uvec3(0, 1, 2) + (hit.primID * 3)
-          : idx;
-      const vec4 *tArr = hasTangentsFV
-          ? ggd.tri.vertexTangentsFV
-          : ggd.tri.vertexTangents;
+      const uvec3 tIdx =
+          hasTangentsFV ? uvec3(0, 1, 2) + (hit.primID * 3) : idx;
+      const vec4 *tArr =
+          hasTangentsFV ? ggd.tri.vertexTangentsFV : ggd.tri.vertexTangents;
       const vec4 t0 = tArr[tIdx.x];
       const vec4 t1 = tArr[tIdx.y];
       const vec4 t2 = tArr[tIdx.z];
@@ -313,9 +311,22 @@ VISRTX_DEVICE void computeTangentSpace(
   case GeometryType::NEURAL:
   case GeometryType::CYLINDER:
   case GeometryType::SDF: {
-    hit.Ng = hit.Ns = vec3(bit_cast<float>(optixGetAttribute_1()),
+    vec3 n = vec3(bit_cast<float>(optixGetAttribute_1()),
         bit_cast<float>(optixGetAttribute_2()),
         bit_cast<float>(optixGetAttribute_3()));
+    // Analytic intersectors report entry AND exit crossings with the outward
+    // normal; orient it toward the ray and record facing, mirroring the
+    // triangle convention above. Derive facing here from the normal itself
+    // rather than the hit kind — isosurfaces reuse the kind for the isovalue
+    // index, and their (like SDF/neural) normals already face the ray, so
+    // they land on isFrontFace == true unchanged.
+    // optixGetObjectRayDirection() is illegal in CH; get the object-space
+    // direction through the instance's worldToObject map instead.
+    const vec3 objDir = mat3(hit.instance->worldToObject) * ray::direction();
+    hit.isFrontFace = dot(n, objDir) < 0.f;
+    if (!hit.isFrontFace)
+      n = -n;
+    hit.Ng = hit.Ns = n;
     auto tangentSpace = computeOrthonormalBasis(hit.Ng);
     hit.tU = tangentSpace[0];
     hit.tV = tangentSpace[1];
@@ -411,12 +422,13 @@ VISRTX_DEVICE void populateSurfaceHit(SurfaceHit &hit)
     // the nearest voxel-DDA, bisection-localized for the marched linear/custom
     // path. Either way the surface has voxel-scale relief, so a secondary ray
     // offset by less than a voxel grazes into adjacent voxels and self-occludes
-    // (AO/shadow acne; on blocky nearest surfaces, a per-voxel waffle). stepSize
-    // is half the smallest voxel, so 2*stepSize lifts the ray clear by one.
-    // stepSize is object-space but hit.epsilon is world-space, so under a scaled
-    // instance scale the lift by the object->world distance ratio along the ray:
-    // |worldDir|/|objDir|. optixGetObjectRayDirection is illegal in closest-hit,
-    // so derive objDir from the stored worldToObject linear map instead.
+    // (AO/shadow acne; on blocky nearest surfaces, a per-voxel waffle).
+    // stepSize is half the smallest voxel, so 2*stepSize lifts the ray clear by
+    // one. stepSize is object-space but hit.epsilon is world-space, so under a
+    // scaled instance scale the lift by the object->world distance ratio along
+    // the ray: |worldDir|/|objDir|. optixGetObjectRayDirection is illegal in
+    // closest-hit, so derive objDir from the stored worldToObject linear map
+    // instead.
     const vec3 wdir = ray::direction();
     const vec3 odir = mat3(hit.instance->worldToObject) * wdir;
     hit.epsilon = fmaxf(hit.epsilon,

--- a/devices/rtx/device/gpu/populateHit.h
+++ b/devices/rtx/device/gpu/populateHit.h
@@ -393,6 +393,16 @@ VISRTX_DEVICE void cullCutPlane()
     optixIgnoreIntersection();
 }
 
+// hit.epsilon floor for analytic primitives, in units of the geometry's
+// object-space coordinate scale (GeometryGPUData::epsilonScale). The
+// intersectors' quadratics run at that scale, so their fp noise band is
+// ~tens of ulps OF THAT SCALE; a secondary ray must clear it or phantom
+// self-hits shadow the surface (acne rings on large ground spheres).
+// epsilonFrom alone under-lifts wherever the hitpoint's own coordinates are
+// small (e.g. near the origin on a giant sphere centered at -r*Y). ~64 fp32
+// ulps.
+constexpr float kAnalyticEpsilonScale = 0x1.p-17f;
+
 VISRTX_DEVICE void populateSurfaceHit(SurfaceHit &hit)
 {
   const auto &ss = ray::screenSample();
@@ -417,6 +427,14 @@ VISRTX_DEVICE void populateSurfaceHit(SurfaceHit &hit)
   hit.objID = sd.id;
   hit.instID = isd.id;
   hit.epsilon = epsilonFrom(ray::hitpoint(), ray::direction(), ray::t());
+  if (gd.epsilonScale > 0.f) {
+    // Object-space scale -> world units via the object->world distance ratio
+    // along the ray (same construction as the isosurface branch below).
+    const vec3 wdir = ray::direction();
+    const vec3 odir = mat3(hit.instance->worldToObject) * wdir;
+    hit.epsilon = fmaxf(hit.epsilon,
+        gd.epsilonScale * kAnalyticEpsilonScale * length(wdir) / length(odir));
+  }
   if (gd.type == GeometryType::ISOSURFACE) {
     // Isosurface hits lie on a voxel-resolution surface — exact voxel faces for
     // the nearest voxel-DDA, bisection-localized for the marched linear/custom


### PR DESCRIPTION
Add or fix missing caps support to cylinders and cones, also reporting entry and exit intersections.

Extract intersection code so it is testable.