### PR TITLE
docs: dedupe and refresh agent guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,23 +40,14 @@ cmake --install .
 | `VISRTX_BUILD_RTX_DEVICE` | ON | OptiX/CUDA ray-tracing device |
 | `VISRTX_BUILD_GL_DEVICE` | ON | OpenGL 4.3/GLES 3.2 device |
 | `VISRTX_BUILD_TSD` | OFF | TSD testing applications |
-| `VISRTX_ENABLE_MDL_SUPPORT` | - | NVIDIA MDL material support |
-| `VISRTX_ENABLE_NEURAL` | - | Neural Graphics Primitives |
-| `VISRTX_ENABLE_NVTX` | - | NVTX profiling |
 
-TSD has its own set of options (when `VISRTX_BUILD_TSD=ON`):
-
-```text
-TSD_BUILD_APPS, TSD_BUILD_INTERACTIVE_APPS, TSD_BUILD_UI_LIBRARY,
-TSD_USE_CUDA, TSD_USE_ASSIMP, TSD_USE_HDF5, TSD_USE_MPI,
-TSD_USE_NETWORKING, TSD_USE_LUA, TSD_USE_VTK, TSD_USE_SILO, TSD_USE_USD
-```
-
-OptiX version can be pinned via `OPTIX_FETCH_VERSION` (supports 7.7, 8.0, 8.1, 9.0).
+Component-specific options (MDL, Neural, NVTX, OptiX pinning, `TSD_USE_*`) are
+documented in the subtree AGENTS.md files: [devices/rtx/AGENTS.md](devices/rtx/AGENTS.md),
+[tsd/AGENTS.md](tsd/AGENTS.md).
 
 ## Tests
 
-TSD contains unit tests; run them with:
+Run from the build dir:
 
 ```bash
 ctest -C Release --output-on-failure
@@ -64,7 +55,7 @@ ctest -C Release --output-on-failure
 ctest -C Release -R <test_name> --output-on-failure
 ```
 
-Test sources are in `tsd/tests/`.
+Test sources: `tsd/tests/` (TSD unit tests), `devices/rtx/apps/tests/api/` (RTX API tests). `ctest -N` lists the current set.
 
 ## Code Style
 
@@ -88,39 +79,6 @@ Both devices implement the ANARI C API and are installed as shared libraries loa
 
 ### TSD: Testing Scene Description (`tsd/`)
 
-TSD is explicitly **experimental**. It has no API stability guarantees. It is educational and for testing ANARI devices, not a production pipeline.
+TSD is explicitly **experimental**. It has no API stability guarantees. It is educational and for testing ANARI devices, not a production pipeline. It maintains its own scene graph that mirrors ANARI object state (editing, serialization, networking without device coupling), layered libraries from `tsd_core` up to `tsd_app`, and apps (`tsdViewer`, `tsdRender`, `tsdLua`, …).
 
-**Core libraries** (always built):
-
-- `tsd_core`: Foundational types: `Any`, `Token`, `ObjectPool`, `DataTree`, logging
-- `tsd_scene`: ANARI-mirrored scene graph with layers (instancing forest), keyframe animation, and an `UpdateDelegate` notification interface
-- `tsd_io`: 30+ file format importers/exporters and procedural generators
-- `tsd_rendering`: `RenderIndex` (TSD/ANARI sync), `ImagePipeline` (composable render passes), camera tools
-- `tsd_app`: `ANARIDeviceManager`, CLI parsing, application context bundling
-- `anari_tsd`: ANARI device that mirrors state back into TSD scenes
-
-**Optional libraries**:
-
-- `tsd_ui_imgui`: ImGui-based UI framework used by interactive apps
-- `tsd_mpi`: MPI distributed state synchronization
-- `tsd_network`: Boost.Asio client/server scene streaming
-- `tsd_lua`: Lua 5.4 scripting with full TSD scene bindings (auto-fetches Lua + Sol3)
-
-**Applications** (`tsd/apps/`):
-
-- `tsdViewer`: Primary interactive viewer (ImGui, multi-device, layer editing)
-- `tsdRender` / `tsdOffline`: CLI/headless renderers
-- `tsdLua`: Lua REPL/interpreter for scene scripting
-- `mpiViewer`, `tsdRemoteViewer`/`tsdServer`: Distributed/networked variants
-
-### Key Design Patterns
-
-- **ANARI mirroring**: TSD maintains its own scene graph that mirrors ANARI object state, enabling editing, serialization, and networking without being tied to device internals.
-- **UpdateDelegate**: `BaseUpdateDelegate` is the notification interface between scene mutations and consumers (renderer, network, UI). Subclass this to react to scene changes.
-- **RenderIndex**: Responsible for translating TSD scene state into live ANARI world/object handles. This is the bridge between TSD and actual rendering.
-- **ImagePipeline**: Composable pipeline of render passes; the standard chain is ANARI render -> composite (multi-device) -> picking -> AOV visualization.
-- **CLI import routing**: Applications use a `-[format] file` pattern (e.g., `-obj mesh.obj`, `-vti vol.vti`) dispatched through `tsd_io` importers.
-
-### Environment Variables
-
-- `TSD_ANARI_LIBRARIES`: Colon-separated list of ANARI device libraries shown in the UI device selector.
+Full library layering, design patterns, env vars: [tsd/AGENTS.md](tsd/AGENTS.md).

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -16,8 +16,10 @@ See [`tsd/STYLEGUIDE.md`](tsd/STYLEGUIDE.md) for TSD-specific addenda.
   ```
 - **Line length**: 80–100 characters. Longer lines are acceptable when breaking
   would harm readability (e.g., long string literals, complex template signatures).
-- **Brace style**: opening brace on the same line (K&R style) for all constructs —
-  functions, classes, `if`/`else`, loops.
+- **Brace style** (set by `.clang-format`, mixed): opening brace on its **own
+  line** for classes/structs, enums, and function definitions; on the **same
+  line** for control statements (`if`/`else`, loops), namespaces, and
+  `extern "C"` blocks.
 - **`clang-format` overrides**: use `// clang-format off` / `// clang-format on`
   sparingly — only for data tables, enum lists, or structured blocks where
   column alignment would otherwise be destroyed.
@@ -85,15 +87,18 @@ Order within a class/struct body:
 6. `private` data members
 
 **Method definitions are never written inside the class/struct body** — even
-trivial one-liners. All definitions (inline, `constexpr`, and template) go in a
-clearly delimited section *after* the class declaration:
+trivial one-liners. Sole exception: a truly empty body (`{}`), including
+constructors that are only a member-init list, may stay inline. All other
+definitions (inline, `constexpr`, and template) go in a clearly delimited
+section *after* the class declaration:
 
 ```cpp
-struct Foo {
+struct Foo
+{
   int bar() const;
   void setBaz(int v);
   // ...
-private:
+ private:
   int m_bar{0};
 };
 
@@ -122,12 +127,15 @@ implementation detail below.
   - `std::shared_ptr<T>` for shared ownership (use sparingly).
 - Non-owning references use raw pointers or project-specific ref wrappers
   (`ObjectPoolRef<T>`).
-- Express copy/move intent explicitly with the macros defined in
-  `TypeMacros.hpp`:
+- Express copy/move intent explicitly. In TSD-layer code, use the macros from
+  `tsd/core/TypeMacros.hpp` rather than hand-rolled `= delete`/`= default`
+  lists:
   ```cpp
   TSD_NOT_COPYABLE(MyClass)
   TSD_DEFAULT_MOVEABLE(MyClass)
   ```
+  (Device code under `devices/` has no TSD dependency — spell intent with
+  explicit `= delete`/`= default` there.)
 - RAII everywhere — resources are owned and released by objects, never managed
   manually.
 
@@ -180,7 +188,7 @@ Avoid features that obscure intent or have poor tooling support.
 - Use `static_assert` to enforce template parameter constraints early, with a
   clear diagnostic message.
 - Avoid CRTP unless virtual dispatch is genuinely unacceptable for performance.
-  Prefer virtual inheritance for most extensibility patterns.
+  Prefer virtual functions (see §13) for most extensibility patterns.
 
 ---
 
@@ -228,7 +236,8 @@ hooks** subclasses must implement, and optional virtual hooks with default
 no-op bodies. Prefer this over CRTP (see §10).
 
 ```cpp
-struct ImagePass {
+struct ImagePass
+{
   // public non-virtual API driven by the owner
   void setEnabled(bool e);
   virtual const char *name() const = 0;

--- a/devices/rtx/AGENTS.md
+++ b/devices/rtx/AGENTS.md
@@ -10,34 +10,23 @@ The `devices/rtx/` subdirectory contains the OptiX-based GPU ray-tracing ANARI d
 ## Domain Docs
 
 - [`CONTEXT-MAP.md`](./CONTEXT-MAP.md) — bounded contexts and how they relate; each context has its own `CONTEXT.md` glossary ([Frontend](./device/CONTEXT.md), [Render Pipeline](./device/renderer/CONTEXT.md), [World](./device/world/CONTEXT.md), [MDL](./libmdl/CONTEXT.md)). Use these terms in code and docs.
-- [`docs/adr/`](./docs/adr/) — architecture decision records (callable-based shading, pipeline-per-renderer, embedded PTX, split surface/volume TLAS). Read before "fixing" any of these designs.
+- [`docs/adr/`](./docs/adr/) — architecture decision records. Scan the directory and read the relevant one before "fixing" a design it locks in.
 
 ## Build
 
-```bash
-mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/path/to/install \
-      -DCMAKE_PREFIX_PATH="/path/to/anari-sdk;/path/to/optix" \
-      /path/to/visrtx
-cmake --build . --parallel
-cmake --install .
-```
+Built as part of the repository build — see the repo-root [AGENTS.md](../../AGENTS.md). `CMAKE_PREFIX_PATH` must locate the ANARI-SDK and OptiX.
 
 Key device-specific CMake options:
 
 - `VISRTX_ENABLE_MDL_SUPPORT`: NVIDIA MDL materials (requires MDL SDK)
+- `VISRTX_ENABLE_MATERIALX_SUPPORT`: MaterialX materials
 - `VISRTX_ENABLE_NEURAL`: Neural Graphics Primitives (requires OptiX 9.0+)
 - `VISRTX_ENABLE_NVTX`: NVTX profiling markers
 - `OPTIX_FETCH_VERSION`: Pin OptiX version: `7.7`, `8.0`, `8.1`, or `9.0`
 
 ## Tests
 
-```bash
-ctest -C Release --output-on-failure
-ctest -C Release -R TestSpheres --output-on-failure
-```
-
-Test sources: `apps/tests/api/`
+Test sources: `apps/tests/api/` (e.g. `ctest -C Release -R TestSpheres`). Run via ctest — see the repo-root [AGENTS.md](../../AGENTS.md).
 
 ## Architecture
 
@@ -75,13 +64,13 @@ Arrays (`Array1D`, `Array2D`, `Array3D`) use `HostDeviceArray` or deferred uploa
 
 Each renderer has its own OptiX pipeline. Material and spatial-field shaders are implemented as **OptiX callable programs** so the renderer pipeline does not need to be recompiled when materials change.
 
-SBT callable slots per material type (8 slots each):
+SBT callable slots per material type (one per `SurfaceShaderEntryPoints` value; `device/gpu/sbt.h` is authoritative):
 
-- `Initialize`, `EvaluateNextRay`, `EvaluateTint`, `EvaluateOpacity`, `EvaluateEmission`, `EvaluateTransmission`, `EvaluateNormal`, `Shade`
+- `Initialize`, `EvaluateNextRay`, `EvaluateTint`, `EvaluateOpacity`, `EvaluateEmission`, `EvaluateTransmission`, `EvaluateNormal`, `Shade`, `EvaluatePdf`
 
 `MaterialGPUData::callableBaseIndex` holds the offset into the callable table. Kernels dispatch shading via `optixDirectCall(callableBaseIndex + SHADE_FN, ...)`.
 
-Spatial field samplers also use callables (`Init`, `Sample`).
+Spatial field samplers also use callables (`SpatialFieldSamplerEntryPoints`): every field family provides the Woodcock-loop bodies `SampleDistance`, `RatioTrackTransmittance`, `RayMarchVolume`; custom fields add `Init`/`SampleValue`/`SampleNormal`, dispatched callable-in-callable from those loop bodies (built-in families sample inline via ADL instead).
 
 ### Material Parameter Indirection
 
@@ -122,7 +111,7 @@ After rebuild, `OptixTraversableHandle`s are stored in `WorldGPUData` and passed
 |---------|----------------|
 | `fast` | Ambient occlusion, one direct-light sample; real-time |
 | `quality` | Full Monte Carlo path tracing, configurable max depth |
-| `interactive` | Adaptive sampling with adaptive AO; responsive preview |
+| `interactive` (aka `default`) | Adaptive sampling with adaptive AO; responsive preview |
 | `debug` | Geometry diagnostics (normals, positions, IDs, etc.) |
 | `test` | Minimal renderer for validation tests |
 

--- a/devices/rtx/CONTEXT-MAP.md
+++ b/devices/rtx/CONTEXT-MAP.md
@@ -23,7 +23,9 @@
   Pipeline; the pipeline traces against them but never builds them.
 - **Frontend → MDL**: the `mdl` material subtype delegates compilation to MDL;
   the Frontend owns the ANARI-facing Material, MDL owns everything from
-  definition to target code.
+  definition to target code. The `materialx` subtype rides the same path: the
+  Frontend resolves the MaterialX documents (see the Frontend context's Search
+  Chain) and generates an MDL Material Definition, then delegates to MDL.
 - **MDL → Render Pipeline**: Compiled Materials link into renderer pipelines
   as PTX callable modules, indistinguishable from built-in Material Shaders at
   dispatch time.

--- a/devices/rtx/libmdl/CONTEXT.md
+++ b/devices/rtx/libmdl/CONTEXT.md
@@ -27,3 +27,25 @@ A descriptor defines its layout; an instance holds actual values.
 **Texture Runtime**:
 The texture access machinery Target Code calls at shading time.
 _Avoid_: sampler (see the Frontend context)
+
+**Emission Classifier**:
+The MDL-pure analysis that lowers a Compiled Material's emission expressions
+into Emission IR and folds them into an Emission Descriptor. It describes;
+it never decides light registration (that is the renderer-side policy, see
+ADR-0007).
+_Avoid_: deciding registration in the classifier
+
+**Emission IR**:
+The owned lowering of the MDL emission expression DAG (constants, parameters,
+calls, textures) the classifier folds over. Retains no MDL-SDK expression
+pointers.
+
+**Emission Descriptor**:
+The immutable per-material output of the Emission Classifier: per-slot
+`{verdict, edfKinds, magnitude, intensity mode}` plus the argument/resource
+dependencies the emission reads.
+
+**Faithful Set**:
+The consumer-exported set of EDF kinds a renderer can evaluate faithfully on
+its synthetic next-event hit (`kFaithfulSet`). A described slot registers as a
+Geometry Light only when its EDF kinds are a subset of it.

--- a/tsd/AGENTS.md
+++ b/tsd/AGENTS.md
@@ -8,6 +8,15 @@ TSD ("Testing Scene Description") is an **experimental** C++17 scene graph and t
 
 See [STYLEGUIDE.md](STYLEGUIDE.md) for TSD-specific and project-wide C++ coding conventions.
 
+## Domain Docs
+
+Each area keeps a `CONTEXT.md` glossary. Use these terms in code and docs:
+
+- [src/tsd/io/CONTEXT.md](src/tsd/io/CONTEXT.md) — Archives, serialization verbs, import/export vocabulary
+- [src/tsd/app/CONTEXT.md](src/tsd/app/CONTEXT.md) — Application Dumps and app-level state
+- [src/tsd/rendering/CONTEXT.md](src/tsd/rendering/CONTEXT.md) — Image Pipeline / Image Pass / render-index vocabulary
+- [apps/interactive/scivisStudio/CONTEXT.md](apps/interactive/scivisStudio/CONTEXT.md) — SciVis Studio Projects and shots
+
 ## Build
 
 TSD can be built standalone (without the VisRTX devices) or as part of VisRTX.
@@ -32,12 +41,7 @@ Key optional CMake flags: `TSD_USE_LUA`, `TSD_USE_ASSIMP`, `TSD_USE_HDF5`, `TSD_
 
 ## Tests
 
-```bash
-ctest -C Release --output-on-failure
-ctest -C Release -R test_Forest --output-on-failure
-```
-
-Test sources in `tests/`: `test_Array`, `test_DataTree`, `test_FlatMap`, `test_Forest`, `test_Geometry`, `test_Material`, `test_Math`, `test_Object`, `test_ObjectPool`, `test_ObjectUsePtr`, `test_Parameter`, `test_Token`.
+Test sources: `tests/` (one `test_*.cpp` per suite, e.g. `ctest -C Release -R test_Forest`). Run via ctest — see the repo-root [AGENTS.md](../AGENTS.md).
 
 ## Architecture
 
@@ -51,7 +55,7 @@ tsd_core  ->  tsd_scene  ->  tsd_io  ->  tsd_rendering  ->  tsd_app
 
 - **`tsd_core`** (`src/tsd/core/`): `Any`, `Token`, `ObjectPool`, `FlatMap`, `Forest`, `DataTree`/`DataStream` (serialization), `TaskQueue`, logging. No scene concepts.
 - **`tsd_scene`** (`src/tsd/scene/`): `Scene`, `Object`, `Parameter`, `Layer`/`Forest` (instancing), `Animation`, `UpdateDelegate`. Mirrors ANARI's object hierarchy.
-- **`tsd_io`** (`src/tsd/io/`): 20+ file format importers (OBJ, GLTF, PLY, USD, VTK, ASSIMP, etc.), volume importers (RAW, NanoVDB, VTI), procedural generators, and TSD scene serialization.
+- **`tsd_io`** (`src/tsd/io/`): 30+ file format importers (OBJ, GLTF, PLY, USD, VTK, ASSIMP, etc.), volume importers (RAW, NanoVDB, VTI), procedural generators, and TSD scene serialization.
 - **`tsd_rendering`** (`src/tsd/rendering/`): `RenderIndex` (TSD-to-ANARI sync), `ImagePipeline` (composable render passes), camera manipulators.
 - **`tsd_app`** (`src/tsd/app/`): `ANARIDeviceManager`, `Context` (bundles scene + render index + pipeline), CLI parsing, `renderAnimationSequence`.
 - **`anari_tsd`** (`src/anari_tsd/`): ANARI device implementation that mirrors ANARI state into a TSD scene; writes `live_capture.tsd` on each committed frame.

--- a/tsd/STYLEGUIDE.md
+++ b/tsd/STYLEGUIDE.md
@@ -193,28 +193,3 @@ without TBB) — never call TBB directly.
   methods use `camelCase` (`isLeaf`, `numChildren`). This split is deliberate.
 - Use the `INVALID_INDEX` sentinel (`core/ObjectPool.hpp`) for absent indices;
   prefer the `TSD_INVALID_INDEX` macro alias at call sites.
-
----
-
-## Inline Method Definitions
-
-Method bodies must **not** appear inside a `class` or `struct` declaration,
-with one exception: a truly empty body (`{}`) is allowed inline.
-
-All other inline definitions go below all other declarations in the file, under
-a single-line comment section:
-
-```cpp
-struct Foo
-{
-  int value() const;         // declaration only
-  void noop() override {}    // OK — empty body, allowed inline
-};
-
-// Inlined definitions ////////////////////////////////////////////////////////
-
-inline int Foo::value() const
-{
-  return m_value;
-}
-```


### PR DESCRIPTION
Duplicated guidance was drifting; several facts had gone stale.

- Root AGENTS.md is the sole source for ctest + VISRTX_BUILD_*; subtrees link to it, keeping component flags only
- rtx: SBT entries match sbt.h; stop enumerating ADRs; interactive is the default renderer
- tsd: link the CONTEXT.md glossaries; 30+ importers
- libmdl CONTEXT.md: ADR-0007 emission vocabulary
- CONTEXT-MAP: materialx rides the MDL path
- STYLEGUIDE: drop tsd duplicate; brace rule matches .clang-format; TSD_* lifetime macros scoped to TSD-layer code