### PR TITLE
fix(denoiser): share full-frame average color across tiles

### DIFF
--- a/devices/rtx/device/frame/Denoiser.cu
+++ b/devices/rtx/device/frame/Denoiser.cu
@@ -75,13 +75,16 @@ void Denoiser::setup(uvec2 size,
   m_tileH = std::min<uint32_t>(kMaxTile, size.y);
 
   OptixDenoiserSizes sizes;
-  OPTIX_CHECK(
-      optixDenoiserComputeMemoryResources(m_denoiser, m_tileW, m_tileH, &sizes));
+  OPTIX_CHECK(optixDenoiserComputeMemoryResources(
+      m_denoiser, m_tileW, m_tileH, &sizes));
 
   m_overlap = sizes.overlapWindowSizeInPixels;
   m_state.reserve(sizes.stateSizeInBytes);
-  m_scratch.reserve(sizes.withOverlapScratchSizeInBytes);
+  m_scratch.reserve(std::max(sizes.withOverlapScratchSizeInBytes,
+      std::max(sizes.computeIntensitySizeInBytes,
+          sizes.computeAverageColorSizeInBytes)));
   m_intensity.reserve(sizeof(float));
+  m_averageColor.reserve(3 * sizeof(float));
 
   if (format != ANARI_FLOAT32_VEC4)
     m_uintPixels.resize(size_t(size.x) * size_t(size.y));
@@ -133,9 +136,9 @@ void Denoiser::launch()
 {
   auto &state = *deviceState();
 
-  // Tiled invoke normalizes each tile independently unless handed a
-  // whole-frame HDR intensity; without it adjacent tiles self-expose and seam.
-  // Compute one average log intensity over the full input and share it.
+  // Tiled invoke normalizes each tile independently unless handed whole-frame
+  // HDR exposure values. Compute them over the full input and share them so
+  // adjacent tiles do not self-expose and seam.
   OPTIX_CHECK(optixDenoiserComputeIntensity(m_denoiser,
       state.stream,
       &m_layer.input,
@@ -143,6 +146,14 @@ void Denoiser::launch()
       (CUdeviceptr)m_scratch.ptr(),
       m_scratch.bytes()));
   m_params.hdrIntensity = (CUdeviceptr)m_intensity.ptr();
+
+  OPTIX_CHECK(optixDenoiserComputeAverageColor(m_denoiser,
+      state.stream,
+      &m_layer.input,
+      (CUdeviceptr)m_averageColor.ptr(),
+      (CUdeviceptr)m_scratch.ptr(),
+      m_scratch.bytes()));
+  m_params.hdrAverageColor = (CUdeviceptr)m_averageColor.ptr();
 
   instrument::rangePush("optixDenoiserInvoke()");
   OPTIX_CHECK(optixUtilDenoiserInvokeTiled(m_denoiser,

--- a/devices/rtx/device/frame/Denoiser.h
+++ b/devices/rtx/device/frame/Denoiser.h
@@ -72,6 +72,7 @@ struct Denoiser : public Object
   DeviceBuffer m_state;
   DeviceBuffer m_scratch;
   DeviceBuffer m_intensity; // whole-frame HDR autoexposure, shared by all tiles
+  DeviceBuffer m_averageColor; // whole-frame AOV exposure, shared by all tiles
   uint32_t m_tileW{0};
   uint32_t m_tileH{0};
   uint32_t m_overlap{0};


### PR DESCRIPTION
Compute optixDenoiserComputeAverageColor over full input and pass hdrAverageColor to tiled invoke, matching the existing shared hdrIntensity.
Prevents adjacent tiles from self-exposing and seaming. Grow scratch buffer to cover the new compute requirements.