### PR TITLE
ci: speed up and harden GitHub Actions workflows

### DIFF
--- a/.github/actions/build-anari-sdk/action.yml
+++ b/.github/actions/build-anari-sdk/action.yml
@@ -22,12 +22,37 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # Resolve the live upstream commit so the cache invalidates when the tracked
+    # branch moves — build_deps pulls a branch zip whose local files never change.
+    # The branch is derived from the build_deps URL itself so there is a single
+    # source of truth: change the URL and the cache key follows.
+    - name: Resolve ANARI-SDK commit
+      id: resolve-sha
+      shell: bash
+      run: |
+        cmakelists="${{ github.workspace }}/${{ inputs.build-deps-path }}/CMakeLists.txt"
+        ref=$(grep -oE 'ANARI-SDK/archive/refs/heads/[^"]+\.zip' "$cmakelists" \
+          | sed -E 's#.*refs/heads/(.+)\.zip#\1#')
+        if [ -z "$ref" ]; then
+          echo "Could not derive ANARI-SDK branch from $cmakelists" >&2
+          exit 1
+        fi
+        sha=$(git ls-remote https://github.com/KhronosGroup/ANARI-SDK "refs/heads/$ref" | cut -f1)
+        if [ -z "$sha" ]; then
+          echo "Failed to resolve ANARI-SDK '$ref' commit" >&2
+          exit 1
+        fi
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        # Slug of the build_deps path guards the key so rtx/tsd never share an
+        # entry if their build_deps diverge (Actions expressions lack replace()).
+        echo "slug=$(echo '${{ inputs.build-deps-path }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
     - name: Cache ANARI-SDK
       uses: actions/cache@v4
       id: cache-anari
       with:
         path: ${{ inputs.install-prefix }}
-        key: anari-sdk-${{ runner.os }}-${{ inputs.config }}-${{ inputs.generator || 'default' }}-${{ hashFiles('**/build_deps/CMakeLists.txt', '**/build_deps/superbuild_macros.cmake') }}
+        key: anari-sdk-${{ runner.os }}-${{ inputs.config }}-${{ steps.resolve-sha.outputs.slug }}-${{ steps.resolve-sha.outputs.sha }}
 
     - name: Configure ANARI-SDK CMake (with generator)
       if: steps.cache-anari.outputs.cache-hit != 'true' && inputs.generator != ''

--- a/.github/workflows/build-visrtx.yml
+++ b/.github/workflows/build-visrtx.yml
@@ -13,6 +13,11 @@ on:
       - '.github/actions/**'
       - '.github/workflows/build-visrtx.yml'
 
+# Cancel superseded PR runs; let next_release pushes finish (green history).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:
@@ -29,6 +34,9 @@ jobs:
             runs-on: windows-2022
             generator: Ninja
     runs-on: ${{ matrix.runs-on }}
+    env:
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -39,6 +47,15 @@ jobs:
         uses: ./.github/actions/setup-cuda
         with:
           cuda-version: ${{ matrix.cudaversion }}
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+      - name: Restore sccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}
+          restore-keys: |
+            sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-
       - name: Build ANARI-SDK
         uses: ./.github/actions/build-anari-sdk
         with:
@@ -52,9 +69,21 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
           -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache
+          -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
+          -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
           -DVISRTX_BUILD_RTX_DEVICE=ON
           -DVISRTX_PRECOMPILE_SHADERS=OFF
           -DVISRTX_BUILD_GL_DEVICE=OFF
       - name: Install VisRTX
         run: >
           cmake --build ${{ github.workspace }}/build-visrtx --config ${{ matrix.config }} --target install --parallel
+      - name: sccache stats
+        run: sccache --show-stats
+      - name: Save sccache
+        if: success() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-visrtx-${{ runner.os }}-cuda${{ matrix.cudaversion }}-${{ matrix.config }}-${{ github.sha }}


### PR DESCRIPTION
- ANARI-SDK cache keyed on live upstream commit + build_deps path slug. Brefore that, the branch-zip URL never invalidated the old hash-based key
- sccache for project C++/CUDA sources; restore-only on PRs, written only on next_release pushes
- concurrency cancels superseded PR runs