### PR TITLE
ci: speed up and harden GitHub Actions workflows

### DIFF
--- a/.github/actions/build-anari-sdk/action.yml
+++ b/.github/actions/build-anari-sdk/action.yml
@@ -22,12 +22,37 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # Resolve the live upstream commit so the cache invalidates when the tracked
+    # branch moves — build_deps pulls a branch zip whose local files never change.
+    # The branch is derived from the build_deps URL itself so there is a single
+    # source of truth: change the URL and the cache key follows.
+    - name: Resolve ANARI-SDK commit
+      id: resolve-sha
+      shell: bash
+      run: |
+        cmakelists="${{ github.workspace }}/${{ inputs.build-deps-path }}/CMakeLists.txt"
+        ref=$(grep -oE 'ANARI-SDK/archive/refs/heads/[^"]+\.zip' "$cmakelists" \
+          | sed -E 's#.*refs/heads/(.+)\.zip#\1#')
+        if [ -z "$ref" ]; then
+          echo "Could not derive ANARI-SDK branch from $cmakelists" >&2
+          exit 1
+        fi
+        sha=$(git ls-remote https://github.com/KhronosGroup/ANARI-SDK "refs/heads/$ref" | cut -f1)
+        if [ -z "$sha" ]; then
+          echo "Failed to resolve ANARI-SDK '$ref' commit" >&2
+          exit 1
+        fi
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        # Slug of the build_deps path guards the key so rtx/tsd never share an
+        # entry if their build_deps diverge (Actions expressions lack replace()).
+        echo "slug=$(echo '${{ inputs.build-deps-path }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
     - name: Cache ANARI-SDK
       uses: actions/cache@v4
       id: cache-anari
       with:
         path: ${{ inputs.install-prefix }}
-        key: anari-sdk-${{ runner.os }}-${{ inputs.config }}-${{ inputs.generator || 'default' }}-${{ hashFiles('**/build_deps/CMakeLists.txt', '**/build_deps/superbuild_macros.cmake') }}
+        key: anari-sdk-${{ runner.os }}-${{ inputs.config }}-${{ steps.resolve-sha.outputs.slug }}-${{ steps.resolve-sha.outputs.sha }}
 
     - name: Configure ANARI-SDK CMake (with generator)
       if: steps.cache-anari.outputs.cache-hit != 'true' && inputs.generator != ''

--- a/.github/workflows/build-tsd.yml
+++ b/.github/workflows/build-tsd.yml
@@ -14,6 +14,11 @@ on:
       - '.github/actions/**'
       - '.github/workflows/build-tsd.yml'
 
+# Cancel superseded PR runs; let next_release pushes finish (green history).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}
@@ -28,14 +33,26 @@ jobs:
           - os: windows
             runs-on: windows-2022
             generator: Ninja
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_GHA_ENABLED: "false"
     steps:
     - uses: actions/checkout@v6
     - name: Setup MSVC (Windows)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
     - name: Install Packages
       if: ${{ matrix.os == 'linux' }}
       run: sudo apt install -y libtbb-dev
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@d651010b8da762cde178750d8eda7b5febfe147a # v0.0.9
+    - name: Restore sccache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsd-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
+        restore-keys: |
+          sccache-tsd-${{ runner.os }}-${{ matrix.config }}-
     - name: Build ANARI-SDK
       uses: ./.github/actions/build-anari-sdk
       with:
@@ -48,6 +65,9 @@ jobs:
         cmake -LA -G Ninja -B ${{github.workspace}}/build
         -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
         -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+        -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
         -DTSD_BUILD_APPS=ON
         -DTSD_BUILD_INTERACTIVE_APPS=OFF
         -DTSD_BUILD_UI_LIBRARY=OFF
@@ -64,6 +84,14 @@ jobs:
     - name: Unit Tests
       working-directory: ${{  github.workspace }}/build
       run: ctest -C ${{ matrix.config }} --output-on-failure
+    - name: sccache stats
+      run: sccache --show-stats
+    - name: Save sccache
+      if: success() && github.event_name == 'push'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsd-${{ runner.os }}-${{ matrix.config }}-${{ github.sha }}
 
   build-cuda:
     runs-on: ${{ matrix.runs-on }}
@@ -79,11 +107,14 @@ jobs:
           - os: windows
             runs-on: windows-2022
             generator: Ninja
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_GHA_ENABLED: "false"
     steps:
     - uses: actions/checkout@v6
     - name: Setup MSVC (Windows)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
     - name: Setup CUDA Toolkit
       uses: ./.github/actions/setup-cuda
       with:
@@ -91,6 +122,15 @@ jobs:
     - name: Install Packages
       if: ${{ matrix.os == 'linux' }}
       run: sudo apt install -y libtbb-dev
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@d651010b8da762cde178750d8eda7b5febfe147a # v0.0.9
+    - name: Restore sccache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsd-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}
+        restore-keys: |
+          sccache-tsd-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-
     - name: Build ANARI-SDK
       uses: ./.github/actions/build-anari-sdk
       with:
@@ -103,6 +143,10 @@ jobs:
         cmake -LA -G Ninja -B ${{github.workspace}}/build-tsd
         -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
         -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache
+        -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+        -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
         -DTSD_BUILD_APPS=ON
         -DTSD_BUILD_INTERACTIVE_APPS=OFF
         -DTSD_BUILD_UI_LIBRARY=OFF
@@ -116,3 +160,11 @@ jobs:
         ${{ github.workspace }}/tsd
     - name: Build TSD (CUDA)
       run: cmake --build ${{ github.workspace }}/build-tsd --config ${{ matrix.config }} --parallel
+    - name: sccache stats
+      run: sccache --show-stats
+    - name: Save sccache
+      if: success() && github.event_name == 'push'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-tsd-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}

--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -13,6 +13,11 @@ on:
       - '.github/actions/**'
       - '.github/workflows/build-visrtx.yml'
 
+# Cancel superseded PR runs; let next_release pushes finish (green history).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:
@@ -29,16 +34,28 @@ jobs:
             runs-on: windows-2022
             generator: Ninja
     runs-on: ${{ matrix.runs-on }}
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
       - name: Setup CUDA Toolkit
         uses: ./.github/actions/setup-cuda
         with:
           cuda-version: ${{ matrix.cudaversion }}
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@d651010b8da762cde178750d8eda7b5febfe147a # v0.0.9
+      - name: Restore sccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}
+          restore-keys: |
+            sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-
       - name: Build ANARI-SDK
         uses: ./.github/actions/build-anari-sdk
         with:
@@ -52,6 +69,10 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
           -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache
+          -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+          -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
           -DVISRTX_BUILD_RTX_DEVICE=ON
           -DVISRTX_PRECOMPILE_SHADERS=OFF
           -DVISRTX_BUILD_GL_DEVICE=OFF
@@ -59,3 +80,11 @@ jobs:
       - name: Install VisRTX
         run: >
           cmake --build ${{ github.workspace }}/build-visrtx --config ${{ matrix.config }} --target install --parallel
+      - name: sccache stats
+        run: sccache --show-stats
+      - name: Save sccache
+        if: success() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}


### PR DESCRIPTION
- ANARI-SDK cache keyed on live upstream commit + build_deps path slug; solves invalid cache reuse on ANARI-SDK update 
- sccache for project C++/CUDA sources; restore-only on PRs, written only on next_release pushes
- concurrency cancels superseded PR runs
- SHA-pin third-party actions (msvc-dev-cmd, sccache-action)