### PR TITLE
chore(ci): drop unused libcurand from CUDA setup

### DIFF
--- a/.github/actions/setup-cuda/components.json
+++ b/.github/actions/setup-cuda/components.json
@@ -50,14 +50,6 @@
         "windows-x86_64"
       ]
     },
-    "libcurand": {
-      "required": true,
-      "description": "Random number generation library",
-      "platforms": [
-        "linux-x86_64",
-        "windows-x86_64"
-      ]
-    },
     "visual_studio_integration": {
       "required": true,
       "description": "Visual Studio build integration (MSBuild rules)",

--- a/.github/actions/setup-cuda/scripts/install-cuda.ps1
+++ b/.github/actions/setup-cuda/scripts/install-cuda.ps1
@@ -27,7 +27,6 @@ $defaultComponents = @(
     "cuda_cudart",
     "cuda_cccl",
     "cuda_nvml_dev",
-    "libcurand",
     "visual_studio_integration"
 )
 

--- a/.github/actions/setup-cuda/scripts/install-cuda.sh
+++ b/.github/actions/setup-cuda/scripts/install-cuda.sh
@@ -46,7 +46,6 @@ DEFAULT_COMPONENTS=(
     "cuda_cudart"
     "cuda_cccl"
     "cuda_nvml_dev"
-    "libcurand"
 )
 
 # Cleanup on exit


### PR DESCRIPTION
VisRTX does not link to curand anymore. Remove it from the CUDA component lists and manifest.