### PR TITLE
fix(tsd, rtx): Drop distinlling, improve PTX stitching, CMake

### DIFF
--- a/devices/rtx/device/material/shaders/MDLShader_ptx.cu
+++ b/devices/rtx/device/material/shaders/MDLShader_ptx.cu
@@ -47,11 +47,11 @@ using BsdfInitFunc = mi::neuraylib::Bsdf_init_function;
 using BsdfSampleFunc = mi::neuraylib::Bsdf_sample_function;
 using BsdfEvaluateFunc = mi::neuraylib::Bsdf_evaluate_function;
 using BsdfPdfFunc = mi::neuraylib::Bsdf_pdf_function;
+using BsdfAuxiliaryFunc = mi::neuraylib::Bsdf_auxiliary_function;
 
 using EdfEvaluateFunc = mi::neuraylib::Edf_evaluate_function;
 
 //
-using TintExprFunc = mi::neuraylib::Material_function<vec3>::Type;
 using OpacityExprFunc = mi::neuraylib::Material_function<float>::Type;
 using TransmissionExprFunc = mi::neuraylib::Material_function<vec3>::Type;
 using EmissionIntensityExprFunc = mi::neuraylib::Material_function<vec3>::Type;
@@ -63,6 +63,8 @@ using BsdfSampleData = mi::neuraylib::Bsdf_sample_data;
 using BsdfEvaluateData =
     mi::neuraylib::Bsdf_evaluate_data<mi::neuraylib::DF_HSM_NONE>;
 using BsdfPdfData = mi::neuraylib::Bsdf_pdf_data;
+using BsdfAuxiliaryData =
+    mi::neuraylib::Bsdf_auxiliary_data<mi::neuraylib::DF_HSM_NONE>;
 
 using BsdfIsThinWalled = bool(
     const ShadingStateMaterial *, const ResourceData *, const char *);
@@ -71,9 +73,9 @@ VISRTX_CALLABLE BsdfInitFunc mdlInit;
 VISRTX_CALLABLE BsdfSampleFunc mdlBsdf_sample;
 VISRTX_CALLABLE BsdfEvaluateFunc mdlBsdf_evaluate;
 VISRTX_CALLABLE BsdfPdfFunc mdlBsdf_pdf;
+VISRTX_CALLABLE BsdfAuxiliaryFunc mdlBsdf_auxiliary;
 VISRTX_CALLABLE BsdfIsThinWalled mdl_isThinWalled;
 
-VISRTX_CALLABLE TintExprFunc mdlTint;
 VISRTX_CALLABLE OpacityExprFunc mdlOpacity;
 VISRTX_CALLABLE TransmissionExprFunc mdlTransmission;
 VISRTX_CALLABLE EdfEvaluateFunc mdlEmission_evaluate;
@@ -241,11 +243,24 @@ NextRay __direct_callable__nextRay(
 }
 
 // Signature must match the call inside shaderMDLSurface in MDLShader.cuh.
+// Base color for the albedo AOV / denoiser guide: the BSDF auxiliary albedo
+// (diffuse + glossy) from the compiled material. Evaluated at normal incidence
+// (k1 = shading normal) so the guide is view-independent and stable across
+// samples.
 VISRTX_CALLABLE
 vec3 __direct_callable__evaluateTint(const MDLShadingState *shadingState)
 {
-  return mdlTint(
-      &shadingState->state, &shadingState->resData, shadingState->argBlock);
+  BsdfAuxiliaryData aux_data = {};
+  aux_data.ior1 = make_float3(1.0f, 1.0f, 1.0f);
+  aux_data.ior2.x = MI_NEURAYLIB_BSDF_USE_MATERIAL_IOR;
+  aux_data.k1 = shadingState->state.normal;
+
+  mdlBsdf_auxiliary(&aux_data,
+      &shadingState->state,
+      &shadingState->resData,
+      shadingState->argBlock);
+
+  return make_vec3(aux_data.albedo_diffuse) + make_vec3(aux_data.albedo_glossy);
 }
 
 VISRTX_CALLABLE

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -23,7 +23,6 @@
 #include <mi/neuraylib/imdl_backend_api.h>
 #include <mi/neuraylib/imdl_compiler.h>
 #include <mi/neuraylib/imdl_configuration.h>
-#include <mi/neuraylib/imdl_distiller_api.h>
 #include <mi/neuraylib/imdl_entity_resolver.h>
 #include <mi/neuraylib/imdl_execution_context.h>
 #include <mi/neuraylib/imdl_factory.h>
@@ -157,13 +156,6 @@ Core::Core(mi::neuraylib::INeuray *neuray, mi::base::ILogger *logger)
         res != 0) {
       logMessage(
           mi::base::MESSAGE_SEVERITY_WARNING, "Failed to load the dds plugin");
-    }
-
-    if (mi::Sint32 res = pluginConf->load_plugin_library(
-            "mdl_distiller" MI_BASE_DLL_FILE_EXT);
-        res != 0) {
-      logMessage(mi::base::MESSAGE_SEVERITY_WARNING,
-          "Failed to load the mdl_distiller plugin");
     }
 
     m_neuray->start();
@@ -489,23 +481,6 @@ mi::neuraylib::ICompiled_material *Core::getCompiledMaterial(
   return compiledMaterial;
 }
 
-mi::neuraylib::ICompiled_material *Core::getDistilledToDiffuse(
-    const mi::neuraylib::ICompiled_material *compiledMaterial)
-{
-  auto distiller_api = make_handle(
-      m_neuray->get_api_component<mi::neuraylib::IMdl_distiller_api>());
-  mi::Sint32 result = 0;
-  auto distilledMaterial = distiller_api->distill_material(
-      compiledMaterial, "diffuse", nullptr, &result);
-  if (result != 0) {
-    logMessage(mi::base::MESSAGE_SEVERITY_ERROR,
-        "Failed to distill material: %i\n",
-        result);
-  }
-
-  return distilledMaterial;
-}
-
 const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
     const mi::neuraylib::ICompiled_material *compiledMaterial,
     mi::neuraylib::ITransaction *transaction)
@@ -517,8 +492,6 @@ const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
       backendApi->get_backend(mi::neuraylib::IMdl_backend_api::MB_CUDA_PTX));
   auto executionContext =
       make_handle(m_mdlFactory->clone(m_executionContext.get()));
-
-  auto distilledMaterial = make_handle(getDistilledToDiffuse(compiledMaterial));
 
   ptxBackend->set_option(
       "num_texture_spaces", std::to_string(kNumTextureSpaces).c_str());
@@ -534,6 +507,10 @@ const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
   ptxBackend->set_option("inline_aggressively", "on");
   ptxBackend->set_option("opt_level", "2");
   ptxBackend->set_option("enable_exceptions", "off");
+  // Generate the BSDF auxiliary function (albedo + normal) so the albedo AOV /
+  // denoiser guide reads a faithful diffuse+glossy albedo straight from the
+  // compiled material, instead of distilling to a `diffuse` proxy.
+  ptxBackend->set_option("enable_auxiliary", "on");
 
   // Generate init, surface scattering, surface emission
   // (emission/intensity/mode), volume scattering and cutout opacity.
@@ -551,27 +528,16 @@ const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
       {"geometry.cutout_opacity", "mdlOpacity"},
   };
 
-  static mi::neuraylib::Target_function_description distilledFunctions[] = {
-      {"surface.scattering.tint", "mdlTint"},
-  };
-
   // Generate target code for the compiled material
   auto linkUnit = make_handle(
       ptxBackend->create_link_unit(transaction, executionContext.get()));
 
-  // Add main material functions (BSDF, emission, and auxiliary
-  // albedo/normal/roughness)
+  // Add main material functions. `surface.scattering` also emits the BSDF
+  // auxiliary function (mdlBsdf_auxiliary: albedo + normal) because
+  // enable_auxiliary is on.
   linkUnit->add_material(compiledMaterial,
       std::data(materialFunctions),
       std::size(materialFunctions),
-      executionContext.get());
-
-  if (!logExecutionContextMessages(executionContext.get()))
-    return {};
-
-  linkUnit->add_material(distilledMaterial.get(),
-      std::data(distilledFunctions),
-      std::size(distilledFunctions),
       executionContext.get());
 
   if (!logExecutionContextMessages(executionContext.get()))

--- a/devices/rtx/libmdl/Core.h
+++ b/devices/rtx/libmdl/Core.h
@@ -134,9 +134,6 @@ class Core
       const mi::neuraylib::IFunction_definition *,
       bool classCompilation = true);
 
-  mi::neuraylib::ICompiled_material *getDistilledToDiffuse(
-      const mi::neuraylib::ICompiled_material *compiledMaterial);
-
   const mi::neuraylib::ITarget_code *getPtxTargetCode(
       const mi::neuraylib::ICompiled_material *compiledMaterial,
       mi::neuraylib::ITransaction *transaction);

--- a/devices/rtx/libmdl/ptx.cpp
+++ b/devices/rtx/libmdl/ptx.cpp
@@ -12,11 +12,54 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 namespace visrtx::libmdl {
+
+namespace {
+
+// PTX `.version M.m` as a numeric (major, minor) key. `v` is the whole
+// directive (".version 8.5"), so scan to the first digit before parsing.
+// Lexicographic string compare would pick "8.5" over "10.0" ('8' > '1'); this
+// keeps the higher ISA.
+std::pair<int, int> ptxVersionKey(std::string_view v)
+{
+  auto isDigit = [](char c) { return std::isdigit(static_cast<unsigned char>(c)); };
+  auto it = std::find_if(cbegin(v), cend(v), isDigit);
+
+  int major = 0;
+  for (; it != cend(v) && isDigit(*it); ++it)
+    major = major * 10 + (*it - '0');
+
+  int minor = 0;
+  if (it != cend(v) && *it == '.')
+    for (++it; it != cend(v) && isDigit(*it); ++it)
+      minor = minor * 10 + (*it - '0');
+
+  return {major, minor};
+}
+
+// PTX `.target sm_NN[suffix]` as the numeric arch NN. Lexicographic string
+// compare would pick "sm_52" over "sm_100" ('5' > '1'); this keeps the higher
+// arch. Non-sm targets sort below any sm_ target.
+int ptxTargetKey(std::string_view t)
+{
+  static constexpr auto smPrefix = "sm_"sv;
+  auto pos = t.find(smPrefix);
+  if (pos == std::string_view::npos)
+    return -1;
+  int arch = 0;
+  for (pos += size(smPrefix);
+      pos < size(t) && std::isdigit(static_cast<unsigned char>(t[pos]));
+      ++pos)
+    arch = arch * 10 + (t[pos] - '0');
+  return arch;
+}
+
+} // namespace
 
 std::vector<char> stitchPTXs(
     nonstd::span<const nonstd::span<const char>> ptxBlobs)
@@ -61,10 +104,10 @@ std::vector<char> stitchPTXs(
         blob.erase(it, eolIt);
 
         if (dotkword == versionKw) { // .version
-          if (sub > version)
+          if (version.empty() || ptxVersionKey(sub) > ptxVersionKey(version))
             version = sub;
         } else if (dotkword == targetKw) { //.target
-          if (sub > target)
+          if (target.empty() || ptxTargetKey(sub) > ptxTargetKey(target))
             target = sub;
         }
       }

--- a/devices/rtx/libmdl/ptx.cpp
+++ b/devices/rtx/libmdl/ptx.cpp
@@ -27,7 +27,9 @@ namespace {
 // keeps the higher ISA.
 std::pair<int, int> ptxVersionKey(std::string_view v)
 {
-  auto isDigit = [](char c) { return std::isdigit(static_cast<unsigned char>(c)); };
+  auto isDigit = [](char c) {
+    return std::isdigit(static_cast<unsigned char>(c));
+  };
   auto it = std::find_if(cbegin(v), cend(v), isDigit);
 
   int major = 0;
@@ -84,6 +86,29 @@ std::vector<char> stitchPTXs(
   std::uint32_t infoStringBaseIndex = 0;
   // For disambiguating file ids
   std::uint32_t fileBaseIndex = 0;
+
+  // Debug line info (`.file`/`.loc`/`$L__info_string`) is only emitted under
+  // -lineinfo/-G. When absent, the renumbering passes below are pure overhead,
+  // so detect it once and skip them for release blobs. Match the bare `.file`
+  // directive (indented, tab-separated) exactly as the renumbering does — no
+  // PTX identifier can be `.file`, so this only hits the debug directive.
+  //
+  // Scan the bytes rather than infer from the CMake build type: (1) the build
+  // is Ninja Multi-Config, so the config (hence -lineinfo) is picked at build
+  // time, not configure time; (2) libmdl is standalone from the device and must
+  // not assume its build config; (3) one blob is the MDL backend's runtime PTX,
+  // whose debug info is governed by MDL exec-context options, not our CUDA
+  // flags. The scan is one pass, run once per target-code build — effectively
+  // free next to the multi-pass renumbering it gates.
+  static constexpr const auto dotFileKw = ".file"sv;
+  const bool hasDebugInfo =
+      std::any_of(std::cbegin(ptxBlobs), std::cend(ptxBlobs), [](const auto &s) {
+        return std::search(std::cbegin(s),
+                   std::cend(s),
+                   std::cbegin(dotFileKw),
+                   std::cend(dotFileKw))
+            != std::cend(s);
+      });
 
   for (const auto &s : ptxBlobs) {
     std::vector<char> blob(std::cbegin(s), std::cend(s));
@@ -223,79 +248,18 @@ std::vector<char> stitchPTXs(
       }
     }
 
-    // Only needed when we build the cuda code with -lineinfo or -G
-    // We don't know that here, so we proceed anyway.
-    // Ensure no duplicate info string for debug symbols
-    {
-      static constexpr const auto prefix = "$L__info_string"sv;
-      for (auto it = std::search(
-               begin(blob), end(blob), cbegin(prefix), cend(prefix));
-          it != end(blob);
-          it = std::search(it, end(blob), cbegin(prefix), cend(prefix))) {
-        it += size(prefix);
-        auto indexEndIt = std::find_if(
-            it, end(blob), [](char c) { return !std::isdigit(c); });
-        if (indexEndIt == end(blob))
-          break;
-
-        auto indexStr = std::string(it, indexEndIt);
-        auto index = std::stoi(indexStr);
-
-        int newIndex;
-        if (*indexEndIt == ':') {
-          newIndex = infoStringBaseIndex++;
-        } else {
-          newIndex = index + infoStringBaseIndex;
-        }
-
-        if (newIndex == index)
-          continue;
-
-        // Replace the index with the new one.
-        auto newIndexStr = std::to_string(newIndex);
-        if (size(newIndexStr) == size(indexStr)) {
-          // Same content, just copy the values
-          // Returned it points after the last copied element.
-          it = std::copy(cbegin(newIndexStr), cend(newIndexStr), it);
-        } else {
-          // Returned it points after the last removed element.
-          // Try and avoid calling erase + insert to move the data only once.
-          assert(size(newIndexStr) > size(indexStr));
-          it = std::copy_n(cbegin(newIndexStr), size(indexStr), it);
-          it = blob.insert(
-              it, cbegin(newIndexStr) + size(indexStr), cend(newIndexStr));
-        }
-      }
-    }
-
-    // Ensure no duplicate file ids for debug symbols
-    {
-      static constexpr const auto dotFilePrefix = ".file"sv;
-      static constexpr const auto dotLocPrefix = ".loc"sv;
-      static constexpr const auto inlinedAtPrefix = " inlined_at"sv;
-
-      // That's the slow code path of the stitching... Let's try and minimize
-      // the amount of traversal we need to do. Let's go with 3 linear
-      // traversal, one for each of the prefixes. WARNING: dotFilePrefix needs
-      // to be last, as it is the one that will compute the new file base index.
-      for (auto dotkword : {inlinedAtPrefix, dotLocPrefix, dotFilePrefix}) {
+    // Debug-only line-info renumbering (gated: see hasDebugInfo above).
+    if (hasDebugInfo) {
+      // Ensure no duplicate info string for debug symbols
+      {
+        static constexpr const auto prefix = "$L__info_string"sv;
         for (auto it = std::search(
-                 begin(blob), end(blob), cbegin(dotkword), cend(dotkword));
+                 begin(blob), end(blob), cbegin(prefix), cend(prefix));
             it != end(blob);
-            it = std::search(it, end(blob), cbegin(dotkword), cend(dotkword))) {
-          // Eat spaces prior to the actual index
-          it += size(dotkword);
-          if (!std::isspace(*it)) {
-            continue;
-          }
-          while (std::isspace(*it))
-            ++it;
-
-          // And go till the end of the current number
-          auto indexEndIt = it + 1;
-          while (std::isdigit(*indexEndIt))
-            ++indexEndIt;
-
+            it = std::search(it, end(blob), cbegin(prefix), cend(prefix))) {
+          it += size(prefix);
+          auto indexEndIt = std::find_if(
+              it, end(blob), [](char c) { return !std::isdigit(c); });
           if (indexEndIt == end(blob))
             break;
 
@@ -303,16 +267,14 @@ std::vector<char> stitchPTXs(
           auto index = std::stoi(indexStr);
 
           int newIndex;
-          if (dotkword == dotFilePrefix) {
-            newIndex = ++fileBaseIndex; // File indices starts at one, hence the
-                                        // pre-increment.
+          if (*indexEndIt == ':') {
+            newIndex = infoStringBaseIndex++;
           } else {
-            newIndex = index + fileBaseIndex;
+            newIndex = index + infoStringBaseIndex;
           }
 
-          if (newIndex == index) {
+          if (newIndex == index)
             continue;
-          }
 
           // Replace the index with the new one.
           auto newIndexStr = std::to_string(newIndex);
@@ -330,7 +292,74 @@ std::vector<char> stitchPTXs(
           }
         }
       }
-    }
+
+      // Ensure no duplicate file ids for debug symbols
+      {
+        static constexpr const auto dotFilePrefix = ".file"sv;
+        static constexpr const auto dotLocPrefix = ".loc"sv;
+        static constexpr const auto inlinedAtPrefix = " inlined_at"sv;
+
+        // That's the slow code path of the stitching... Let's try and minimize
+        // the amount of traversal we need to do. Let's go with 3 linear
+        // traversal, one for each of the prefixes. WARNING: dotFilePrefix needs
+        // to be last, as it is the one that will compute the new file base
+        // index.
+        for (auto dotkword : {inlinedAtPrefix, dotLocPrefix, dotFilePrefix}) {
+          for (auto it = std::search(
+                   begin(blob), end(blob), cbegin(dotkword), cend(dotkword));
+              it != end(blob);
+              it = std::search(
+                  it, end(blob), cbegin(dotkword), cend(dotkword))) {
+            // Eat spaces prior to the actual index
+            it += size(dotkword);
+            if (!std::isspace(*it)) {
+              continue;
+            }
+            while (std::isspace(*it))
+              ++it;
+
+            // And go till the end of the current number
+            auto indexEndIt = it + 1;
+            while (std::isdigit(*indexEndIt))
+              ++indexEndIt;
+
+            if (indexEndIt == end(blob))
+              break;
+
+            auto indexStr = std::string(it, indexEndIt);
+            auto index = std::stoi(indexStr);
+
+            int newIndex;
+            if (dotkword == dotFilePrefix) {
+              newIndex = ++fileBaseIndex; // File indices starts at one, hence
+                                          // the pre-increment.
+            } else {
+              newIndex = index + fileBaseIndex;
+            }
+
+            if (newIndex == index) {
+              continue;
+            }
+
+            // Replace the index with the new one.
+            auto newIndexStr = std::to_string(newIndex);
+            if (size(newIndexStr) == size(indexStr)) {
+              // Same content, just copy the values
+              // Returned it points after the last copied element.
+              it = std::copy(cbegin(newIndexStr), cend(newIndexStr), it);
+            } else {
+              // Returned it points after the last removed element.
+              // Try and avoid calling erase + insert to move the data only
+              // once.
+              assert(size(newIndexStr) > size(indexStr));
+              it = std::copy_n(cbegin(newIndexStr), size(indexStr), it);
+              it = blob.insert(
+                  it, cbegin(newIndexStr) + size(indexStr), cend(newIndexStr));
+            }
+          }
+        }
+      }
+    } // if (hasDebugInfo)
 
     fixedBlobs.push_back(std::move(blob));
     totalSize += size(s);

--- a/tsd/src/tsd/io/CMakeLists.txt
+++ b/tsd/src/tsd/io/CMakeLists.txt
@@ -150,10 +150,6 @@ endif()
 if (TSD_USE_USD)
   find_package(OpenGL)
   find_package(X11)
-  # Resolve MaterialX before pxr so its config is shared. A bare, failing
-  # find_package would cache MaterialX_DIR=NOTFOUND and block pxrConfig's own
-  # find_dependency(MaterialX) fallback.
-  find_package(MaterialX 1.39 CONFIG REQUIRED)
   find_package(pxr REQUIRED sdf usd usdGeom tf gf usdShade usdLux)
   project_compile_definitions(PRIVATE -DTSD_USE_USD=1)
   project_link_libraries(PRIVATE ${PXR_LIBRARIES})


### PR DESCRIPTION
- Dropping distilling in favor of MDL auxilliary expressions
- Fix possibly invalid version sorting when stitching PTXs
- Only trigger debug renumber if actual debug information when stitching
- Fix a TSD hard error with find_package(pxr) when MaterialX is not found