### PR TITLE
rtx: make minimum SM a declared knob, MDL follows it, defaulting to virtual targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ repository build.
 
 ### Requirements
 
-- CMake 3.17+, C++17 compiler, NVIDIA Driver 530+
+- CMake 3.17+, C++17 compiler, NVIDIA Driver 530+, GPU of compute capability 5.0+
 - CUDA 12+ (for RTX device), ANARI-SDK 0.15.0+
 
 ### Basic Build

--- a/devices/rtx/AGENTS.md
+++ b/devices/rtx/AGENTS.md
@@ -23,6 +23,19 @@ Key device-specific CMake options:
 - `VISRTX_ENABLE_NEURAL`: Neural Graphics Primitives (requires OptiX 9.0+)
 - `VISRTX_ENABLE_NVTX`: NVTX profiling markers
 - `OPTIX_FETCH_VERSION`: Pin OptiX version: `7.7`, `8.0`, `8.1`, or `9.0`
+- `VISRTX_MIN_ARCH`: Minimum compute capability (default `50`, or `75` under
+  CUDA 13, which dropped pre-Turing codegen — an explicit floor below `75` there
+  is a configure error). Single source for the host kernel PTX target, the OptiX
+  module PTX target, and the MDL backend's `sm_version`. The host kernels and
+  the OptiX module both target `compute_<MIN_ARCH>` (PTX, JIT-compiled by the
+  driver/OptiX to the actual GPU at launch); the MDL backend instead picks the
+  highest entry its fixed `sm_version` set offers at or below the floor, so a
+  floor with no exact match (e.g. `89` → `86`) rounds down — safe, since lower
+  SM PTX runs on newer GPUs. `VISRTX_ENABLE_NEURAL` raises the floor to at least
+  `89` (cooperative vectors need Ada). Override the host side with
+  `-DCMAKE_CUDA_ARCHITECTURES=<...>` (e.g. `all-major`) to bake per-arch cubins
+  instead of shipping PTX; the OptiX module target ignores that override and
+  stays at `compute_<MIN_ARCH>`.
 
 ## Tests
 

--- a/devices/rtx/CMakeLists.txt
+++ b/devices/rtx/CMakeLists.txt
@@ -87,6 +87,45 @@ mark_as_advanced(VISRTX_ENABLE_HDRI_SAMPLING_DEBUG)
 
 find_package(anari 0.16.0 REQUIRED)
 find_package(CUDAToolkit 12 REQUIRED)
+
+# Minimum GPU the built device runs on. Every OptiX version VisRTX builds
+# against accepts SM 5.0 (Maxwell) as its floor, so 50 is the widest reach and
+# costs nothing over a higher value. Raise it to 75 for Turing and newer only:
+# CUDA 13 removed pre-Turing code generation, so that is mandatory there.
+if(CUDAToolkit_FOUND)
+  if(CUDAToolkit_VERSION_MAJOR LESS_EQUAL 12)
+    set(VISRTX_MIN_ARCH 50 CACHE STRING "Minimum CUDA compute capability (50, 75, 86, ...)")
+  else()
+    set(VISRTX_MIN_ARCH 75 CACHE STRING "Minimum CUDA compute capability (50, 75, 86, ...)")
+  endif()
+endif()
+
+if(NOT VISRTX_MIN_ARCH MATCHES "^[0-9][0-9]+$" OR VISRTX_MIN_ARCH LESS 50)
+  message(FATAL_ERROR
+    "VISRTX_MIN_ARCH must be a compute capability of 50 or above (OptiX's own floor), got '${VISRTX_MIN_ARCH}'")
+endif()
+
+# Cooperative vectors need Ada. Raise the floor rather than overriding any
+# single consumer of it, so the host and OptiX module PTX targets and the MDL
+# backend stay in agreement. A floor already above 89 is left alone.
+#
+# This is a normal (non-cache) set: it shadows the cached value for this
+# configure and its subdirectories, so every consumer below sees 89, while the
+# cache keeps the user's original entry. Reconfigure re-raises cleanly, so the
+# cache never silently disagrees with the build.
+if(VISRTX_ENABLE_NEURAL AND VISRTX_MIN_ARCH LESS 89)
+  message(STATUS
+    "VISRTX_ENABLE_NEURAL raises VISRTX_MIN_ARCH from ${VISRTX_MIN_ARCH} to 89")
+  set(VISRTX_MIN_ARCH 89)
+endif()
+
+# Finally validate MIN_ARCH againt the target CUDA toolkit
+if(VISRTX_MIN_ARCH LESS 75 AND CUDAToolkit_VERSION_MAJOR GREATER 12)
+  message(FATAL_ERROR
+    "VISRTX_MIN_ARCH=${VISRTX_MIN_ARCH} requires CUDA 12.x: CUDA ${CUDAToolkit_VERSION_MAJOR} "
+    "removed code generation for pre-Turing architectures. "
+    "Build with CUDA 12, or configure with -DVISRTX_MIN_ARCH=75.")
+endif()
 find_package(glm MODULE REQUIRED)
 
 ## Get OptiX headers ##
@@ -107,6 +146,10 @@ else()
   message(FATAL_ERROR "Invalid/unknown version of OptiX selected")
 endif()
 
+if(VISRTX_ENABLE_NEURAL AND NOT ${OPTIX_FETCH_VERSION} STREQUAL "9.0")
+  message(FATAL_ERROR "OptiX 9.0+ must be used to enable Neural Graphics Primitives support in VisRTX")
+endif()
+
 anari_sdk_fetch_project(NAME optix_headers URL ${OPTIX_URL})
 appendSearchPaths(${optix_headers_LOCATION})
 
@@ -114,23 +157,31 @@ find_package(OptiX REQUIRED)
 
 #### Validate Neural Graphics Primitives support ####
 
-if(VISRTX_ENABLE_NEURAL AND NOT ${OPTIX_FETCH_VERSION} STREQUAL "9.0")
-  message(FATAL_ERROR "OptiX 9.0+ must be used to enable Neural Graphics Primitives support in VisRTX")
-endif()
-
 #### Setup CMAKE_CUDA_ARCHITECTURES for device compilation ####
 
+# Host-side kernels ship as PTX only, at the floor architecture. The CUDA
+# driver JIT-compiles compute_<VISRTX_MIN_ARCH> PTX to whatever GPU is present
+# at launch (any GPU at or above the floor), so one build runs everywhere
+# without baking a cubin per architecture. This mirrors the OptiX module PTX
+# target and keeps the two in agreement: both are compute_<floor>, so a GPU at
+# the floor JITs the host kernels and the OptiX modules alike instead of
+# loading one and failing on the other. Build time and binary size stay flat
+# regardless of how many architectures the toolkit knows about.
+#
+# Override with -DCMAKE_CUDA_ARCHITECTURES=<...> to emit cubins instead (e.g.
+# "75-real;80-real" for offline, JIT-free launches, or "all-major" to restore
+# the per-arch cubin list). This is a host-kernel-only knob: the OptiX module
+# PTX targets are pinned to compute_<VISRTX_MIN_ARCH>-virtual in
+# device/CMakeLists.txt and do NOT follow this override — a -real or multi-arch
+# value here would emit cubins/multi-blobs optixModuleCreate cannot load. The MDL
+# backend's sm_version likewise tracks VISRTX_MIN_ARCH (see libmdl/CMakeLists.txt),
+# not this variable, so all three consumers stay in agreement regardless of the
+# host-side override.
 if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   if (CMAKE_VERSION VERSION_LESS "3.23")
     set(CMAKE_CUDA_ARCHITECTURES OFF)
   else()
-    if(VISRTX_ENABLE_NEURAL)
-      set(CMAKE_CUDA_ARCHITECTURES 89-virtual)
-    elseif(${CUDAToolkit_VERSION_MAJOR} GREATER 12)
-      set(CMAKE_CUDA_ARCHITECTURES 75-virtual)
-    else()
-      set(CMAKE_CUDA_ARCHITECTURES 52-virtual)
-    endif()
+    set(CMAKE_CUDA_ARCHITECTURES ${VISRTX_MIN_ARCH}-virtual)
   endif()
 endif()
 

--- a/devices/rtx/README.md
+++ b/devices/rtx/README.md
@@ -24,6 +24,8 @@ Building VisRTX requires the following:
 - C++17 compiler
 - NVIDIA Driver 530+
 - CUDA 12+
+- A GPU of compute capability 5.0 (Maxwell) or newer, or 7.5 (Turing) when
+  building with CUDA 13. Set `VISRTX_MIN_ARCH` to raise that floor.
 - [ANARI-SDK](https://github.com/KhronosGroup/ANARI-SDK)
 
 Building VisRTX is done through invoking CMake on the source directory from a

--- a/devices/rtx/device/CMakeLists.txt
+++ b/devices/rtx/device/CMakeLists.txt
@@ -370,7 +370,14 @@ function(GenerateEmbeddedPTX DIR BASE_NAME)
     ${CMAKE_CURRENT_LIST_DIR}
   )
 
-  set_target_properties(${INPUT_TARGET} PROPERTIES CUDA_PTX_COMPILATION ON)
+  # OptiX rewrites module PTX for the actual GPU, so a virtual target at the
+  # floor runs on everything above it. Pinned rather than inherited from
+  # CMAKE_CUDA_ARCHITECTURES: a -real override there is valid for the host
+  # kernels but would emit cubins OptiX cannot load.
+  set_target_properties(${INPUT_TARGET} PROPERTIES
+    CUDA_PTX_COMPILATION ON
+    CUDA_ARCHITECTURES ${VISRTX_MIN_ARCH}-virtual
+  )
 
   EmbedPTX(
     OUTPUT_HEADER_FILE ${OUTPUT_HEADER}

--- a/devices/rtx/libmdl/CMakeLists.txt
+++ b/devices/rtx/libmdl/CMakeLists.txt
@@ -28,3 +28,19 @@ PUBLIC
 )
 
 project_include_directories(PUBLIC ..)
+
+# The MDL backend takes its SM target from a fixed set (imdl_backend.h), which
+# has no entry for every compute capability. Pick the highest one the floor
+# covers so generated material PTX never outranks the GPU it links into. This
+# list mirrors imdl_backend.h's allowed "sm_version" values at or above the
+# OptiX floor (50); keep it in sync if the MDL SDK grows new entries. A floor
+# with no exact match (e.g. 89) rounds down to the next lower entry (86), which
+# is safe — sm_86 PTX runs on Ada — just not maximally matched.
+set(MDL_SM_VERSIONS 50 52 60 61 62 70 75 80 86)
+set(MDL_SM_VERSION 50)
+foreach(sm IN LISTS MDL_SM_VERSIONS)
+  if(NOT sm GREATER VISRTX_MIN_ARCH)
+    set(MDL_SM_VERSION ${sm})
+  endif()
+endforeach()
+target_compile_definitions(libmdl PRIVATE VISRTX_MDL_SM_VERSION="${MDL_SM_VERSION}")

--- a/devices/rtx/libmdl/Core.cpp
+++ b/devices/rtx/libmdl/Core.cpp
@@ -500,7 +500,7 @@ const mi::neuraylib::ITarget_code *Core::getPtxTargetCode(
   ptxBackend->set_option_binary("llvm_renderer_module", nullptr, 0);
   ptxBackend->set_option("visible_functions", "");
 
-  ptxBackend->set_option("sm_version", "52");
+  ptxBackend->set_option("sm_version", VISRTX_MDL_SM_VERSION);
   ptxBackend->set_option("tex_lookup_call_mode", "direct_call");
   ptxBackend->set_option("lambda_return_mode", "value");
   ptxBackend->set_option("texture_runtime_with_derivs", "off");


### PR DESCRIPTION
The floor was picked twice: CMAKE_CUDA_ARCHITECTURES from a neural/CUDA-version branch (89, 75 or 52-virtual) feeding both host kernels and OptiX modules, and the MDL backend from a hardcoded "52". Nothing named the floor, so it could not be moved without editing both, and the supported GPU range stayed implicit in the branch.

VISRTX_MIN_ARCH now names it and feeds all three consumers. It defaults to 50 -- OptiX's own floor for every version we build against, so 52 gave up first-gen Maxwell for nothing -- and to 75 under CUDA 13, which dropped pre-Turing codegen; an explicit floor below 75 there is a configure error rather than a silent arch shift. VISRTX_ENABLE_NEURAL raises the floor to 89 (cooperative vectors need Ada) instead of overriding one consumer of it. The MDL backend's sm_version is the highest entry its fixed set offers at or below the floor, so generated material PTX never outranks the GPU it links into.

-DCMAKE_CUDA_ARCHITECTURES=<...> still overrides the host kernels (e.g. "75-real;80-real" for offline, JIT-free launches). This is a host-kernel-only knob: the OptiX module target stays pinned at compute_<floor> (a -real override would emit cubins optixModuleCreate cannot load), and the MDL backend's sm_version tracks VISRTX_MIN_ARCH, not this variable -- so all three consumers stay in agreement regardless of the host-side override.