### PR TITLE
feat(rtx): add denoiseOnlyLastFrame renderer parameter

### DIFF
--- a/devices/rtx/device/frame/Frame.cu
+++ b/devices/rtx/device/frame/Frame.cu
@@ -681,24 +681,39 @@ void Frame::renderFrame()
 
   const bool useFloatOutput = m_denoise || m_colorType == ANARI_FLOAT32_VEC4;
 
-  if (m_denoise) {
-    launchPrepareDenoiseInputs(m_accumColor.ptrAs<vec4>(),
-        m_accumAlbedo.ptrAs<vec3>(),
-        m_accumNormal.ptrAs<vec3>(),
-        m_denoiseInput.ptrAs<vec4>(),
-        m_denoiseAlbedo.ptrAs<vec3>(),
-        m_denoiseNormal.ptrAs<vec3>(),
-        hd.fb.size,
-        hd.fb.frameID,
-        hd.fb.checkerboardID,
-        hd.renderer.fireflyFilterMode,
-        m_trimTopK.ptrAs<vec4>(),
-        m_lumStats.ptrAs<PixelLumStats>(),
-        hd.renderer.fireflyFilterTrim,
-        hd.renderer.fireflyFilterSigma,
-        state.stream);
+  // 'denoiseStart' is the accumulated sample count at which denoising begins;
+  // earlier frames go through the denoise-enabled output path (float pixel
+  // buffer + convertOutput) but skip the denoiser itself. Negative values
+  // count back from sampleLimit (-1 == sampleLimit, i.e. only the last
+  // frame); without a sample limit there is no end to count from, so
+  // negative values denoise every frame.
+  const int denoiseStart = m_renderer->denoiseStart();
+  const int effectiveDenoiseStart = denoiseStart >= 0
+      ? denoiseStart
+      : (sampleLimit > 0 ? sampleLimit + denoiseStart + 1 : 0);
+  const bool denoiseThisFrame =
+      m_denoise && hd.fb.frameID >= effectiveDenoiseStart;
 
-    m_denoiser.launch();
+  if (m_denoise) {
+    if (denoiseThisFrame) {
+      launchPrepareDenoiseInputs(m_accumColor.ptrAs<vec4>(),
+          m_accumAlbedo.ptrAs<vec3>(),
+          m_accumNormal.ptrAs<vec3>(),
+          m_denoiseInput.ptrAs<vec4>(),
+          m_denoiseAlbedo.ptrAs<vec3>(),
+          m_denoiseNormal.ptrAs<vec3>(),
+          hd.fb.size,
+          hd.fb.frameID,
+          hd.fb.checkerboardID,
+          hd.renderer.fireflyFilterMode,
+          m_trimTopK.ptrAs<vec4>(),
+          m_lumStats.ptrAs<PixelLumStats>(),
+          hd.renderer.fireflyFilterTrim,
+          hd.renderer.fireflyFilterSigma,
+          state.stream);
+
+      m_denoiser.launch();
+    }
 
     launchCompositeBackground(m_accumColor.ptrAs<vec4>(),
         (vec4 *)m_pixelBuffer.dataDevice(),
@@ -709,7 +724,7 @@ void Frame::renderFrame()
         FrameFormat::FLOAT,
         hd.fb.frameID,
         hd.fb.checkerboardID,
-        /*isDenoised=*/true,
+        /*isDenoised=*/denoiseThisFrame,
         m_trimTopK.ptrAs<vec4>(),
         m_lumStats.ptrAs<PixelLumStats>(),
         state.stream);

--- a/devices/rtx/device/renderer/Renderer.cpp
+++ b/devices/rtx/device/renderer/Renderer.cpp
@@ -174,6 +174,7 @@ void Renderer::commitParameters()
   m_checkerboard = getParam<bool>("checkerboarding", false);
 
   m_denoise = getParam<bool>("denoise", false);
+  m_denoiseStart = getParam<int>("denoiseStart", 0);
   auto denoiseMode = getParamString("denoiseMode", "color");
   m_denoiseAlbedo =
       (denoiseMode == "colorAlbedo" || denoiseMode == "colorAlbedoNormal");
@@ -304,6 +305,11 @@ bool Renderer::checkerboarding() const
 bool Renderer::denoise() const
 {
   return m_denoise;
+}
+
+int Renderer::denoiseStart() const
+{
+  return m_denoiseStart;
 }
 
 bool Renderer::denoiseUsingAlbedo() const

--- a/devices/rtx/device/renderer/Renderer.h
+++ b/devices/rtx/device/renderer/Renderer.h
@@ -72,6 +72,7 @@ struct Renderer : public Object
   int spp() const;
   bool checkerboarding() const;
   bool denoise() const;
+  int denoiseStart() const;
   bool denoiseUsingAlbedo() const;
   bool denoiseUsingNormal() const;
   FireflyFilterMode fireflyFilterMode() const;
@@ -88,6 +89,7 @@ struct Renderer : public Object
   float m_occlusionDistance{1e20f};
   bool m_checkerboard{false};
   bool m_denoise{false};
+  int m_denoiseStart{0};
   bool m_denoiseAlbedo{false};
   bool m_denoiseNormal{false};
   FireflyFilterMode m_fireflyFilterMode{FireflyFilterMode::TONEMAP};

--- a/devices/rtx/device/visrtx_renderer_fast.json
+++ b/devices/rtx/device/visrtx_renderer_fast.json
@@ -45,6 +45,15 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "denoiseStart",
+          "types": [
+            "ANARI_INT32"
+          ],
+          "tags": [],
+          "default": 0,
+          "description": "accumulated sample count at which denoising starts; negative values count back from sampleLimit (-1 == only the final frame)"
+        },
+        {
           "name": "denoiseMode",
           "types": [
             "ANARI_STRING"

--- a/devices/rtx/device/visrtx_renderer_interactive.json
+++ b/devices/rtx/device/visrtx_renderer_interactive.json
@@ -36,6 +36,15 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "denoiseStart",
+          "types": [
+            "ANARI_INT32"
+          ],
+          "tags": [],
+          "default": 0,
+          "description": "accumulated sample count at which denoising starts; negative values count back from sampleLimit (-1 == only the final frame)"
+        },
+        {
           "name": "denoiseMode",
           "types": [
             "ANARI_STRING"

--- a/devices/rtx/device/visrtx_renderer_quality.json
+++ b/devices/rtx/device/visrtx_renderer_quality.json
@@ -36,6 +36,15 @@
           "description": "enable the OptiX denoiser"
         },
         {
+          "name": "denoiseStart",
+          "types": [
+            "ANARI_INT32"
+          ],
+          "tags": [],
+          "default": 0,
+          "description": "accumulated sample count at which denoising starts; negative values count back from sampleLimit (-1 == only the final frame)"
+        },
+        {
           "name": "denoiseMode",
           "types": [
             "ANARI_STRING"


### PR DESCRIPTION
When 'denoise' is enabled and 'denoiseOnlyLastFrame' is set, intermediate accumulation frames skip the OptiX denoiser (and its input preparation) and composite the raw accumulation instead; the denoiser runs only once accumulation reaches 'sampleLimit'. Intermediate frames still go through the denoise-enabled float pixel-buffer path so mapped channels behave identically. With no sample limit (sampleLimit <= 0) there is no last frame, so the option is ignored and denoising runs every frame.