### PR TITLE
studio: externalize file-animation source lists

### DIFF
--- a/tsd/apps/interactive/scivisStudio/CONTEXT.md
+++ b/tsd/apps/interactive/scivisStudio/CONTEXT.md
@@ -37,7 +37,8 @@ _Avoid_: Automatic refresh
 
 **Dataset Archive**:
 A portable native TSD representation of a Dataset without its project-local
-Dataset ID.
+Dataset ID. For a File Animation Dataset, the Archive is the dataset file and
+its sibling Source List File together.
 
 **Dataset Archive Load**:
 The incorporation of a Dataset Archive as an independent project-owned Dataset
@@ -139,9 +140,18 @@ Its portability depends on its recorded paths remaining valid.
 _Avoid_: Time-series dataset
 
 **File Animation Source List**:
-The authoritative, persisted, ordered opaque path strings owned by a File
-Animation Dataset. The runtime file binding implements this list but does not
-own it; importer settings belong to the dataset rather than individual entries.
+The authoritative ordered path entries owned by a File Animation Dataset and
+persisted only in its Source List File. Relative entries are anchored once, at
+read, to the Source List File's directory and are opaque thereafter; importer
+settings belong to the dataset rather than individual entries.
+_Avoid_: Manifest, embedded source list
+
+**Source List File**:
+The human-editable sibling text file that persists a File Animation Dataset's
+Source List, named after its dataset file. It is part of the dataset asset:
+Studio manages it with the dataset, and a missing or empty Source List File
+makes the dataset Unavailable.
+_Avoid_: Manifest, frame list
 
 **File Animation**:
 A derived core TSD runtime animation that loads and unloads individual source

--- a/tsd/apps/interactive/scivisStudio/Dataset.h
+++ b/tsd/apps/interactive/scivisStudio/Dataset.h
@@ -66,7 +66,13 @@ struct DatasetSourceMetadata
 
 struct DatasetSourceFile
 {
+  // The raw entry as authored; entries are opaque and are written back
+  // verbatim (ADR 0013).
   std::string path;
+  // Runtime-only: a relative entry anchored once, at read, to its Source List
+  // File's directory. Empty when the raw entry is used as-is (an absolute
+  // entry or a legacy embedded one).
+  std::string resolvedPath;
 };
 
 struct Dataset
@@ -85,6 +91,10 @@ struct Dataset
   // IDs or these bookkeeping fields.
   bool dirty{true};
   bool pendingExtraction{false};
+  // The dataset file carries legacy embedded sourceFiles: the next explicit
+  // save of the loaded dataset writes the Source List File and rewrites the
+  // dataset file without paths (ADR 0013).
+  bool pendingSourceListMigration{false};
   std::string persistedName;
 };
 

--- a/tsd/apps/interactive/scivisStudio/DatasetIO.cpp
+++ b/tsd/apps/interactive/scivisStudio/DatasetIO.cpp
@@ -14,6 +14,7 @@
 #include "tsd/scene/objects/Volume.hpp"
 
 #include <algorithm>
+#include <fstream>
 #include <vector>
 
 namespace tsd::scivis_studio {
@@ -45,11 +46,9 @@ void datasetMetadataToNode(const Dataset &dataset, tsd::core::DataNode &node)
   if (dataset.sourceKind == DatasetSourceKind::Static) {
     auto &provenance = node["provenance"];
     provenance["sourcePath"] = dataset.source.sourcePath;
-  } else if (dataset.sourceKind == DatasetSourceKind::FileAnimation) {
-    auto &files = node["sourceFiles"];
-    for (const auto &source : dataset.sourceFiles)
-      files.append() = source.path;
   }
+  // A File Animation Dataset's source list is persisted only in its sibling
+  // Source List File; dataset files no longer embed it (ADR 0013).
 }
 
 bool nodeToDatasetMetadata(
@@ -91,18 +90,22 @@ bool nodeToDatasetMetadata(
     if (auto *files = node.child("sourceFiles"); files && files->numChildren())
       return fail("static datasets cannot contain a source-file list", error);
   } else {
-    auto *files = node.child("sourceFiles");
-    if (!files || files->numChildren() == 0)
-      return fail("file-animation datasets require sourceFiles", error);
-    files->foreach_child([&](tsd::core::DataNode &entry) {
-      dataset.sourceFiles.push_back({entry.getValueOr<std::string>("")});
-    });
-    if (std::any_of(dataset.sourceFiles.begin(),
-            dataset.sourceFiles.end(),
-            [](const DatasetSourceFile &source) {
-              return source.path.empty();
-            }))
-      return fail("file-animation source paths cannot be empty", error);
+    // A new-format dataset file carries no paths (the sibling Source List
+    // File is the only persisted list); legacy embedded sourceFiles still
+    // load unmodified and mark the dataset for migration (ADR 0013).
+    if (auto *files = node.child("sourceFiles");
+        files && files->numChildren() != 0) {
+      files->foreach_child([&](tsd::core::DataNode &entry) {
+        dataset.sourceFiles.push_back({entry.getValueOr<std::string>("")});
+      });
+      if (std::any_of(dataset.sourceFiles.begin(),
+              dataset.sourceFiles.end(),
+              [](const DatasetSourceFile &source) {
+                return source.path.empty();
+              }))
+        return fail("file-animation source paths cannot be empty", error);
+      dataset.pendingSourceListMigration = true;
+    }
     if (dataset.importerType != "VOLUME_ANIMATION")
       return fail("unsupported file-animation importerType", error);
   }
@@ -144,8 +147,10 @@ bool recreateFileAnimation(const Dataset &dataset,
 
   std::vector<std::string> files;
   files.reserve(dataset.sourceFiles.size());
-  for (const auto &source : dataset.sourceFiles)
-    files.push_back(source.path);
+  for (const auto &source : dataset.sourceFiles) {
+    files.push_back(
+        source.resolvedPath.empty() ? source.path : source.resolvedPath);
+  }
 
   auto &animation =
       animationManager.addAnimation(dataset.name + " file animation");
@@ -156,7 +161,101 @@ bool recreateFileAnimation(const Dataset &dataset,
 
 } // namespace
 
+std::filesystem::path sourceListFilePath(
+    const std::filesystem::path &datasetFile)
+{
+  auto path = datasetFile;
+  path.replace_extension(SOURCE_LIST_FILE_EXTENSION);
+  return path;
+}
+
+bool readSourceListFile(const std::filesystem::path &file,
+    std::vector<DatasetSourceFile> &sourceList,
+    std::string *error)
+{
+  sourceList.clear();
+  std::ifstream in(file, std::ios::binary);
+  if (!in) {
+    return fail(
+        "Source List File is missing or unreadable: " + file.string(), error);
+  }
+
+  const auto anchor = file.parent_path();
+  std::string line;
+  while (std::getline(in, line)) {
+    const auto first = line.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos)
+      continue;
+    const auto last = line.find_last_not_of(" \t\r\n");
+    DatasetSourceFile entry;
+    entry.path = line.substr(first, last - first + 1);
+    if (std::filesystem::path(entry.path).is_relative())
+      entry.resolvedPath = (anchor / entry.path).string();
+    sourceList.push_back(std::move(entry));
+  }
+  if (in.bad()) {
+    sourceList.clear();
+    return fail("Source List File is unreadable: " + file.string(), error);
+  }
+  if (sourceList.empty())
+    return fail("Source List File is empty: " + file.string(), error);
+  return true;
+}
+
+bool writeSourceListFile(const std::filesystem::path &file,
+    const std::vector<DatasetSourceFile> &sourceList,
+    std::string *error)
+{
+  if (sourceList.empty())
+    return fail("File Animation Source List is empty", error);
+  for (const auto &source : sourceList) {
+    if (source.path.empty())
+      return fail("file-animation source paths cannot be empty", error);
+    if (source.path.find_first_of("\r\n") != std::string::npos) {
+      return fail(
+          "file-animation source paths cannot contain line breaks", error);
+    }
+  }
+
+  std::ofstream out(file, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    return fail(
+        "failed to open Source List File for writing: " + file.string(),
+        error);
+  }
+  for (const auto &source : sourceList)
+    out << source.path << '\n';
+  out.flush();
+  if (!out)
+    return fail("failed to write Source List File: " + file.string(), error);
+  return true;
+}
+
+bool datasetArchiveUsesSourceListFile(tsd::core::DataNode &archive)
+{
+  auto *metadata = archive.child("dataset");
+  if (!metadata
+      || (*metadata)["sourceKind"].getValueOr<std::string>("")
+          != dataset::toString(DatasetSourceKind::FileAnimation))
+    return false;
+  auto *files = metadata->child("sourceFiles");
+  return !files || files->numChildren() == 0;
+}
+
 DatasetAssetValidationResult validateDatasetAsset(
+    const std::filesystem::path &file)
+{
+  auto result = validateDatasetArchiveFile(file);
+  if (result.ok
+      && result.dataset.sourceKind == DatasetSourceKind::FileAnimation
+      && !result.dataset.pendingSourceListMigration) {
+    result.ok = readSourceListFile(
+        sourceListFilePath(file), result.dataset.sourceFiles, &result.error);
+  }
+  return result;
+}
+
+DatasetAssetValidationResult validateDatasetArchiveFile(
     const std::filesystem::path &file)
 {
   tsd::core::DataTree tree;
@@ -271,7 +370,9 @@ bool saveDatasetArchiveFile(const Dataset &dataset,
   if (!tree.save(file.string().c_str()))
     return fail("failed to write dataset metadata", error);
 
-  auto validation = validateDatasetAsset(file);
+  // Only the dataset file is validated here: the sibling Source List File is
+  // written, staged, and validated by the caller that owns the pair.
+  auto validation = validateDatasetArchiveFile(file);
   if (!validation.ok)
     return fail("dataset validation failed: " + validation.error, error);
   return true;
@@ -289,10 +390,21 @@ bool loadDatasetArchiveFile(tsd::scene::Scene &scene,
   if (!tree.load(file.string().c_str()))
     return fail("failed to load Dataset Archive", error);
 
+  // Dataset Load is the one moment the Source List File is read; the load
+  // fails cleanly when the sibling is missing, unreadable, or empty.
+  std::vector<DatasetSourceFile> sourceList;
+  const std::vector<DatasetSourceFile> *sourceListPtr = nullptr;
+  if (datasetArchiveUsesSourceListFile(tree.root())) {
+    if (!readSourceListFile(sourceListFilePath(file), sourceList, error))
+      return false;
+    sourceListPtr = &sourceList;
+  }
+
   return deserializeDatasetArchive(scene,
       animationManager,
       tree.root(),
       destinationParent,
+      sourceListPtr,
       datasetOut,
       rootOut,
       error);
@@ -302,6 +414,7 @@ bool deserializeDatasetArchive(tsd::scene::Scene &scene,
     tsd::animation::AnimationManager &animationManager,
     tsd::core::DataNode &archive,
     tsd::scene::LayerNodeRef destinationParent,
+    const std::vector<DatasetSourceFile> *sourceList,
     Dataset &datasetOut,
     tsd::scene::LayerNodeRef &rootOut,
     std::string *error)
@@ -309,6 +422,15 @@ bool deserializeDatasetArchive(tsd::scene::Scene &scene,
   auto validation = validateDatasetArchive(archive);
   if (!validation.ok)
     return fail(validation.error, error);
+
+  if (validation.dataset.sourceKind == DatasetSourceKind::FileAnimation
+      && validation.dataset.sourceFiles.empty()) {
+    if (!sourceList || sourceList->empty()) {
+      return fail(
+          "file-animation dataset requires its Source List File", error);
+    }
+    validation.dataset.sourceFiles = *sourceList;
+  }
 
   tsd::io::SubtreeArchiveContentOptions options;
   options.animationManager = &animationManager;

--- a/tsd/apps/interactive/scivisStudio/DatasetIO.h
+++ b/tsd/apps/interactive/scivisStudio/DatasetIO.h
@@ -10,6 +10,7 @@
 
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace tsd::core {
 struct DataNode;
@@ -19,6 +20,29 @@ namespace tsd::scivis_studio {
 
 constexpr const char *DATASET_FILE_TYPE = "dataset";
 constexpr const char *DATASET_SCHEMA = "tsd.scivis-studio.dataset";
+constexpr const char *SOURCE_LIST_FILE_EXTENSION = ".sources";
+
+// The sibling Source List File for a dataset file: same directory and stem
+// with the ".sources" extension. The pairing is a naming convention, not a
+// stored path (ADR 0013).
+std::filesystem::path sourceListFilePath(
+    const std::filesystem::path &datasetFile);
+
+// Read a Source List File: one path per line, lines trimmed, blank lines
+// skipped, line order = frame order. Relative entries are anchored here —
+// once, at read — to the file's directory; the raw entries stay authoritative
+// and are what gets written back. A missing, unreadable, or empty file fails.
+bool readSourceListFile(const std::filesystem::path &file,
+    std::vector<DatasetSourceFile> &sourceList,
+    std::string *error = nullptr);
+
+bool writeSourceListFile(const std::filesystem::path &file,
+    const std::vector<DatasetSourceFile> &sourceList,
+    std::string *error = nullptr);
+
+// True when a Dataset Archive persists its File Animation Source List in a
+// sibling Source List File, i.e. it carries no legacy embedded sourceFiles.
+bool datasetArchiveUsesSourceListFile(tsd::core::DataNode &archive);
 
 struct DatasetAssetValidationResult
 {
@@ -27,7 +51,13 @@ struct DatasetAssetValidationResult
   Dataset dataset;
 };
 
+// validateDatasetAsset validates the complete asset: for a new-format
+// file-animation dataset that includes reading the sibling Source List File.
+// validateDatasetArchiveFile validates the dataset file's archive content
+// alone (used where the sibling is staged and validated separately).
 DatasetAssetValidationResult validateDatasetAsset(
+    const std::filesystem::path &file);
+DatasetAssetValidationResult validateDatasetArchiveFile(
     const std::filesystem::path &file);
 DatasetAssetValidationResult validateDatasetArchive(
     tsd::core::DataNode &archive);
@@ -46,10 +76,15 @@ bool loadDatasetArchiveFile(tsd::scene::Scene &scene,
     tsd::scene::LayerNodeRef &rootOut,
     std::string *error = nullptr);
 
+// sourceList supplies the File Animation Source List read from the archive's
+// sibling Source List File; a new-format file-animation archive fails without
+// it. Legacy archives with embedded sourceFiles ignore it and mark the
+// dataset for migration.
 bool deserializeDatasetArchive(tsd::scene::Scene &scene,
     tsd::animation::AnimationManager &animationManager,
     tsd::core::DataNode &archive,
     tsd::scene::LayerNodeRef destinationParent,
+    const std::vector<DatasetSourceFile> *sourceList,
     Dataset &datasetOut,
     tsd::scene::LayerNodeRef &rootOut,
     std::string *error = nullptr);

--- a/tsd/apps/interactive/scivisStudio/ProjectContext.cpp
+++ b/tsd/apps/interactive/scivisStudio/ProjectContext.cpp
@@ -1167,12 +1167,15 @@ bool ProjectContext::removeDataset(
 
   if (!keepAssetFile && !m_project.projectDirectory.empty()
       && !itr->persistedName.empty()) {
+    const auto assetFile =
+        m_project.projectDirectory / "datasets" / (itr->persistedName + ".tsd");
     std::error_code ec;
-    std::filesystem::remove(
-        m_project.projectDirectory / "datasets" / (itr->persistedName + ".tsd"),
-        ec);
+    std::filesystem::remove(assetFile, ec);
     if (ec)
       return fail("failed to remove Dataset Archive: " + ec.message(), error);
+    std::filesystem::remove(sourceListFilePath(assetFile), ec);
+    if (ec)
+      return fail("failed to remove Source List File: " + ec.message(), error);
   }
 
   if (m_ctx) {
@@ -1211,8 +1214,43 @@ bool ProjectContext::saveDatasetArchive(
   auto root = resolveDatasetRoot(*dataset);
   if (!root)
     return fail("dataset has no scene subtree", error);
-  return saveDatasetArchiveFile(
-      *dataset, root, m_ctx->tsd.animationMgr, file, error);
+  if (dataset->sourceKind != DatasetSourceKind::FileAnimation) {
+    return saveDatasetArchiveFile(
+        *dataset, root, m_ctx->tsd.animationMgr, file, error);
+  }
+
+  // For a File Animation Dataset the Archive is the pair: stage both files
+  // and install them together, so a failed save cannot leave half a pair or
+  // destroy a valid pair already at the target.
+  const auto sources = sourceListFilePath(file);
+  const auto stageName = [](const std::filesystem::path &target) {
+    return target.parent_path()
+        / ("." + target.filename().string() + ".stage");
+  };
+  const auto stagedFile = stageName(file);
+  const auto stagedSources = stageName(sources);
+  auto discardStages = [&]() {
+    std::error_code ec;
+    std::filesystem::remove(stagedFile, ec);
+    std::filesystem::remove(stagedSources, ec);
+  };
+
+  if (!saveDatasetArchiveFile(
+          *dataset, root, m_ctx->tsd.animationMgr, stagedFile, error)
+      || !writeSourceListFile(stagedSources, dataset->sourceFiles, error)) {
+    discardStages();
+    return false;
+  }
+
+  std::error_code ec;
+  std::filesystem::rename(stagedFile, file, ec);
+  if (!ec)
+    std::filesystem::rename(stagedSources, sources, ec);
+  if (ec) {
+    discardStages();
+    return fail("failed to install Dataset Archive: " + ec.message(), error);
+  }
+  return true;
 }
 
 Dataset *ProjectContext::loadDatasetArchiveImpl(

--- a/tsd/apps/interactive/scivisStudio/ProjectOpenPersistence.cpp
+++ b/tsd/apps/interactive/scivisStudio/ProjectOpenPersistence.cpp
@@ -41,6 +41,19 @@ struct StagedCameraRig
   std::string error;
 };
 
+/*
+ * A staged dataset is the archive plus — for a new-format file-animation
+ * dataset — its sibling Source List File, read once while staging so the
+ * stage-and-validate open works from one consistent snapshot (ADR 0013).
+ */
+struct StagedDataset
+{
+  StagedArchive archive;
+  bool sourceListLoaded{false};
+  std::vector<DatasetSourceFile> sourceList;
+  std::string sourceListError;
+};
+
 bool fail(std::string message, std::string *error)
 {
   if (error)
@@ -232,7 +245,7 @@ struct ProjectOpenState
   StagedArchive renderers;
   std::vector<StagedCameraRig> cameraRigs;
   std::vector<StagedArchive> lightRigs;
-  std::vector<StagedArchive> datasets;
+  std::vector<StagedDataset> datasets;
 };
 
 } // namespace detail
@@ -333,16 +346,19 @@ void hydrateDatasets(const detail::ProjectOpenState &state,
     }
     Dataset loaded;
     tsd::scene::LayerNodeRef loadedRoot;
-    std::string datasetError = staged.error;
-    const bool loadedAsset = staged.tree
+    std::string datasetError = staged.archive.error;
+    const bool loadedAsset = staged.archive.tree
         && deserializeDatasetArchive(scene,
             animationManager,
-            staged.tree->root(),
+            staged.archive.tree->root(),
             destination,
+            staged.sourceListLoaded ? &staged.sourceList : nullptr,
             loaded,
             loadedRoot,
             &datasetError);
     if (!loadedAsset) {
+      if (!staged.sourceListError.empty())
+        datasetError = staged.sourceListError;
       inventoryEntry.status = DatasetStatus::Unavailable;
       inventoryEntry.dirty = false;
       inventoryEntry.persistedName = inventoryEntry.name;
@@ -539,8 +555,16 @@ bool stageProjectOpen(const std::filesystem::path &directory,
         state->datasets.emplace_back();
         continue;
       }
-      state->datasets.push_back(
-          stageArchive(directory / "datasets" / (dataset.name + ".tsd")));
+      const auto file = directory / "datasets" / (dataset.name + ".tsd");
+      StagedDataset staged;
+      staged.archive = stageArchive(file);
+      if (staged.archive.tree
+          && datasetArchiveUsesSourceListFile(staged.archive.tree->root())) {
+        staged.sourceListLoaded = readSourceListFile(sourceListFilePath(file),
+            staged.sourceList,
+            &staged.sourceListError);
+      }
+      state->datasets.push_back(std::move(staged));
     }
   }
 

--- a/tsd/apps/interactive/scivisStudio/ProjectPersistence.cpp
+++ b/tsd/apps/interactive/scivisStudio/ProjectPersistence.cpp
@@ -207,6 +207,26 @@ bool isSavingCurrentProject(
       && !ec;
 }
 
+bool validateStagedSourceList(
+    const std::filesystem::path &file, std::string *error)
+{
+  std::vector<DatasetSourceFile> entries;
+  return readSourceListFile(file, entries, error);
+}
+
+ProjectAssetWriter copySourceListFileWriter(const std::filesystem::path &from)
+{
+  return [from](const std::filesystem::path &file, std::string *writeError) {
+    std::error_code ec;
+    std::filesystem::copy_file(from, file, ec);
+    if (ec) {
+      return fail(
+          "failed to copy Source List File: " + ec.message(), writeError);
+    }
+    return true;
+  };
+}
+
 void addRemoval(ProjectSavePlan &plan, const std::filesystem::path &path)
 {
   const bool alreadyAdded = std::any_of(
@@ -288,8 +308,13 @@ bool buildProjectSavePlan(const ProjectSaveRequest &request,
   for (size_t i = 0; i < result.project.datasets.size(); ++i) {
     auto &savedDataset = result.project.datasets[i];
     const auto &liveDataset = request.project.datasets[i];
+    // A pending source-list migration rewrites the asset on the next explicit
+    // save, but only while the dataset is loaded: an Unloaded dataset is
+    // read-only and keeps its legacy embedded sourceFiles until loaded again.
+    const bool migrateSourceList = liveDataset.pendingSourceListMigration
+        && liveDataset.residency == DatasetResidency::Loaded;
     const bool needsWrite = !savingCurrent || liveDataset.dirty
-        || liveDataset.pendingExtraction
+        || liveDataset.pendingExtraction || migrateSourceList
         || liveDataset.persistedName != savedDataset.name;
     if (!needsWrite)
       continue;
@@ -301,6 +326,8 @@ bool buildProjectSavePlan(const ProjectSaveRequest &request,
 
     savedDataset.persistedName = savedDataset.name;
     savedDataset.pendingExtraction = false;
+    if (migrateSourceList)
+      savedDataset.pendingSourceListMigration = false;
     savedDataset.dirty = false;
     ProjectAssetWrite write;
     write.description = "dataset '" + savedDataset.name + "'";
@@ -350,9 +377,11 @@ bool buildProjectSavePlan(const ProjectSaveRequest &request,
       };
     }
     const auto expectedName = savedDataset.name;
+    // The staged dataset file is validated alone: its sibling Source List
+    // File is staged and validated as its own transaction entry.
     write.validator = [expectedName](const std::filesystem::path &file,
                           std::string *validationError) {
-      auto validation = validateDatasetAsset(file);
+      auto validation = validateDatasetArchiveFile(file);
       if (!validation.ok)
         return fail(validation.error, validationError);
       if (validation.dataset.name != expectedName)
@@ -360,6 +389,70 @@ bool buildProjectSavePlan(const ProjectSaveRequest &request,
       return true;
     };
     plan.assets.push_back(std::move(write));
+
+    // The dataset file and its sibling Source List File are one asset: the
+    // transaction stages and installs the pair together. The sibling is
+    // written only when the target lacks one (Save As, first save, rename) or
+    // a migration is pending; a sibling already in place is never rewritten,
+    // so external edits survive saves that rewrite the dataset file for
+    // unrelated reasons (ADR 0013).
+    const auto sourcesTarget = std::filesystem::path("datasets")
+        / (savedDataset.name + SOURCE_LIST_FILE_EXTENSION);
+    if (liveDataset.residency == DatasetResidency::Unloaded) {
+      const auto sourceSibling =
+          sourceListFilePath(request.project.projectDirectory / "datasets"
+              / (liveDataset.persistedName + ".tsd"));
+      std::error_code ec;
+      if (std::filesystem::exists(sourceSibling, ec) && !ec) {
+        ProjectAssetWrite sourcesWrite;
+        sourcesWrite.description =
+            "dataset '" + savedDataset.name + "' Source List File";
+        sourcesWrite.target = sourcesTarget;
+        sourcesWrite.writer = copySourceListFileWriter(sourceSibling);
+        sourcesWrite.validator = validateStagedSourceList;
+        plan.assets.push_back(std::move(sourcesWrite));
+      }
+    } else if (savedDataset.sourceKind == DatasetSourceKind::FileAnimation) {
+      std::error_code ec;
+      const bool siblingInPlace = savingCurrent
+          && std::filesystem::exists(request.directory / sourcesTarget, ec)
+          && !ec;
+      if (!siblingInPlace || migrateSourceList) {
+        ProjectAssetWrite sourcesWrite;
+        sourcesWrite.description =
+            "dataset '" + savedDataset.name + "' Source List File";
+        sourcesWrite.target = sourcesTarget;
+        if (savingCurrent && !liveDataset.persistedName.empty()) {
+          sourcesWrite.ownedTarget = std::filesystem::path("datasets")
+              / (liveDataset.persistedName + SOURCE_LIST_FILE_EXTENSION);
+        }
+
+        // A rename is not a source-list edit: when the previously persisted
+        // sibling is on disk, carry it over verbatim so external edits
+        // survive. Serialize the in-memory entries only when there is no
+        // sibling to carry (first save, Save As, repair) or a migration
+        // externalizes the legacy embedded sourceFiles.
+        const auto persistedSibling =
+            savingCurrent && !liveDataset.persistedName.empty()
+            ? request.directory / "datasets"
+                / (liveDataset.persistedName + SOURCE_LIST_FILE_EXTENSION)
+            : std::filesystem::path();
+        const bool carrySibling = !migrateSourceList
+            && !persistedSibling.empty()
+            && std::filesystem::exists(persistedSibling, ec) && !ec;
+        if (carrySibling) {
+          sourcesWrite.writer = copySourceListFileWriter(persistedSibling);
+        } else {
+          const auto sourceList = savedDataset.sourceFiles;
+          sourcesWrite.writer = [sourceList](const std::filesystem::path &file,
+                                    std::string *writeError) {
+            return writeSourceListFile(file, sourceList, writeError);
+          };
+        }
+        sourcesWrite.validator = validateStagedSourceList;
+        plan.assets.push_back(std::move(sourcesWrite));
+      }
+    }
   }
 
   for (size_t i = 0; i < result.project.cameraRigs.size(); ++i) {
@@ -469,6 +562,11 @@ bool buildProjectSavePlan(const ProjectSaveRequest &request,
           && !assetNamesEqual(oldName, result.project.datasets[i].name)) {
         addRemoval(
             plan, std::filesystem::path("datasets") / (oldName + ".tsd"));
+        // Renaming renames the pair: retire the old sibling Source List File
+        // with the old dataset file (a missing sibling is skipped).
+        addRemoval(plan,
+            std::filesystem::path("datasets")
+                / (oldName + SOURCE_LIST_FILE_EXTENSION));
       }
     }
     for (size_t i = 0; i < result.project.cameraRigs.size(); ++i) {

--- a/tsd/apps/interactive/scivisStudio/ProjectSerialization.h
+++ b/tsd/apps/interactive/scivisStudio/ProjectSerialization.h
@@ -20,7 +20,11 @@ constexpr const char *PROJECT_SCHEMA = "tsd.scivis-studio.project";
 constexpr int DECOMPOSED_SCENE_SCHEMA_VERSION = 6;
 // v7: each manifest dataset records its residency (Loaded/Unloaded); an
 // absent field means Loaded, so v6 projects behave identically.
-constexpr int SCHEMA_VERSION = 7;
+// v8: a File Animation Dataset persists its source list only in a sibling
+// Source List File (datasets/<name>.sources); dataset files no longer embed
+// sourceFiles, though legacy embedded sourceFiles still load and migrate on
+// the next explicit save (ADR 0013).
+constexpr int SCHEMA_VERSION = 8;
 constexpr const char *PROJECT_MANIFEST_FILENAME = "project.tsd";
 
 // Standalone rig Archive schemas, versioned independently of the project.

--- a/tsd/docs/adr/0013-externalize-file-animation-source-lists.md
+++ b/tsd/docs/adr/0013-externalize-file-animation-source-lists.md
@@ -1,0 +1,45 @@
+# Externalize file-animation source lists into sibling Source List Files
+
+A File Animation Dataset's authoritative source list is persisted only in a
+Source List File: a UTF-8 text file with one path per line, saved as
+`datasets/<name>.sources` next to `datasets/<name>.tsd`. The dataset file
+stores importer settings but no frame paths; the sibling relationship is a
+naming convention, not a stored path. This makes the list storable and
+editable by humans and external tools without Studio, at the cost of a
+two-file dataset asset. The pair is the asset everywhere: Dataset Archive
+Save, Save As, and the ADR 0004 save transaction write both files together,
+Dataset Archive Load fails cleanly without the sibling, and Dataset Discovery
+still scans only `.tsd` files. This revises ADR 0003/0004's rule that the
+dataset `.tsd` contains its frame references and ADR 0005's rule that the
+dataset directory holds no supporting files.
+
+Line order is frame order; blank lines are ignored and lines are trimmed;
+there are no comments, globs, quoting, or includes — reserved syntax would
+restrict what paths can contain, and glob expansion would make frame count
+and order depend on directory state rather than on what the file says.
+Relative entries are resolved once, at read, against the Source List File's
+directory — a deliberate narrow revision of ADR 0007's opaque-path rule,
+because a hand-written relative path that resolves against process CWD is a
+trap. After that single anchoring, entries remain opaque: Studio still never
+rebases entries, copies targets, or persists resolved duplicates, and writes
+the raw entries back verbatim.
+
+The file is read exactly at Dataset Load; the in-memory authority is the raw
+entries as authored. Studio rewrites the file only when the source list was
+edited in-tool (last writer wins; no watching, merging, or mtime checks), and
+saving a clean dataset never touches it, so external edits survive unrelated
+saves and take effect on the next load. A missing, unreadable, or empty
+Source List File makes the dataset Unavailable; individual entries are still
+never preflighted (ADR 0003), so one bad path costs one frame, not the
+dataset. Legacy dataset files with embedded `sourceFiles` open unmodified and
+are marked for migration; the next explicit save writes the Source List File
+and rewrites the `.tsd` without paths, following the ADR 0006 pattern.
+Entries migrate verbatim: a legacy relative entry changes anchor from CWD to
+the file's directory, accepted because its old meaning was never defined.
+
+Rejected alternatives: keeping an embedded copy alongside the external file
+(competing serialized representations), a stored path to the list file
+(bookkeeping whose only sanctioned value is "next to me"), and embedding the
+list when saving portable archives (a second serialization path hidden from
+the humans the file serves). The name "manifest" was rejected because it
+already denotes `project.tsd`.

--- a/tsd/tests/test_SciVisStudio.cpp
+++ b/tsd/tests/test_SciVisStudio.cpp
@@ -31,6 +31,7 @@
 #include "tsd/scene/objects/SpatialField.hpp"
 #include "tsd/scene/objects/Volume.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -64,6 +65,52 @@ tsd::scene::LayerNodeRef findDirectChild(
     child = child->sibling();
   }
   return {};
+}
+
+// Build the minimal file-animation dataset runtime — a volume with an initial
+// spatial field plus one runtime file animation over the given paths — and
+// return its dataset metadata.
+Dataset makeFileAnimationDatasetRuntime(tsd::scene::Scene &scene,
+    tsd::animation::AnimationManager &animations,
+    tsd::scene::LayerNodeRef parent,
+    const std::string &id,
+    const std::string &name,
+    const std::vector<std::string> &paths,
+    tsd::scene::LayerNodeRef *rootOut = nullptr)
+{
+  auto field = scene.createObject<tsd::scene::SpatialField>(
+      tsd::scene::tokens::spatial_field::structuredRegular);
+  auto voxels = scene.createArray(ANARI_FLOAT32, 1, 1, 1);
+  *voxels->mapAs<float>() = 1.f;
+  voxels->unmap();
+  field->setParameterObject("data", *voxels);
+  auto volume = scene.createObject<tsd::scene::Volume>(
+      tsd::scene::tokens::volume::transferFunction1D);
+  volume->setParameterObject("value", *field);
+  auto root = scene.insertChildNode(parent, id.c_str());
+  scene.insertChildObjectNode(root, volume, "volume");
+  animations.addAnimation(name + " file animation")
+      .emplaceFileBinding<tsd::io::SpatialFieldFileBinding>(
+          &scene, volume.data(), field, paths);
+  if (rootOut)
+    *rootOut = root;
+
+  Dataset dataset;
+  dataset.id = id;
+  dataset.name = name;
+  dataset.sourceKind = DatasetSourceKind::FileAnimation;
+  dataset.importerType = "VOLUME_ANIMATION";
+  for (const auto &path : paths)
+    dataset.sourceFiles.push_back({path});
+  return dataset;
+}
+
+std::string fileContents(const std::filesystem::path &file)
+{
+  std::ifstream in(file, std::ios::binary);
+  std::stringstream contents;
+  contents << in.rdbuf();
+  return contents.str();
 }
 
 } // namespace
@@ -216,7 +263,8 @@ SCENARIO("SciVis Studio static Dataset Archives are self-contained",
   std::filesystem::remove(file);
 }
 
-SCENARIO("SciVis Studio file-animation Dataset Archives preserve source paths",
+SCENARIO("SciVis Studio file-animation Dataset Archives externalize their "
+         "source list",
     "[SciVisStudio]")
 {
   const auto file = std::filesystem::temp_directory_path()
@@ -224,36 +272,21 @@ SCENARIO("SciVis Studio file-animation Dataset Archives preserve source paths",
   const auto corruptFile = std::filesystem::temp_directory_path()
       / "tsd_scivis_studio_file_animation_dataset_corrupt.tsd";
   std::filesystem::remove(file);
+  std::filesystem::remove(sourceListFilePath(file));
   std::filesystem::remove(corruptFile);
 
   tsd::scene::Scene source;
   tsd::animation::AnimationManager sourceAnimations(&source);
-  auto field = source.createObject<tsd::scene::SpatialField>(
-      tsd::scene::tokens::spatial_field::structuredRegular);
-  auto voxels = source.createArray(ANARI_FLOAT32, 1, 1, 1);
-  *voxels->mapAs<float>() = 1.f;
-  voxels->unmap();
-  field->setParameterObject("data", *voxels);
-  auto volume = source.createObject<tsd::scene::Volume>(
-      tsd::scene::tokens::volume::transferFunction1D);
-  volume->setParameterObject("value", *field);
-  auto root =
-      source.insertChildNode(source.defaultLayer()->root(), "dataset_0001");
-  source.insertChildObjectNode(root, volume, "volume");
-
   const std::vector<std::string> paths = {
       "relative/frame 01.raw", "/missing/../opaque/frame02.raw"};
-  sourceAnimations.addAnimation("runtime file animation")
-      .emplaceFileBinding<tsd::io::SpatialFieldFileBinding>(
-          &source, volume.data(), field, paths);
-
-  Dataset dataset;
-  dataset.id = "dataset_0001";
-  dataset.name = "Opaque Frames";
-  dataset.sourceKind = DatasetSourceKind::FileAnimation;
-  dataset.importerType = "VOLUME_ANIMATION";
-  for (const auto &path : paths)
-    dataset.sourceFiles.push_back({path});
+  tsd::scene::LayerNodeRef root;
+  auto dataset = makeFileAnimationDatasetRuntime(source,
+      sourceAnimations,
+      source.defaultLayer()->root(),
+      "dataset_0001",
+      "Opaque Frames",
+      paths,
+      &root);
   Dataset invalidStatic = dataset;
   invalidStatic.sourceKind = DatasetSourceKind::Static;
   invalidStatic.importerType = "VOLUME";
@@ -281,6 +314,36 @@ SCENARIO("SciVis Studio file-animation Dataset Archives preserve source paths",
   REQUIRE(corruptValidation.error.find("derived runtime file bindings")
       != std::string::npos);
 
+  // New-format dataset files persist importer settings but no frame paths.
+  tsd::core::DataTree serialized;
+  REQUIRE(serialized.load(file.string().c_str()));
+  REQUIRE(serialized.root()["dataset"].child("sourceFiles") == nullptr);
+  REQUIRE(datasetArchiveUsesSourceListFile(serialized.root()));
+
+  // Dataset Archive Load fails cleanly without the sibling Source List File.
+  {
+    tsd::scene::Scene target;
+    tsd::animation::AnimationManager targetAnimations(&target);
+    Dataset missingDataset;
+    tsd::scene::LayerNodeRef missingRoot;
+    std::string missingError;
+    REQUIRE_FALSE(loadDatasetArchiveFile(target,
+        targetAnimations,
+        file,
+        target.defaultLayer()->root(),
+        missingDataset,
+        missingRoot,
+        &missingError));
+    REQUIRE(missingError.find("Source List File") != std::string::npos);
+    REQUIRE(target.numberOfObjects(ANARI_VOLUME) == 0);
+    REQUIRE_FALSE(validateDatasetAsset(file).ok);
+  }
+
+  REQUIRE(writeSourceListFile(sourceListFilePath(file), dataset.sourceFiles));
+  auto pairValidation = validateDatasetAsset(file);
+  REQUIRE(pairValidation.ok);
+  REQUIRE(pairValidation.dataset.sourceFiles.size() == paths.size());
+
   tsd::scene::Scene target;
   tsd::animation::AnimationManager targetAnimations(&target);
   Dataset loadedDataset;
@@ -291,9 +354,16 @@ SCENARIO("SciVis Studio file-animation Dataset Archives preserve source paths",
       target.defaultLayer()->root(),
       loadedDataset,
       importedRoot));
+  REQUIRE_FALSE(loadedDataset.pendingSourceListMigration);
   REQUIRE(loadedDataset.sourceFiles.size() == paths.size());
   REQUIRE(loadedDataset.sourceFiles[0].path == paths[0]);
   REQUIRE(loadedDataset.sourceFiles[1].path == paths[1]);
+  // The relative entry is anchored once, at read, to the Source List File's
+  // directory; the absolute entry stays opaque.
+  const auto anchored =
+      (std::filesystem::temp_directory_path() / paths[0]).string();
+  REQUIRE(loadedDataset.sourceFiles[0].resolvedPath == anchored);
+  REQUIRE(loadedDataset.sourceFiles[1].resolvedPath.empty());
   REQUIRE(targetAnimations.animations().size() == 1);
   REQUIRE(targetAnimations.animations().front().fileBindings().size() == 1);
 
@@ -301,12 +371,157 @@ SCENARIO("SciVis Studio file-animation Dataset Archives preserve source paths",
   targetAnimations.animations().front().fileBindings().front()->toDataNode(
       binding.root());
   REQUIRE(
-      binding.root()["files"].child(0)->getValueAs<std::string>() == paths[0]);
+      binding.root()["files"].child(0)->getValueAs<std::string>() == anchored);
   REQUIRE(
       binding.root()["files"].child(1)->getValueAs<std::string>() == paths[1]);
 
   std::filesystem::remove(file);
+  std::filesystem::remove(sourceListFilePath(file));
   std::filesystem::remove(corruptFile);
+}
+
+SCENARIO("SciVis Studio Source List Files hold one trimmed path per line",
+    "[SciVisStudio]")
+{
+  const auto directory = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_files";
+  std::filesystem::remove_all(directory);
+  std::filesystem::create_directories(directory);
+  const auto file = directory / "Frames.sources";
+
+  GIVEN("A hand-written Source List File")
+  {
+    {
+      std::ofstream out(file);
+      out << "\n";
+      out << "  relative/frame 01.raw \t\n";
+      out << "\t\n";
+      out << "/absolute/frame02.raw\n";
+      out << "trailing/frame03.raw"; // no final newline
+    }
+
+    THEN("Entries read back trimmed, in line order, skipping blanks")
+    {
+      std::vector<DatasetSourceFile> entries;
+      REQUIRE(readSourceListFile(file, entries));
+      REQUIRE(entries.size() == 3);
+      REQUIRE(entries[0].path == "relative/frame 01.raw");
+      REQUIRE(entries[1].path == "/absolute/frame02.raw");
+      REQUIRE(entries[2].path == "trailing/frame03.raw");
+      REQUIRE(entries[0].resolvedPath
+          == (directory / "relative/frame 01.raw").string());
+      REQUIRE(entries[1].resolvedPath.empty());
+
+      AND_THEN("Writing the entries back reproduces the raw lines verbatim")
+      {
+        const auto rewritten = directory / "Rewritten.sources";
+        REQUIRE(writeSourceListFile(rewritten, entries));
+        std::ifstream in(rewritten);
+        std::stringstream contents;
+        contents << in.rdbuf();
+        REQUIRE(contents.str()
+            == "relative/frame 01.raw\n/absolute/frame02.raw\n"
+               "trailing/frame03.raw\n");
+      }
+    }
+  }
+
+  GIVEN("A missing, empty, or blank Source List File")
+  {
+    THEN("Reading fails with a clear error")
+    {
+      std::vector<DatasetSourceFile> entries;
+      std::string error;
+      REQUIRE_FALSE(
+          readSourceListFile(directory / "Missing.sources", entries, &error));
+      REQUIRE_FALSE(error.empty());
+
+      const auto blank = directory / "Blank.sources";
+      {
+        std::ofstream out(blank);
+        out << " \n\t\n";
+      }
+      error.clear();
+      REQUIRE_FALSE(readSourceListFile(blank, entries, &error));
+      REQUIRE(error.find("empty") != std::string::npos);
+    }
+  }
+
+  GIVEN("An empty File Animation Source List")
+  {
+    THEN("Writing refuses to produce an unloadable dataset")
+    {
+      std::string error;
+      REQUIRE_FALSE(writeSourceListFile(file, {}, &error));
+    }
+  }
+
+  std::filesystem::remove_all(directory);
+}
+
+SCENARIO(
+    "SciVis Studio legacy embedded sourceFiles load and mark migration",
+    "[SciVisStudio]")
+{
+  const auto file = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_legacy_embedded_dataset.tsd";
+  std::filesystem::remove(file);
+  std::filesystem::remove(sourceListFilePath(file));
+
+  tsd::scene::Scene source;
+  tsd::animation::AnimationManager sourceAnimations(&source);
+  const std::vector<std::string> paths = {
+      "legacy/frame01.raw", "/legacy/frame02.raw"};
+  tsd::scene::LayerNodeRef root;
+  auto dataset = makeFileAnimationDatasetRuntime(source,
+      sourceAnimations,
+      source.defaultLayer()->root(),
+      "dataset_0001",
+      "Legacy Frames",
+      paths,
+      &root);
+  REQUIRE(saveDatasetArchiveFile(dataset, root, sourceAnimations, file));
+
+  // Recreate the legacy on-disk format: the dataset file embeds the list.
+  {
+    tsd::core::DataTree legacy;
+    REQUIRE(legacy.load(file.string().c_str()));
+    auto &files = legacy.root()["dataset"]["sourceFiles"];
+    for (const auto &path : paths)
+      files.append() = path;
+    REQUIRE_FALSE(datasetArchiveUsesSourceListFile(legacy.root()));
+    REQUIRE(legacy.save(file.string().c_str()));
+  }
+
+  auto validation = validateDatasetAsset(file);
+  REQUIRE(validation.ok);
+  REQUIRE(validation.dataset.pendingSourceListMigration);
+  REQUIRE(validation.dataset.sourceFiles.size() == paths.size());
+
+  tsd::scene::Scene target;
+  tsd::animation::AnimationManager targetAnimations(&target);
+  Dataset loadedDataset;
+  tsd::scene::LayerNodeRef importedRoot;
+  REQUIRE(loadDatasetArchiveFile(target,
+      targetAnimations,
+      file,
+      target.defaultLayer()->root(),
+      loadedDataset,
+      importedRoot));
+  REQUIRE(loadedDataset.pendingSourceListMigration);
+  REQUIRE(loadedDataset.sourceFiles.size() == paths.size());
+  REQUIRE(loadedDataset.sourceFiles[0].path == paths[0]);
+  // Legacy entries stay opaque: no read-time anchoring is applied.
+  REQUIRE(loadedDataset.sourceFiles[0].resolvedPath.empty());
+  REQUIRE(targetAnimations.animations().size() == 1);
+
+  tsd::core::DataTree binding;
+  targetAnimations.animations().front().fileBindings().front()->toDataNode(
+      binding.root());
+  REQUIRE(
+      binding.root()["files"].child(0)->getValueAs<std::string>() == paths[0]);
+
+  std::filesystem::remove(file);
 }
 
 SCENARIO("SciVis Studio project model serialization", "[SciVisStudio]")
@@ -980,7 +1195,7 @@ SCENARIO("SciVis Studio projects store scene pools in required Archives",
     auto metadata = tsd::core::readDataTreeMetadata(manifest.root());
     REQUIRE(metadata.found());
     REQUIRE(metadata.metadata->schemaVersion == SCHEMA_VERSION);
-    REQUIRE(SCHEMA_VERSION == 7);
+    REQUIRE(SCHEMA_VERSION == 8);
     REQUIRE(manifest.root().child("context") == nullptr);
 
     tsd::core::DataTree cameras;
@@ -1179,6 +1394,252 @@ SCENARIO(
     REQUIRE(project.shots.front().datasetBindings.size() == 1);
     REQUIRE(project.shots.front().datasetBindings.front().datasetId
         == "dataset_0001");
+  }
+
+  std::filesystem::remove_all(root);
+}
+
+SCENARIO("SciVis Studio projects persist file-animation source lists in "
+         "sibling Source List Files",
+    "[SciVisStudio]")
+{
+  const auto root = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_pair";
+  const auto copy = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_pair_copy";
+  std::filesystem::remove_all(root);
+  std::filesystem::remove_all(copy);
+
+  const std::vector<std::string> paths = {"frames/a.raw", "frames/b.raw"};
+  const auto datasetFile = root / "datasets" / "Frames.tsd";
+  const auto sourcesFile = root / "datasets" / "Frames.sources";
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    projectContext.createUnsavedProject();
+    auto &project = projectContext.project();
+    auto &scene = appContext.tsd.scene;
+    auto datasetsRoot =
+        findDirectChild(scene.layer("studio")->root(), "datasets");
+    auto dataset = makeFileAnimationDatasetRuntime(scene,
+        appContext.tsd.animationMgr,
+        datasetsRoot,
+        "dataset_0001",
+        "Frames",
+        paths);
+    dataset.status = DatasetStatus::Available;
+    dataset.rootNode = projectContext.refFor(
+        "studio", findDirectChild(datasetsRoot, "dataset_0001"));
+    project.datasets.push_back(std::move(dataset));
+    shot::setDatasetBinding(project.shots.front(), "dataset_0001", true);
+    project.markDirty();
+
+    // The ADR 0004 transaction stages the pair together: the plan carries
+    // both files, and a failure while installing leaves neither behind.
+    {
+      struct : AssetTransactionFailureInjector
+      {
+        bool fail(AssetTransactionPhase phase,
+            const std::filesystem::path &,
+            std::string &message) override
+        {
+          if (phase != AssetTransactionPhase::ManifestInstall)
+            return false;
+          message = "injected manifest failure";
+          return true;
+        }
+      } injector;
+      ProjectSaveRequest request(
+          project, scene, appContext.tsd.animationMgr, root);
+      ProjectSaveResult result;
+      REQUIRE(buildProjectSavePlan(request, result));
+      const auto hasTarget = [&](const char *target) {
+        return std::any_of(result.plan.assets.begin(),
+            result.plan.assets.end(),
+            [&](const ProjectAssetWrite &write) {
+              return write.target == std::filesystem::path(target);
+            });
+      };
+      REQUIRE(hasTarget("datasets/Frames.tsd"));
+      REQUIRE(hasTarget("datasets/Frames.sources"));
+      AssetTransaction transaction(&injector);
+      std::string error;
+      REQUIRE_FALSE(transaction.commit(result.plan, &error));
+      REQUIRE_FALSE(std::filesystem::exists(datasetFile));
+      REQUIRE_FALSE(std::filesystem::exists(sourcesFile));
+    }
+
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(std::filesystem::exists(datasetFile));
+    REQUIRE(fileContents(sourcesFile) == "frames/a.raw\nframes/b.raw\n");
+    tsd::core::DataTree assetTree;
+    REQUIRE(assetTree.load(datasetFile.string().c_str()));
+    REQUIRE(assetTree.root()["dataset"].child("sourceFiles") == nullptr);
+  }
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    REQUIRE(projectContext.openProject(root));
+    auto &project = projectContext.project();
+    REQUIRE(project.datasets.front().status == DatasetStatus::Available);
+    REQUIRE(project.datasets.front().sourceFiles.size() == 2);
+    REQUIRE(project.datasets.front().sourceFiles[0].path == "frames/a.raw");
+    REQUIRE(project.datasets.front().sourceFiles[0].resolvedPath
+        == (root / "datasets" / "frames/a.raw").string());
+
+    // Saves that do not touch the source list never rewrite the sibling, so
+    // external edits survive: an unrelated project edit...
+    const auto sentinel =
+        std::filesystem::file_time_type::clock::now() - std::chrono::hours(1);
+    std::filesystem::last_write_time(sourcesFile, sentinel);
+    project.shots.front().name = "Unrelated Shot Edit";
+    project.markDirty();
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(std::filesystem::last_write_time(sourcesFile) == sentinel);
+
+    // ...and a save that rewrites a dirty dataset file for unrelated reasons.
+    project.datasets.front().dirty = true;
+    project.markDirty();
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(std::filesystem::last_write_time(sourcesFile) == sentinel);
+  }
+
+  {
+    // A hand-edited Source List File takes effect on the next Dataset Load.
+    std::ofstream out(sourcesFile, std::ios::trunc);
+    out << "\n  frames/b.raw\nframes/c.raw\nframes/a.raw\n";
+  }
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    REQUIRE(projectContext.openProject(root));
+    auto &project = projectContext.project();
+    const auto &dataset = project.datasets.front();
+    REQUIRE(dataset.status == DatasetStatus::Available);
+    REQUIRE(dataset.sourceFiles.size() == 3);
+    REQUIRE(dataset.sourceFiles[0].path == "frames/b.raw");
+    REQUIRE(dataset.sourceFiles[1].path == "frames/c.raw");
+    REQUIRE(dataset.sourceFiles[2].path == "frames/a.raw");
+
+    // Save As writes the pair into the new project.
+    REQUIRE(projectContext.saveProject(copy));
+    REQUIRE(std::filesystem::exists(copy / "datasets" / "Frames.tsd"));
+    REQUIRE(fileContents(copy / "datasets" / "Frames.sources")
+        == "frames/b.raw\nframes/c.raw\nframes/a.raw\n");
+  }
+  std::filesystem::remove_all(copy);
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    REQUIRE(projectContext.openProject(root));
+    auto &project = projectContext.project();
+    const auto id = project.datasets.front().id;
+
+    // Renaming the dataset renames the pair. A rename is not a source-list
+    // edit, so an external edit made after the load is carried over verbatim
+    // rather than clobbered by the in-memory entries.
+    {
+      std::ofstream out(sourcesFile, std::ios::trunc);
+      out << "frames/hand-edited-after-load.raw\n";
+    }
+    REQUIRE(projectContext.renameDataset(id, "Renamed Frames"));
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(std::filesystem::exists(root / "datasets" / "Renamed Frames.tsd"));
+    REQUIRE(fileContents(root / "datasets" / "Renamed Frames.sources")
+        == "frames/hand-edited-after-load.raw\n");
+    REQUIRE_FALSE(std::filesystem::exists(datasetFile));
+    REQUIRE_FALSE(std::filesystem::exists(sourcesFile));
+
+    // Dataset Removal deletes the pair with the asset.
+    REQUIRE(projectContext.removeDataset(id));
+    REQUIRE_FALSE(
+        std::filesystem::exists(root / "datasets" / "Renamed Frames.tsd"));
+    REQUIRE_FALSE(
+        std::filesystem::exists(root / "datasets" / "Renamed Frames.sources"));
+  }
+
+  std::filesystem::remove_all(root);
+}
+
+SCENARIO(
+    "SciVis Studio migrates legacy embedded sourceFiles on explicit save",
+    "[SciVisStudio]")
+{
+  const auto root = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_migration";
+  std::filesystem::remove_all(root);
+
+  const std::vector<std::string> paths = {"legacy/a.raw", "/legacy/b.raw"};
+  const auto datasetFile = root / "datasets" / "Frames.tsd";
+  const auto sourcesFile = root / "datasets" / "Frames.sources";
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    projectContext.createUnsavedProject();
+    auto &project = projectContext.project();
+    auto &scene = appContext.tsd.scene;
+    auto datasetsRoot =
+        findDirectChild(scene.layer("studio")->root(), "datasets");
+    auto dataset = makeFileAnimationDatasetRuntime(scene,
+        appContext.tsd.animationMgr,
+        datasetsRoot,
+        "dataset_0001",
+        "Frames",
+        paths);
+    dataset.status = DatasetStatus::Available;
+    dataset.rootNode = projectContext.refFor(
+        "studio", findDirectChild(datasetsRoot, "dataset_0001"));
+    project.datasets.push_back(std::move(dataset));
+    shot::setDatasetBinding(project.shots.front(), "dataset_0001", true);
+    project.markDirty();
+    REQUIRE(projectContext.saveProject(root));
+  }
+
+  // Rewrite the managed asset into the legacy embedded-sourceFiles format.
+  {
+    tsd::core::DataTree legacy;
+    REQUIRE(legacy.load(datasetFile.string().c_str()));
+    auto &files = legacy.root()["dataset"]["sourceFiles"];
+    for (const auto &path : paths)
+      files.append() = path;
+    REQUIRE(legacy.save(datasetFile.string().c_str()));
+    std::filesystem::remove(sourcesFile);
+  }
+
+  {
+    tsd::app::Context appContext;
+    ProjectContext projectContext(&appContext);
+    REQUIRE(projectContext.openProject(root));
+    auto &project = projectContext.project();
+    REQUIRE(project.datasets.front().status == DatasetStatus::Available);
+    REQUIRE(project.datasets.front().pendingSourceListMigration);
+    REQUIRE_FALSE(project.datasets.front().dirty);
+    // Merely opening never migrates.
+    REQUIRE_FALSE(std::filesystem::exists(sourcesFile));
+
+    // The next explicit save writes the Source List File verbatim and
+    // rewrites the dataset file without paths.
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(fileContents(sourcesFile) == "legacy/a.raw\n/legacy/b.raw\n");
+    tsd::core::DataTree migrated;
+    REQUIRE(migrated.load(datasetFile.string().c_str()));
+    REQUIRE(migrated.root()["dataset"].child("sourceFiles") == nullptr);
+    REQUIRE_FALSE(project.datasets.front().pendingSourceListMigration);
+
+    // The migrated pair is now stable across further saves.
+    const auto sentinel =
+        std::filesystem::file_time_type::clock::now() - std::chrono::hours(1);
+    std::filesystem::last_write_time(sourcesFile, sentinel);
+    std::filesystem::last_write_time(datasetFile, sentinel);
+    project.markDirty();
+    REQUIRE(projectContext.saveProject(root));
+    REQUIRE(std::filesystem::last_write_time(sourcesFile) == sentinel);
+    REQUIRE(std::filesystem::last_write_time(datasetFile) == sentinel);
   }
 
   std::filesystem::remove_all(root);
@@ -1489,6 +1950,124 @@ SCENARIO("SciVis Studio dataset lifecycle workflows preserve asset semantics",
   std::filesystem::remove_all(root);
   std::filesystem::remove(source);
   std::filesystem::remove(savedArchive);
+}
+
+SCENARIO("SciVis Studio treats the file-animation pair as one dataset asset",
+    "[SciVisStudio]")
+{
+  const auto root = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_asset";
+  const auto archiveDir = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_archives";
+  std::filesystem::remove_all(root);
+  std::filesystem::remove_all(archiveDir);
+  std::filesystem::create_directories(archiveDir);
+
+  tsd::app::Context appContext;
+  ProjectContext projectContext(&appContext);
+  projectContext.createUnsavedProject();
+  auto &project = projectContext.project();
+  auto &scene = appContext.tsd.scene;
+  auto datasetsRoot =
+      findDirectChild(scene.layer("studio")->root(), "datasets");
+  auto dataset = makeFileAnimationDatasetRuntime(scene,
+      appContext.tsd.animationMgr,
+      datasetsRoot,
+      "dataset_0001",
+      "Frames",
+      {"frames/a.raw", "frames/b.raw"});
+  dataset.status = DatasetStatus::Available;
+  dataset.rootNode = projectContext.refFor(
+      "studio", findDirectChild(datasetsRoot, "dataset_0001"));
+  project.datasets.push_back(std::move(dataset));
+  shot::setDatasetBinding(project.shots.front(), "dataset_0001", true);
+  project.markDirty();
+  REQUIRE(projectContext.saveProject(root));
+  const auto id = project.datasets.front().id;
+
+  // Dataset Archive Save writes the pair.
+  const auto archiveFile = archiveDir / "Archived.tsd";
+  REQUIRE(projectContext.saveDatasetArchive(id, archiveFile));
+  REQUIRE(std::filesystem::exists(archiveFile));
+  REQUIRE(fileContents(archiveDir / "Archived.sources")
+      == "frames/a.raw\nframes/b.raw\n");
+
+  // Dataset Archive Load incorporates the pair with a fresh identity...
+  std::string error;
+  auto *incorporated = projectContext.loadDatasetArchive(archiveFile, &error);
+  REQUIRE(incorporated);
+  REQUIRE(incorporated->sourceFiles.size() == 2);
+  REQUIRE(incorporated->sourceFiles[0].resolvedPath
+      == (archiveDir / "frames/a.raw").string());
+  REQUIRE(projectContext.removeDataset(incorporated->id));
+
+  // ...and fails cleanly without the sibling.
+  std::filesystem::remove(archiveDir / "Archived.sources");
+  const auto datasetCount = project.datasets.size();
+  REQUIRE(projectContext.loadDatasetArchive(archiveFile, &error) == nullptr);
+  REQUIRE(error.find("Source List File") != std::string::npos);
+  REQUIRE(project.datasets.size() == datasetCount);
+
+  // Dataset Load re-reads the Source List File, so a hand edit made while the
+  // dataset was Unloaded takes effect when it is loaded back.
+  REQUIRE(projectContext.unloadDataset(id, &error));
+  {
+    std::ofstream out(root / "datasets" / "Frames.sources", std::ios::trunc);
+    out << "frames/z.raw\n";
+  }
+  REQUIRE(projectContext.loadDataset(id, &error));
+  REQUIRE(project::findDataset(project, id)->sourceFiles.size() == 1);
+  REQUIRE(project::findDataset(project, id)->sourceFiles[0].path
+      == "frames/z.raw");
+
+  // Discovery scans only dataset files, and a file-animation dataset file
+  // without its sibling is not a valid Dataset Candidate.
+  {
+    std::error_code ec;
+    std::filesystem::copy_file(
+        archiveFile, root / "datasets" / "Orphan.tsd", ec);
+    REQUIRE_FALSE(ec);
+    std::ofstream stray(root / "datasets" / "Stray.sources");
+    stray << "frames/a.raw\n";
+  }
+  REQUIRE(projectContext.discoverDatasetCandidates().empty());
+  {
+    std::ofstream sibling(root / "datasets" / "Orphan.sources");
+    sibling << "frames/a.raw\n";
+  }
+  auto candidates = projectContext.discoverDatasetCandidates();
+  REQUIRE(candidates.size() == 1);
+  REQUIRE(candidates.front().file.filename() == "Orphan.tsd");
+
+  // A missing Source List File makes the dataset Unavailable at open; the
+  // project itself still opens.
+  std::filesystem::remove(root / "datasets" / "Frames.sources");
+  {
+    tsd::app::Context reopenedContext;
+    ProjectContext reopened(&reopenedContext);
+    REQUIRE(reopened.openProject(root));
+    REQUIRE(reopened.project().datasets.front().status
+        == DatasetStatus::Unavailable);
+  }
+
+  // Save As copies an Unloaded dataset's pair without loading it.
+  const auto destination = std::filesystem::temp_directory_path()
+      / "tsd_scivis_studio_source_list_asset_save_as";
+  std::filesystem::remove_all(destination);
+  {
+    std::ofstream out(root / "datasets" / "Frames.sources", std::ios::trunc);
+    out << "frames/z.raw\n";
+  }
+  REQUIRE(projectContext.unloadDataset(id, &error));
+  REQUIRE(
+      projectContext.saveProject(destination, nullptr, "", nullptr, &error));
+  REQUIRE(validateDatasetAsset(destination / "datasets" / "Frames.tsd").ok);
+  REQUIRE(fileContents(destination / "datasets" / "Frames.sources")
+      == "frames/z.raw\n");
+
+  std::filesystem::remove_all(root);
+  std::filesystem::remove_all(destination);
+  std::filesystem::remove_all(archiveDir);
 }
 
 SCENARIO("SciVis Studio unloads a clean dataset without touching its asset",


### PR DESCRIPTION
A File Animation Dataset's source list now persists only in a sibling Source List File (datasets/<name>.sources): UTF-8 text, one path per line, trimmed, blanks skipped, line order = frame order. Dataset files no longer embed sourceFiles.

- Relative entries anchor once, at read, to the Source List File's directory; raw entries stay authoritative and are written back verbatim.
- The pair is the asset everywhere: the ADR 0004 save transaction stages both files together, Save As and Dataset Archive Save write both (Archive Save stages and installs the pair so a failed export cannot destroy a valid one), rename renames the sibling (carrying external edits over verbatim), and Dataset Removal deletes it.
- The file is read exactly at Dataset Load; a clean dataset's saves never rewrite it, so external edits survive and take effect on the next load. A missing, unreadable, or empty sibling makes the dataset Unavailable; Dataset Archive Load fails cleanly without it.
- Legacy dataset files with embedded sourceFiles open unmodified and are marked for migration; the next explicit save of the loaded dataset writes the Source List File and rewrites the dataset file without paths (entries migrate verbatim). Unloaded datasets stay read-only and keep their legacy form until loaded again.
- Project schema bumped to v8.